### PR TITLE
feat: add unit test for remaining eip 712 messages

### DIFF
--- a/packages/sdk-ts/src/core/modules/bank/msgs/MsgSend.spec.ts
+++ b/packages/sdk-ts/src/core/modules/bank/msgs/MsgSend.spec.ts
@@ -14,12 +14,12 @@ const params: MsgSend['params'] = {
 
 const protoType = '/cosmos.bank.v1beta1.MsgSend'
 const protoTypeShort = 'cosmos-sdk/MsgSend'
-const protoParamsBefore = {
+const protoParams = {
   toAddress: params.dstInjectiveAddress,
   fromAddress: params.srcInjectiveAddress,
   amountList: [params.amount],
 }
-const protoParamsAfter = {
+const protoParamsAmino = {
   to_address: params.dstInjectiveAddress,
   from_address: params.srcInjectiveAddress,
   amount: [params.amount],
@@ -32,7 +32,7 @@ describe.only('MsgSend', () => {
     const proto = message.toProto()
 
     expect(proto instanceof BaseMsgSend).toBe(true)
-    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+    expect(proto.toObject()).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -40,7 +40,7 @@ describe.only('MsgSend', () => {
 
     expect(data).toStrictEqual({
       '@type': protoType,
-      ...protoParamsBefore,
+      ...protoParams,
     })
   })
 
@@ -49,7 +49,7 @@ describe.only('MsgSend', () => {
 
     expect(amino).toStrictEqual({
       type: protoTypeShort,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 
@@ -74,7 +74,7 @@ describe.only('MsgSend', () => {
 
     expect(eip712).toStrictEqual({
       type: protoTypeShort,
-      value: protoParamsAfter,
+      value: protoParamsAmino,
     })
   })
 
@@ -83,7 +83,7 @@ describe.only('MsgSend', () => {
 
     expect(web3).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 })

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.spec.ts
@@ -1,0 +1,102 @@
+import { MsgBatchCancelDerivativeOrders as BaseMsgBatchCancelDerivativeOrders } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgBatchCancelDerivativeOrders from './MsgBatchCancelDerivativeOrders'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgBatchCancelDerivativeOrders['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      orderHash: mockFactory.orderHash,
+      subaccountId: mockFactory.subaccountId,
+    },
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      orderHash: mockFactory.orderHash2,
+      subaccountId: mockFactory.subaccountId,
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v1beta1.MsgBatchCancelDerivativeOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelDerivativeOrders'
+
+const ordersWithOrderMask = params.orders.map((order) => ({
+  ...order,
+  orderMask: 1,
+}))
+
+const protoParamsBefore = {
+  sender: params.injectiveAddress,
+  dataList: ordersWithOrderMask,
+}
+
+const protoParamsAfter = {
+  sender: params.injectiveAddress,
+  data: snakecaseKeys(ordersWithOrderMask),
+}
+
+const message = MsgBatchCancelDerivativeOrders.fromJSON(params)
+
+describe.only('MsgBatchCancelDerivativeOrders', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgBatchCancelDerivativeOrders).toBe(true)
+    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsBefore,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      ...protoParamsAfter,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      TypeData: [
+        { name: 'market_id', type: 'string' },
+        { name: 'subaccount_id', type: 'string' },
+        { name: 'order_hash', type: 'string' },
+        { name: 'order_mask', type: 'int32' },
+      ],
+      MsgValue: [
+        { name: 'sender', type: 'string' },
+        { name: 'data', type: 'TypeData[]' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAfter,
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAfter,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrders.spec.ts
@@ -27,12 +27,12 @@ const ordersWithOrderMask = params.orders.map((order) => ({
   orderMask: 1,
 }))
 
-const protoParamsBefore = {
+const protoParams = {
   sender: params.injectiveAddress,
   dataList: ordersWithOrderMask,
 }
 
-const protoParamsAfter = {
+const protoParamsAmino = {
   sender: params.injectiveAddress,
   data: snakecaseKeys(ordersWithOrderMask),
 }
@@ -44,7 +44,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
     const proto = message.toProto()
 
     expect(proto instanceof BaseMsgBatchCancelDerivativeOrders).toBe(true)
-    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+    expect(proto.toObject()).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -52,7 +52,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(data).toStrictEqual({
       '@type': protoType,
-      ...protoParamsBefore,
+      ...protoParams,
     })
   })
 
@@ -61,7 +61,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(amino).toStrictEqual({
       type: protoTypeShort,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 
@@ -87,7 +87,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(eip712).toStrictEqual({
       type: protoTypeShort,
-      value: protoParamsAfter,
+      value: protoParamsAmino,
     })
   })
 
@@ -96,7 +96,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(web3).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 })

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrders.spec.ts
@@ -1,0 +1,102 @@
+import { MsgBatchCancelDerivativeOrders as BaseMsgBatchCancelDerivativeOrders } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgBatchCancelDerivativeOrders from './MsgBatchCancelDerivativeOrders'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgBatchCancelDerivativeOrders['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      orderHash: mockFactory.orderHash,
+      subaccountId: mockFactory.subaccountId,
+    },
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      orderHash: mockFactory.orderHash2,
+      subaccountId: mockFactory.subaccountId,
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v1beta1.MsgBatchCancelDerivativeOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelDerivativeOrders'
+
+const ordersWithOrderMask = params.orders.map((order) => ({
+  ...order,
+  orderMask: 1,
+}))
+
+const protoParamsBefore = {
+  sender: params.injectiveAddress,
+  dataList: ordersWithOrderMask,
+}
+
+const protoParamsAfter = {
+  sender: params.injectiveAddress,
+  data: snakecaseKeys(ordersWithOrderMask),
+}
+
+const message = MsgBatchCancelDerivativeOrders.fromJSON(params)
+
+describe.only('MsgBatchCancelDerivativeOrders', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgBatchCancelDerivativeOrders).toBe(true)
+    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsBefore,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      ...protoParamsAfter,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      TypeData: [
+        { name: 'market_id', type: 'string' },
+        { name: 'subaccount_id', type: 'string' },
+        { name: 'order_hash', type: 'string' },
+        { name: 'order_mask', type: 'int32' },
+      ],
+      MsgValue: [
+        { name: 'sender', type: 'string' },
+        { name: 'data', type: 'TypeData[]' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAfter,
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAfter,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrders.spec.ts
@@ -27,12 +27,12 @@ const ordersWithOrderMask = params.orders.map((order) => ({
   orderMask: 1,
 }))
 
-const protoParamsBefore = {
+const protoParams = {
   sender: params.injectiveAddress,
   dataList: ordersWithOrderMask,
 }
 
-const protoParamsAfter = {
+const protoParamsAmino = {
   sender: params.injectiveAddress,
   data: snakecaseKeys(ordersWithOrderMask),
 }
@@ -44,7 +44,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
     const proto = message.toProto()
 
     expect(proto instanceof BaseMsgBatchCancelDerivativeOrders).toBe(true)
-    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+    expect(proto.toObject()).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -52,7 +52,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(data).toStrictEqual({
       '@type': protoType,
-      ...protoParamsBefore,
+      ...protoParams,
     })
   })
 
@@ -61,7 +61,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(amino).toStrictEqual({
       type: protoTypeShort,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 
@@ -87,7 +87,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(eip712).toStrictEqual({
       type: protoTypeShort,
-      value: protoParamsAfter,
+      value: protoParamsAmino,
     })
   })
 
@@ -96,7 +96,7 @@ describe.only('MsgBatchCancelDerivativeOrders', () => {
 
     expect(web3).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 })

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrders.spec.ts
@@ -1,0 +1,102 @@
+import { MsgBatchCancelSpotOrders as BaseMsgBatchCancelSpotOrders } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgBatchCancelSpotOrders from './MsgBatchCancelSpotOrders'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgBatchCancelSpotOrders['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtSpotMarket.marketId,
+      orderHash: mockFactory.orderHash,
+      subaccountId: mockFactory.subaccountId,
+    },
+    {
+      marketId: mockFactory.injUsdtSpotMarket.marketId,
+      orderHash: mockFactory.orderHash2,
+      subaccountId: mockFactory.subaccountId,
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v1beta1.MsgBatchCancelSpotOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelSpotOrders'
+
+const ordersWithOrderMask = params.orders.map((order) => ({
+  ...order,
+  orderMask: 1,
+}))
+
+const protoParamsBefore = {
+  sender: params.injectiveAddress,
+  dataList: ordersWithOrderMask,
+}
+
+const protoParamsAfter = {
+  sender: params.injectiveAddress,
+  data: snakecaseKeys(ordersWithOrderMask),
+}
+
+const message = MsgBatchCancelSpotOrders.fromJSON(params)
+
+describe.only('MsgBatchCancelSpotOrders', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgBatchCancelSpotOrders).toBe(true)
+    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsBefore,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      ...protoParamsAfter,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      TypeData: [
+        { name: 'market_id', type: 'string' },
+        { name: 'subaccount_id', type: 'string' },
+        { name: 'order_hash', type: 'string' },
+        { name: 'order_mask', type: 'int32' },
+      ],
+      MsgValue: [
+        { name: 'sender', type: 'string' },
+        { name: 'data', type: 'TypeData[]' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAfter,
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAfter,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrders.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrders.spec.ts
@@ -27,12 +27,12 @@ const ordersWithOrderMask = params.orders.map((order) => ({
   orderMask: 1,
 }))
 
-const protoParamsBefore = {
+const protoParams = {
   sender: params.injectiveAddress,
   dataList: ordersWithOrderMask,
 }
 
-const protoParamsAfter = {
+const protoParamsAmino = {
   sender: params.injectiveAddress,
   data: snakecaseKeys(ordersWithOrderMask),
 }
@@ -44,7 +44,7 @@ describe.only('MsgBatchCancelSpotOrders', () => {
     const proto = message.toProto()
 
     expect(proto instanceof BaseMsgBatchCancelSpotOrders).toBe(true)
-    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+    expect(proto.toObject()).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -52,7 +52,7 @@ describe.only('MsgBatchCancelSpotOrders', () => {
 
     expect(data).toStrictEqual({
       '@type': protoType,
-      ...protoParamsBefore,
+      ...protoParams,
     })
   })
 
@@ -61,7 +61,7 @@ describe.only('MsgBatchCancelSpotOrders', () => {
 
     expect(amino).toStrictEqual({
       type: protoTypeShort,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 
@@ -87,7 +87,7 @@ describe.only('MsgBatchCancelSpotOrders', () => {
 
     expect(eip712).toStrictEqual({
       type: protoTypeShort,
-      value: protoParamsAfter,
+      value: protoParamsAmino,
     })
   })
 
@@ -96,7 +96,7 @@ describe.only('MsgBatchCancelSpotOrders', () => {
 
     expect(web3).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 })

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrder.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrder.spec.ts
@@ -1,17 +1,17 @@
-import { MsgCancelDerivativeOrder as BaseMsgCancelDerivativeOrder } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
-import MsgCancelDerivativeOrder from './MsgCancelDerivativeOrder'
+import { MsgCancelBinaryOptionsOrder as BaseMsgCancelBinaryOptionsOrder } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgCancelBinaryOptionsOrder from './MsgCancelBinaryOptionsOrder'
 import { mockFactory } from '@injectivelabs/test-utils'
 import snakecaseKeys from 'snakecase-keys'
 
-const params: MsgCancelDerivativeOrder['params'] = {
+const params: MsgCancelBinaryOptionsOrder['params'] = {
   injectiveAddress: mockFactory.injectiveAddress,
   marketId: mockFactory.injUsdtDerivativeMarket.marketId,
   orderHash: mockFactory.orderHash,
   subaccountId: mockFactory.subaccountId,
 }
 
-const protoType = '/injective.exchange.v1beta1.MsgCancelDerivativeOrder'
-const protoTypeShort = 'exchange/MsgCancelDerivativeOrder'
+const protoType = '/injective.exchange.v1beta1.MsgCancelBinaryOptionsOrder'
+const protoTypeShort = 'exchange/MsgCancelBinaryOptionsOrder'
 const protoParams = {
   sender: params.injectiveAddress,
   marketId: params.marketId,
@@ -20,13 +20,13 @@ const protoParams = {
   orderMask: 1,
 }
 
-const message = MsgCancelDerivativeOrder.fromJSON(params)
+const message = MsgCancelBinaryOptionsOrder.fromJSON(params)
 
-describe.only('MsgCancelDerivativeOrder', () => {
+describe.only('MsgCancelBinaryOptionsOrder', () => {
   it('generates proper proto', () => {
     const proto = message.toProto()
 
-    expect(proto instanceof BaseMsgCancelDerivativeOrder).toBe(true)
+    expect(proto instanceof BaseMsgCancelBinaryOptionsOrder).toBe(true)
     expect(proto.toObject()).toStrictEqual(protoParams)
   })
 

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrder.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrder.spec.ts
@@ -1,0 +1,82 @@
+import { MsgCancelDerivativeOrder as BaseMsgCancelDerivativeOrder } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgCancelDerivativeOrder from './MsgCancelDerivativeOrder'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgCancelDerivativeOrder['params'] = {
+  injectiveAddress: mockFactory.subaccountId,
+  marketId: mockFactory.injUsdtSpotMarket.marketId,
+  orderHash: mockFactory.orderHash,
+  subaccountId: mockFactory.subaccountId,
+}
+
+const protoType = '/injective.exchange.v1beta1.MsgCancelDerivativeOrder'
+const protoTypeShort = 'exchange/MsgCancelDerivativeOrder'
+const protoParams = {
+  sender: params.subaccountId,
+  marketId: params.marketId,
+  orderHash: params.orderHash,
+  subaccountId: params.subaccountId,
+  orderMask: 1,
+}
+
+const message = MsgCancelDerivativeOrder.fromJSON(params)
+
+describe.only('MsgCancelDerivativeOrder', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgCancelDerivativeOrder).toBe(true)
+    expect(proto.toObject()).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      MsgValue: [
+        { name: 'sender', type: 'string' },
+        { name: 'market_id', type: 'string' },
+        { name: 'subaccount_id', type: 'string' },
+        { name: 'order_hash', type: 'string' },
+        { name: 'order_mask', type: 'int32' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: snakecaseKeys(protoParams),
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrder.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrder.spec.ts
@@ -1,0 +1,80 @@
+import { MsgCancelSpotOrder as BaseMsgCancelSpotOrder } from '@injectivelabs/chain-api/injective/exchange/v1beta1/tx_pb'
+import MsgCancelSpotOrder from './MsgCancelSpotOrder'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgCancelSpotOrder['params'] = {
+  injectiveAddress: mockFactory.subaccountId,
+  marketId: mockFactory.injUsdtSpotMarket.marketId,
+  orderHash: mockFactory.orderHash,
+  subaccountId: mockFactory.subaccountId,
+}
+
+const protoType = '/injective.exchange.v1beta1.MsgCancelSpotOrder'
+const protoTypeShort = 'exchange/MsgCancelSpotOrder'
+const protoParams = {
+  sender: params.subaccountId,
+  marketId: params.marketId,
+  orderHash: params.orderHash,
+  subaccountId: params.subaccountId,
+}
+
+const message = MsgCancelSpotOrder.fromJSON(params)
+
+describe.only('MsgCancelSpotOrder', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgCancelSpotOrder).toBe(true)
+    expect(proto.toObject()).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      MsgValue: [
+        { name: 'sender', type: 'string' },
+        { name: 'market_id', type: 'string' },
+        { name: 'subaccount_id', type: 'string' },
+        { name: 'order_hash', type: 'string' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: snakecaseKeys(protoParams),
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrder.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrder.spec.ts
@@ -4,7 +4,7 @@ import { mockFactory } from '@injectivelabs/test-utils'
 import snakecaseKeys from 'snakecase-keys'
 
 const params: MsgCancelSpotOrder['params'] = {
-  injectiveAddress: mockFactory.subaccountId,
+  injectiveAddress: mockFactory.injectiveAddress,
   marketId: mockFactory.injUsdtSpotMarket.marketId,
   orderHash: mockFactory.orderHash,
   subaccountId: mockFactory.subaccountId,
@@ -13,7 +13,7 @@ const params: MsgCancelSpotOrder['params'] = {
 const protoType = '/injective.exchange.v1beta1.MsgCancelSpotOrder'
 const protoTypeShort = 'exchange/MsgCancelSpotOrder'
 const protoParams = {
-  sender: params.subaccountId,
+  sender: params.injectiveAddress,
   marketId: params.marketId,
   orderHash: params.orderHash,
   subaccountId: params.subaccountId,

--- a/packages/sdk-ts/src/core/modules/gov/msgs/MsgDeposit.spec.ts
+++ b/packages/sdk-ts/src/core/modules/gov/msgs/MsgDeposit.spec.ts
@@ -15,13 +15,13 @@ const params: MsgDeposit['params'] = {
 
 const protoType = '/cosmos.gov.v1beta1.MsgDeposit'
 const protoTypeAmino = 'cosmos-sdk/MsgDeposit'
-const protoParamsBefore = {
+const protoParams = {
   proposalId: params.proposalId,
   depositor: params.depositor,
   amountList: [params.amount],
 }
 
-const protoParamsAfter = {
+const protoParamsAmino = {
   proposal_id: params.proposalId,
   depositor: params.depositor,
   amount: [params.amount],
@@ -34,7 +34,7 @@ describe.only('MsgDeposit', () => {
     const proto = message.toProto()
 
     expect(proto instanceof BaseMsgDeposit).toBe(true)
-    expect(proto.toObject()).toStrictEqual(protoParamsBefore)
+    expect(proto.toObject()).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -42,7 +42,7 @@ describe.only('MsgDeposit', () => {
 
     expect(data).toStrictEqual({
       '@type': protoType,
-      ...protoParamsBefore,
+      ...protoParams,
     })
   })
 
@@ -51,7 +51,7 @@ describe.only('MsgDeposit', () => {
 
     expect(amino).toStrictEqual({
       type: protoTypeAmino,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 
@@ -77,7 +77,7 @@ describe.only('MsgDeposit', () => {
     expect(eip712).toStrictEqual({
       type: protoTypeAmino,
       value: snakecaseKeys({
-        ...protoParamsAfter,
+        ...protoParamsAmino,
         proposal_id: params.proposalId.toString(),
       }),
     })
@@ -88,7 +88,7 @@ describe.only('MsgDeposit', () => {
 
     expect(web3).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAfter,
+      ...protoParamsAmino,
     })
   })
 })

--- a/packages/test-utils/src/mocks/index.ts
+++ b/packages/test-utils/src/mocks/index.ts
@@ -10,6 +10,10 @@ const subaccountId =
   '0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000000'
 const subaccountId2 =
   '0xaf79152ac5df276d9a8e1e2e22822f9713474902000000000000000000000001'
+const orderHash =
+  '0x3b1bcc8ab01e1e0f1f2cf9de5f44267bed6368fabd62adbcf3826a207340194e'
+const orderHash2 =
+  '0x3b1bcc8ab01e1e0f1f2cf9de5f44267bed6368fabd62adbcf3826a207340194e'
 
 export const injUsdtSpotMarket = {
   marketId:
@@ -82,4 +86,6 @@ export const mockFactory = {
   subaccountId2,
   injUsdtSpotMarket,
   injUsdtDerivativeMarket,
+  orderHash,
+  orderHash2,
 }


### PR DESCRIPTION
## This PR:
- adds unit test coverage on remaining EIP712 messages
    - MsgBatchCancelBinaryOptionsOrders
    - MsgBatchCancelDerivativeOrders
    - MsgBatchCancelSpotOrders
    - MsgCancelBinaryOptionsOrder
    - MsgCancelDerivativeOrder
    - MsgCancelSpotOrder