### PR TITLE
[WIP] chore: add postOnly to Msg Types

### DIFF
--- a/packages/sdk-ts/src/client/exchange/types/derivatives.ts
+++ b/packages/sdk-ts/src/client/exchange/types/derivatives.ts
@@ -22,6 +22,8 @@ export enum DerivativeOrderSide {
   StopSell = 'stop_sell',
   TakeBuy = 'take_buy',
   TakeSell = 'take_sell',
+  BuyPO = 'buy_po',
+  SellPO = 'sell_po',
 }
 
 export enum DerivativeOrderState {

--- a/packages/sdk-ts/src/client/exchange/types/spot.ts
+++ b/packages/sdk-ts/src/client/exchange/types/spot.ts
@@ -15,6 +15,8 @@ export enum SpotOrderSide {
   StopSell = 'stop_sell',
   TakeBuy = 'take_buy',
   TakeSell = 'take_sell',
+  BuyPO = 'buy_po',
+  SellPO = 'sell_po',
 }
 
 export enum SpotOrderState {

--- a/packages/sdk-ui-ts/src/client/types/derivatives.ts
+++ b/packages/sdk-ui-ts/src/client/types/derivatives.ts
@@ -57,6 +57,8 @@ export enum DerivativeMarketMap {
   STOP_SELL = 4,
   TAKE_BUY = 5,
   TAKE_SELL = 6,
+  BUY_PO = 7,
+  SELL_PO = 8,
 }
 
 export {

--- a/packages/sdk-ui-ts/src/client/types/spot.ts
+++ b/packages/sdk-ui-ts/src/client/types/spot.ts
@@ -53,6 +53,8 @@ export enum SpotMarketMap {
   STOP_SELL = 4,
   TAKE_BUY = 5,
   TAKE_SELL = 6,
+  BUY_PO = 7,
+  SELL_PO = 8,
 }
 
 export {

--- a/packages/sdk-ui-ts/src/utils/derivatives.ts
+++ b/packages/sdk-ui-ts/src/utils/derivatives.ts
@@ -23,6 +23,10 @@ export const derivativeOrderTypeToGrpcOrderType = (
       return DerivativeMarketMap.TAKE_BUY
     case DerivativeOrderSide.TakeSell:
       return DerivativeMarketMap.TAKE_SELL
+    case DerivativeOrderSide.BuyPO:
+      return DerivativeMarketMap.BUY_PO
+    case DerivativeOrderSide.SellPO:
+      return DerivativeOrderSide.SELL_PO
     default:
       return DerivativeMarketMap.BUY
   }

--- a/packages/sdk-ui-ts/src/utils/spot.ts
+++ b/packages/sdk-ui-ts/src/utils/spot.ts
@@ -35,6 +35,10 @@ export const spotOrderTypeToGrpcOrderType = (
       return SpotMarketMap.TAKE_BUY
     case SpotOrderSide.TakeSell:
       return SpotMarketMap.TAKE_SELL
+    case SpotOrderSide.BuyPO:
+      return SpotMarketMap.BUY_PO
+    case SpotOrderSide.SellPO:
+      return SpotMarketMap.SELL_PO
     default:
       return SpotMarketMap.BUY
   }


### PR DESCRIPTION
## Changes
- updated `sdk-ui-ts` and `sdk-ts` packages with buy/sell limit order post-only order types.

## Todo
- update changelog and package pump
- update `chain-api/injective/exchange/v1beta1/exchange_pb.d.ts` with `BUY_PO: 7` and `SELl_PO: 8` options for the `OrderTypeMap` enum which is used by `sdk-ts` `MsgCreateSpotLimitOrder.ts` `orderType` `Params`