### PR TITLE
fix: add order mask to batch cancel spot order message

### DIFF
--- a/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.ts
@@ -63,9 +63,9 @@ export default class MsgBatchCancelBinaryOptionsOrders extends MsgBase<
       orderData.setMarketId(order.marketId)
       orderData.setOrderHash(order.orderHash)
       orderData.setSubaccountId(order.subaccountId)
-      orderData.setOrderMask(
-        order.orderMask !== undefined ? order.orderMask : OrderMask.Any,
-      )
+
+      // TODO: Send order.orderMask instead when chain handles order mask properly.
+      orderData.setOrderMask(OrderMask.Any)
 
       return orderData
     })

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelDerivativeOrders.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelDerivativeOrders.ts
@@ -62,9 +62,9 @@ export default class MsgBatchCancelDerivativeOrders extends MsgBase<
       orderData.setMarketId(order.marketId)
       orderData.setOrderHash(order.orderHash)
       orderData.setSubaccountId(order.subaccountId)
-      orderData.setOrderMask(
-        order.orderMask !== undefined ? order.orderMask : OrderMask.Any,
-      )
+
+      // TODO: Send order.orderMask instead when chain handles order mask properly.
+      orderData.setOrderMask(OrderMask.Any)
 
       return orderData
     })

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
@@ -63,12 +63,8 @@ export default class MsgBatchCancelSpotOrders extends MsgBase<
       orderData.setOrderHash(order.orderHash)
       orderData.setSubaccountId(order.subaccountId)
 
+      // TODO: Send order.orderMask instead when chain handles order mask properly.
       orderData.setOrderMask(OrderMask.Any)
-
-      // TODO: Use this instead once chain handles order mask properly.
-      // message.setOrderMask(
-      //   params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
-      // )
 
       return orderData
     })

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
@@ -62,9 +62,13 @@ export default class MsgBatchCancelSpotOrders extends MsgBase<
       orderData.setMarketId(order.marketId)
       orderData.setOrderHash(order.orderHash)
       orderData.setSubaccountId(order.subaccountId)
-      orderData.setOrderMask(
-        order.orderMask !== undefined ? order.orderMask : OrderMask.Any
-      )
+
+      orderData.setOrderMask(OrderMask.Any)
+
+      // TODO: Use this instead once chain handles order mask properly.
+      // message.setOrderMask(
+      //   params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
+      // )
 
       return orderData
     })

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgBatchCancelSpotOrders.ts
@@ -1,7 +1,9 @@
+import { OrderMaskMap } from '@injectivelabs/chain-api/injective/exchange/v1beta1/exchange_pb'
 import {
   MsgBatchCancelSpotOrders as BaseMsgBatchCancelSpotOrders,
   OrderData,
 } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import { OrderMask } from '../../../types/exchange'
 import snakeCaseKeys from 'snakecase-keys'
 import { MsgBase } from '../../MsgBase'
 
@@ -11,7 +13,8 @@ export declare namespace MsgBatchCancelSpotOrders {
     orders: {
       marketId: string
       subaccountId: string
-      orderHash: string
+      orderHash: string,
+      orderMask?: OrderMaskMap[keyof OrderMaskMap]
     }[]
   }
 
@@ -59,6 +62,9 @@ export default class MsgBatchCancelSpotOrders extends MsgBase<
       orderData.setMarketId(order.marketId)
       orderData.setOrderHash(order.orderHash)
       orderData.setSubaccountId(order.subaccountId)
+      orderData.setOrderMask(
+        order.orderMask !== undefined ? order.orderMask : OrderMask.Any
+      )
 
       return orderData
     })

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgCancelBinaryOptionsOrder.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgCancelBinaryOptionsOrder.ts
@@ -56,9 +56,9 @@ export default class MsgCancelBinaryOptionsOrder extends MsgBase<
     message.setMarketId(params.marketId)
     message.setOrderHash(params.orderHash)
     message.setSubaccountId(params.subaccountId)
-    message.setOrderMask(
-      params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
-    )
+
+    // TODO: Send order.orderMask instead when chain handles order mask properly.
+    message.setOrderMask(OrderMask.Any)
 
     return message
   }

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgCancelDerivativeOrder.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgCancelDerivativeOrder.ts
@@ -53,9 +53,9 @@ export default class MsgCancelDerivativeOrder extends MsgBase<
     message.setMarketId(params.marketId)
     message.setOrderHash(params.orderHash)
     message.setSubaccountId(params.subaccountId)
-    message.setOrderMask(
-      params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
-    )
+
+    // TODO: Send order.orderMask instead when chain handles order mask properly.
+    message.setOrderMask(OrderMask.Any)
 
     return message
   }

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgCancelSpotOrder.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgCancelSpotOrder.ts
@@ -55,7 +55,7 @@ export default class MsgCancelSpotOrder extends MsgBase<
     message.setOrderHash(params.orderHash)
     message.setSubaccountId(params.subaccountId)
 
-    // TODO: Enable this once chain handles it properly.
+    // TODO: message.setOrderMask does not exist yet, enable this once it does.
     // message.setOrderMask(
     //   params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
     // )

--- a/packages/sdk-ts/src/core/exchange/msgs/MsgCancelSpotOrder.ts
+++ b/packages/sdk-ts/src/core/exchange/msgs/MsgCancelSpotOrder.ts
@@ -1,4 +1,6 @@
+// import { OrderMaskMap } from '@injectivelabs/chain-api/injective/exchange/v1beta1/exchange_pb'
 import { MsgCancelSpotOrder as BaseMsgCancelSpotOrder } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+// import { OrderMask } from '../../../types/exchange'
 import { MsgBase } from '../../MsgBase'
 
 export declare namespace MsgCancelSpotOrder {
@@ -7,6 +9,7 @@ export declare namespace MsgCancelSpotOrder {
     subaccountId: string
     injectiveAddress: string
     orderHash: string
+    // orderMask?: OrderMaskMap[keyof OrderMaskMap]
   }
 
   export interface DirectSign {
@@ -51,6 +54,11 @@ export default class MsgCancelSpotOrder extends MsgBase<
     message.setMarketId(params.marketId)
     message.setOrderHash(params.orderHash)
     message.setSubaccountId(params.subaccountId)
+
+    // TODO: Enable this once chain handles it properly.
+    // message.setOrderMask(
+    //   params.orderMask !== undefined ? params.orderMask : OrderMask.Any,
+    // )
 
     return message
   }


### PR DESCRIPTION
This PR adds missing order mask to `MsgBatchCancelSpotOrder.ts`.