### PR TITLE
feat: adds support to flush wallet addresses on ledger and trezor

### DIFF
--- a/packages/wallet-ts/src/wallet-strategy/WalletStrategy.ts
+++ b/packages/wallet-ts/src/wallet-strategy/WalletStrategy.ts
@@ -127,6 +127,12 @@ export default class WalletStrategy {
     return this.getStrategy().getWeb3()
   }
 
+  public clearAddresses(): void {
+    if (this.getStrategy().clearAddresses) {
+      return this.getStrategy().clearAddresses!()
+    }
+  }
+
   public onAccountChange(callback: onAccountChangeCallback): void {
     if (this.getStrategy().onAccountChange) {
       return this.getStrategy().onAccountChange!(callback)

--- a/packages/wallet-ts/src/wallet-strategy/strategies/Ledger/Base.ts
+++ b/packages/wallet-ts/src/wallet-strategy/strategies/Ledger/Base.ts
@@ -88,6 +88,12 @@ export default class LedgerBase
     this.ledger = new LedgerHW()
   }
 
+  public async clearAddresses() {
+    const accountManager = await this.ledger.getAccountManager()
+
+    accountManager.clearAddresses()
+  }
+
   public async getAddresses(): Promise<string[]> {
     const { baseDerivationPath, derivationPathType } = this
 
@@ -97,6 +103,7 @@ export default class LedgerBase
         baseDerivationPath,
         derivationPathType,
       )
+
       return wallets.map((k) => k.address)
     } catch (e: any) {
       throw new Error(

--- a/packages/wallet-ts/src/wallet-strategy/strategies/Ledger/hw/AccountManager.ts
+++ b/packages/wallet-ts/src/wallet-strategy/strategies/Ledger/hw/AccountManager.ts
@@ -27,6 +27,10 @@ export default class AccountManager {
     this.wallets = []
   }
 
+  clearAddresses() {
+    this.wallets = []
+  }
+
   async getWallets(
     baseDerivationPath: string,
     derivationPathType: LedgerDerivationPathType,

--- a/packages/wallet-ts/src/wallet-strategy/strategies/Trezor/hw/AccountManager.ts
+++ b/packages/wallet-ts/src/wallet-strategy/strategies/Trezor/hw/AccountManager.ts
@@ -30,6 +30,10 @@ export default class AccountManager {
     this.hdKey = hdKey
   }
 
+  clearAddresses() {
+    this.wallets = []
+  }
+
   async getWallets(): Promise<TrezorWalletInfo[]> {
     const { start, end } = this.getOffset()
 

--- a/packages/wallet-ts/src/wallet-strategy/strategies/Trezor/index.ts
+++ b/packages/wallet-ts/src/wallet-strategy/strategies/Trezor/index.ts
@@ -58,6 +58,12 @@ export default class Trezor
     this.trezor = new TrezorHW()
   }
 
+  public async clearAddresses() {
+    const accountManager = await this.trezor.getAccountManager()
+
+    accountManager.clearAddresses()
+  }
+
   public async getAddresses(): Promise<string[]> {
     try {
       await this.trezor.connect()

--- a/packages/wallet-ts/src/wallet-strategy/types/strategy.ts
+++ b/packages/wallet-ts/src/wallet-strategy/types/strategy.ts
@@ -51,6 +51,8 @@ export interface ConcreteWalletStrategy {
 
   getEthereumTransactionReceipt(txHash: string): void
 
+  clearAddresses?(): void
+
   onAccountChange?(callback: onAccountChangeCallback): void
 
   onChainIdChange?(callback: onChainIdChangeCallback): void


### PR DESCRIPTION
## This PR:
- adds support to flush wallet addresses on ledger and trezor

## Context:
This implementation is designed to fix the UX issue as reported [here](https://github.com/InjectiveLabs/injective-hub/issues/467). Wallet addresses stored on the [AccountManger ](https://github.com/InjectiveLabs/injective-ts/blob/5ebc62502e713740a3b5dea83ee1c14a33c4ccd2/packages/wallet-ts/src/wallet-strategy/strategies/Ledger/hw/AccountManager.ts#L21) are not in sync with the FE if the user click `get addreses` and close the connect wallet modal, on reopening the connect wallet ledger modal clicking `get addresses` will return the 5th to 10th addresses instead of 0 to 5th addresses.

## Screenshot:
<img width="613" alt="image" src="https://user-images.githubusercontent.com/10151054/177264434-a6ca1e4c-6142-4e6d-b9bd-b03bdf0f1fc4.png">
