### PR TITLE
chore: add new proposal decomposer types

### DIFF
--- a/packages/chain-consumer/src/decomposers/CosmosProposalDecomposer.ts
+++ b/packages/chain-consumer/src/decomposers/CosmosProposalDecomposer.ts
@@ -6,7 +6,7 @@ export class CosmosProposalDecomposer {
     return TextProposal.deserializeBinary(content)
   }
 
-  static SoftwareUpgradeProposal(content: Uint8Array) {
+  static SoftwareUpgrade(content: Uint8Array) {
     return SoftwareUpgradeProposal.deserializeBinary(content)
   }
 }

--- a/packages/chain-consumer/src/decomposers/CosmosProposalDecomposer.ts
+++ b/packages/chain-consumer/src/decomposers/CosmosProposalDecomposer.ts
@@ -1,7 +1,12 @@
 import { TextProposal } from '@injectivelabs/chain-api/cosmos/gov/v1beta1/gov_pb'
+import { SoftwareUpgradeProposal } from '@injectivelabs/chain-api/cosmos/upgrade/v1beta1/upgrade_pb'
 
 export class CosmosProposalDecomposer {
   static textProposal(content: Uint8Array) {
     return TextProposal.deserializeBinary(content)
+  }
+
+  static SoftwareUpgradeProposal(content: Uint8Array) {
+    return SoftwareUpgradeProposal.deserializeBinary(content)
   }
 }

--- a/packages/chain-consumer/src/decomposers/ExchangeProposalDecomposer.ts
+++ b/packages/chain-consumer/src/decomposers/ExchangeProposalDecomposer.ts
@@ -2,9 +2,12 @@ import {
   DerivativeMarketParamUpdateProposal,
   ExchangeEnableProposal,
   ExpiryFuturesMarketLaunchProposal,
+  FeeDiscountProposal,
   PerpetualMarketLaunchProposal,
   SpotMarketLaunchProposal,
   SpotMarketParamUpdateProposal,
+  TradingRewardCampaignLaunchProposal,
+  TradingRewardCampaignUpdateProposal,
 } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
 
 export class ExchangeProposalDecomposer {
@@ -30,5 +33,17 @@ export class ExchangeProposalDecomposer {
 
   static derivativeMarketUpdate(content: Uint8Array) {
     return DerivativeMarketParamUpdateProposal.deserializeBinary(content)
+  }
+
+  static FeeDiscountProposal(content: Uint8Array) {
+    return FeeDiscountProposal.deserializeBinary(content)
+  }
+
+  static TradingRewardCampaignLaunchProposal(content: Uint8Array) {
+    return TradingRewardCampaignLaunchProposal.deserializeBinary(content)
+  }
+
+  static TradingRewardCampaignUpdateProposal(content: Uint8Array) {
+    return TradingRewardCampaignUpdateProposal.deserializeBinary(content)
   }
 }

--- a/packages/chain-consumer/src/decomposers/ExchangeProposalDecomposer.ts
+++ b/packages/chain-consumer/src/decomposers/ExchangeProposalDecomposer.ts
@@ -35,15 +35,15 @@ export class ExchangeProposalDecomposer {
     return DerivativeMarketParamUpdateProposal.deserializeBinary(content)
   }
 
-  static FeeDiscountProposal(content: Uint8Array) {
+  static FeeDiscount(content: Uint8Array) {
     return FeeDiscountProposal.deserializeBinary(content)
   }
 
-  static TradingRewardCampaignLaunchProposal(content: Uint8Array) {
+  static TradingRewardCampaignLaunch(content: Uint8Array) {
     return TradingRewardCampaignLaunchProposal.deserializeBinary(content)
   }
 
-  static TradingRewardCampaignUpdateProposal(content: Uint8Array) {
+  static TradingRewardCampaignUpdate(content: Uint8Array) {
     return TradingRewardCampaignUpdateProposal.deserializeBinary(content)
   }
 }

--- a/packages/chain-consumer/src/decomposers/OracleProposalDecomposer.ts
+++ b/packages/chain-consumer/src/decomposers/OracleProposalDecomposer.ts
@@ -1,0 +1,14 @@
+import {
+  AuthorizeBandOracleRequestProposal,
+  EnableBandIBCProposal,
+} from '@injectivelabs/chain-api/injective/oracle/v1beta1/oracle_pb'
+
+export class OracleProposalDecomposer {
+  static EnableBandIBC(content: Uint8Array) {
+    return EnableBandIBCProposal.deserializeBinary(content)
+  }
+
+  static AuthorizeBandOracleRequest(content: Uint8Array) {
+    return AuthorizeBandOracleRequestProposal.deserializeBinary(content)
+  }
+}

--- a/packages/chain-consumer/src/decomposers/index.ts
+++ b/packages/chain-consumer/src/decomposers/index.ts
@@ -1,3 +1,4 @@
 export * from './ExchangeProposalDecomposer'
 export * from './GovernanceProposalDecomposer'
 export * from './CosmosProposalDecomposer'
+export * from './OracleProposalDecomposer'


### PR DESCRIPTION
## This PR:
- adds support for new proposal type decomposer
    - AuthorizeBandOracleRequestProposal
    - EnableBandIBCProposal
    - FeeDiscountProposal
    - SoftwareUpgradeProposal
    - TradingRewardCampaignLaunchProposal
    - TradingRewardCampaignUpdateProposal
