### PR TITLE
fix: bridge transaction token meta doesnt include full logo path

### DIFF
--- a/packages/ui-common/src/bridge/utils.ts
+++ b/packages/ui-common/src/bridge/utils.ts
@@ -6,7 +6,11 @@ import {
   BridgingNetwork,
   MintScanExplorerUrl,
 } from './types'
-import { PEGGY_GRAPH_URL, PEGGY_TESTNET_GRAPH_URL } from '../constants'
+import {
+  PEGGY_GRAPH_URL,
+  PEGGY_DEVNET_GRAPH_URL,
+  PEGGY_TESTNET_GRAPH_URL,
+} from '../constants'
 
 const sameTxHash = (txHashOne: string, txHashTwo: string) =>
   txHashOne &&
@@ -192,9 +196,8 @@ export const getPeggoGraphQlEndpoint = (network: Network): string => {
     return PEGGY_TESTNET_GRAPH_URL
   }
 
-  // TODO
   if ([Network.Devnet].includes(network)) {
-    return PEGGY_TESTNET_GRAPH_URL
+    return PEGGY_DEVNET_GRAPH_URL
   }
 
   return ''

--- a/packages/ui-common/src/constants.ts
+++ b/packages/ui-common/src/constants.ts
@@ -41,3 +41,5 @@ export const PEGGY_GRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/injectivelabs/injective-peggo-mainnet'
 export const PEGGY_TESTNET_GRAPH_URL =
   'https://api.thegraph.com/subgraphs/name/injectivelabs/injective-peggo-kovan'
+export const PEGGY_DEVNET_GRAPH_URL =
+  'https://api.thegraph.com/subgraphs/name/davidtian719/injective-peggo-devnet'

--- a/packages/ui-common/src/token/service.ts
+++ b/packages/ui-common/src/token/service.ts
@@ -407,7 +407,10 @@ export class TokenService extends BaseService {
     if (tokenFromSymbol) {
       return {
         ...transaction,
-        token: tokenFromSymbol,
+        token: TokenTransformer.tokenMetaToToken(
+          tokenFromSymbol,
+          tokenFromSymbol.denom,
+        ) as Token,
       }
     }
 


### PR DESCRIPTION
## This PR:
- fix bridge transaction token meta doesn't include full logo path
- adds peggy subgraph endpoint for devnet environment