### PR TITLE
fix: added executionSide prop to trade objects

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -37,7 +37,7 @@
     "@injectivelabs/chain-api": "^1.8.0-rc8",
     "@injectivelabs/exceptions": "^1.0.13",
     "@injectivelabs/exchange-api": "^2.2.77",
-    "@injectivelabs/indexer-api": "^1.0.16",
+    "@injectivelabs/indexer-api": "^1.0.18",
     "@injectivelabs/networks": "^1.0.21",
     "@injectivelabs/token-metadata": "^1.0.29",
     "@injectivelabs/ts-types": "^1.0.12",

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcDerivativeTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcDerivativeTransformer.ts
@@ -1,4 +1,8 @@
-import { TradeDirection, TradeExecutionType } from '@injectivelabs/ts-types'
+import {
+  TradeDirection,
+  TradeExecutionSide,
+  TradeExecutionType,
+} from '@injectivelabs/ts-types'
 import { BigNumber } from '@injectivelabs/utils'
 import {
   DerivativeOrderSide,
@@ -411,7 +415,7 @@ export class IndexerGrpcDerivativeTransformer {
       isConditional: order.getIsConditional(),
       triggerAt: order.getTriggerAt(),
       placedOrderHash: order.getPlacedOrderHash(),
-      executionType: order.getExecutionType()
+      executionType: order.getExecutionType(),
     }
   }
 
@@ -445,7 +449,7 @@ export class IndexerGrpcDerivativeTransformer {
       isConditional: orderHistory.getIsConditional(),
       triggerAt: orderHistory.getTriggerAt(),
       placedOrderHash: orderHistory.getPlacedOrderHash(),
-      margin: orderHistory.getMargin()
+      margin: orderHistory.getMargin(),
     }
   }
 
@@ -497,6 +501,7 @@ export class IndexerGrpcDerivativeTransformer {
       marketId: trade.getMarketId(),
       executedAt: trade.getExecutedAt(),
       tradeExecutionType: trade.getTradeExecutionType() as TradeExecutionType,
+      executionSide: trade.getExecutionSide() as TradeExecutionSide,
       fee: trade.getFee(),
       feeRecipient:
         trade.getFeeRecipient !== undefined ? trade.getFeeRecipient() : '', // TODO: remove the check

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcDerivativeTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcDerivativeTransformer.ts
@@ -415,7 +415,7 @@ export class IndexerGrpcDerivativeTransformer {
       isConditional: order.getIsConditional(),
       triggerAt: order.getTriggerAt(),
       placedOrderHash: order.getPlacedOrderHash(),
-      executionType: order.getExecutionType(),
+      executionType: order.getExecutionType()
     }
   }
 
@@ -449,7 +449,7 @@ export class IndexerGrpcDerivativeTransformer {
       isConditional: orderHistory.getIsConditional(),
       triggerAt: orderHistory.getTriggerAt(),
       placedOrderHash: orderHistory.getPlacedOrderHash(),
-      margin: orderHistory.getMargin(),
+      margin: orderHistory.getMargin()
     }
   }
 

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
@@ -241,7 +241,7 @@ export class IndexerGrpcSpotTransformer {
       state: orderHistory.getState(),
       createdAt: orderHistory.getCreatedAt(),
       updatedAt: orderHistory.getUpdatedAt(),
-      direction: orderHistory.getDirection(),
+      direction: orderHistory.getDirection()
     }
   }
 

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
@@ -1,4 +1,8 @@
-import { TradeDirection, TradeExecutionType } from '@injectivelabs/ts-types'
+import {
+  TradeDirection,
+  TradeExecutionSide,
+  TradeExecutionType,
+} from '@injectivelabs/ts-types'
 import { BigNumber } from '@injectivelabs/utils'
 import {
   SpotOrderSide,
@@ -237,7 +241,7 @@ export class IndexerGrpcSpotTransformer {
       state: orderHistory.getState(),
       createdAt: orderHistory.getCreatedAt(),
       updatedAt: orderHistory.getUpdatedAt(),
-      direction: orderHistory.getDirection()
+      direction: orderHistory.getDirection(),
     }
   }
 
@@ -263,6 +267,7 @@ export class IndexerGrpcSpotTransformer {
       feeRecipient:
         trade.getFeeRecipient !== undefined ? trade.getFeeRecipient() : '', // TODO: remove the check
       tradeExecutionType: trade.getTradeExecutionType() as TradeExecutionType,
+      executionSide: trade.getExecutionSide() as TradeExecutionSide,
       tradeDirection: trade.getTradeDirection() as TradeDirection,
       fee: trade.getFee(),
       ...mappedPrice,

--- a/packages/sdk-ts/src/client/indexer/types/derivatives.ts
+++ b/packages/sdk-ts/src/client/indexer/types/derivatives.ts
@@ -29,7 +29,7 @@ export enum DerivativeOrderSide {
   TakeBuy = 'take_buy',
   TakeSell = 'take_sell',
   BuyPO = 'buy_po',
-  SellPO = 'sell_po',
+  SellPO = 'sell_po'
 }
 
 export enum DerivativeOrderState {
@@ -39,7 +39,7 @@ export enum DerivativeOrderState {
   PartiallyFilled = 'partially_filled',
   Filled = 'filled',
   Canceled = 'canceled',
-  Triggered = 'triggered',
+  Triggered = 'triggered'
 }
 
 export interface PositionDelta {
@@ -242,5 +242,5 @@ export {
   GrpcDerivativeTrade,
   GrpcPositionDelta,
   GrpcBinaryOptionsMarketInfo,
-  GrpcDerivativeOrderHistory,
+  GrpcDerivativeOrderHistory
 }

--- a/packages/sdk-ts/src/client/indexer/types/derivatives.ts
+++ b/packages/sdk-ts/src/client/indexer/types/derivatives.ts
@@ -12,7 +12,11 @@ import {
   BinaryOptionsMarketInfo as GrpcBinaryOptionsMarketInfo,
   DerivativeOrderHistory as GrpcDerivativeOrderHistory,
 } from '@injectivelabs/indexer-api/injective_derivative_exchange_rpc_pb'
-import { TradeExecutionType, TradeDirection } from '@injectivelabs/ts-types'
+import {
+  TradeExecutionType,
+  TradeDirection,
+  TradeExecutionSide,
+} from '@injectivelabs/ts-types'
 import { GrpcOrderType } from '../../chain/types/exchange'
 import { TokenMeta } from '@injectivelabs/token-metadata'
 
@@ -35,7 +39,7 @@ export enum DerivativeOrderState {
   PartiallyFilled = 'partially_filled',
   Filled = 'filled',
   Canceled = 'canceled',
-  Triggered = 'triggered'
+  Triggered = 'triggered',
 }
 
 export interface PositionDelta {
@@ -55,7 +59,7 @@ export interface Position {
   liquidationPrice: string
   markPrice: string
   ticker: string
-  aggregateReduceOnlyQuantity: string,
+  aggregateReduceOnlyQuantity: string
   updatedAt: number
 }
 
@@ -187,6 +191,7 @@ export interface DerivativeTrade extends PositionDelta {
   executedAt: number
   tradeExecutionType: TradeExecutionType
   tradeDirection: TradeDirection
+  executionSide: TradeExecutionSide
   fee: string
   feeRecipient: string
   isLiquidation: boolean

--- a/packages/sdk-ts/src/client/indexer/types/spot.ts
+++ b/packages/sdk-ts/src/client/indexer/types/spot.ts
@@ -4,7 +4,11 @@ import {
   SpotTrade as GrpcSpotTrade,
   SpotOrderHistory as GrpcSpotOrderHistory,
 } from '@injectivelabs/indexer-api/injective_spot_exchange_rpc_pb'
-import { TradeExecutionType, TradeDirection, TradeExecutionSide } from '@injectivelabs/ts-types'
+import {
+  TradeExecutionType,
+  TradeDirection,
+  TradeExecutionSide,
+} from '@injectivelabs/ts-types'
 import { GrpcOrderType } from '../../chain/types/exchange'
 import { PriceLevel } from './exchange'
 import { TokenMeta } from '@injectivelabs/token-metadata'
@@ -18,7 +22,7 @@ export enum SpotOrderSide {
   TakeBuy = 'take_buy',
   TakeSell = 'take_sell',
   BuyPO = 'buy_po',
-  SellPO = 'sell_po',
+  SellPO = 'sell_po'
 }
 
 export enum SpotOrderState {
@@ -66,7 +70,7 @@ export interface SpotOrderHistory {
   marketId: string
   active: boolean
   subaccountId: string
-  executionType: string,
+  executionType: string
   orderType: string
   price: string
   triggerPrice: string
@@ -112,5 +116,5 @@ export {
   GrpcSpotMarketInfo,
   GrpcSpotLimitOrder,
   GrpcSpotOrderHistory,
-  GrpcSpotTrade,
+  GrpcSpotTrade
 }

--- a/packages/sdk-ts/src/client/indexer/types/spot.ts
+++ b/packages/sdk-ts/src/client/indexer/types/spot.ts
@@ -4,7 +4,7 @@ import {
   SpotTrade as GrpcSpotTrade,
   SpotOrderHistory as GrpcSpotOrderHistory,
 } from '@injectivelabs/indexer-api/injective_spot_exchange_rpc_pb'
-import { TradeExecutionType, TradeDirection } from '@injectivelabs/ts-types'
+import { TradeExecutionType, TradeDirection, TradeExecutionSide } from '@injectivelabs/ts-types'
 import { GrpcOrderType } from '../../chain/types/exchange'
 import { PriceLevel } from './exchange'
 import { TokenMeta } from '@injectivelabs/token-metadata'
@@ -84,6 +84,7 @@ export interface SpotTrade extends PriceLevel {
   marketId: string
   executedAt: number
   tradeExecutionType: TradeExecutionType
+  executionSide: TradeExecutionSide
   tradeDirection: TradeDirection
   fee: string
   feeRecipient: string

--- a/packages/ts-types/src/trade.ts
+++ b/packages/ts-types/src/trade.ts
@@ -22,5 +22,5 @@ export enum OrderState {
   PartiallyFilled = 'partially_filled',
   Filled = 'filled',
   Canceled = 'canceled',
-  Triggered = 'triggered',
+  Triggered = 'triggered'
 }

--- a/packages/ts-types/src/trade.ts
+++ b/packages/ts-types/src/trade.ts
@@ -6,7 +6,7 @@ export enum TradeExecutionType {
 }
 
 export enum TradeExecutionSide {
-  Maker = 'market',
+  Maker = 'maker',
   Taker = 'taker',
 }
 
@@ -22,5 +22,5 @@ export enum OrderState {
   PartiallyFilled = 'partially_filled',
   Filled = 'filled',
   Canceled = 'canceled',
-  Triggered = 'triggered'
+  Triggered = 'triggered',
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2293,10 +2293,10 @@
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.14.0"
 
-"@injectivelabs/indexer-api@^1.0.16":
-  version "1.0.17"
-  resolved "https://registry.npmjs.org/@injectivelabs/indexer-api/-/indexer-api-1.0.17.tgz#0d0428f30aca83493ca73e2ab69e579580014f58"
-  integrity sha512-8D1V/FFe5Pnz+o3CTiTlPTBeI+tkQYgsJvJxI5Ps46sBDIBRxSulF0nhauexOZwBduW5arYRGC8QBm0VNM1Wxw==
+"@injectivelabs/indexer-api@^1.0.18":
+  version "1.0.18"
+  resolved "https://registry.yarnpkg.com/@injectivelabs/indexer-api/-/indexer-api-1.0.18.tgz#2efaebc2d9a72fbf01105da8177f1423c674e80b"
+  integrity sha512-5UG5OuGlPkQNiAPDfued7Pig2W74P7hV69VHPIiOlovYtHZWRqkRMh9w6BwNnqZNBLzdfmcVaOuz90voFUAryg==
   dependencies:
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.14.0"
@@ -8635,7 +8635,7 @@ glob-parent@^5.1.1, glob-parent@^5.1.2, glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@7.2.3, glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
+glob@7.2.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6, glob@^7.2.0:
   version "7.2.3"
   resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz#b8df0fb802bbfa8e89bd1d938b4e16578ed44f2b"
   integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
@@ -9267,11 +9267,6 @@ internal-slot@^1.0.3:
     get-intrinsic "^1.1.0"
     has "^1.0.3"
     side-channel "^1.0.4"
-
-interpret@^1.0.0:
-  version "1.4.0"
-  resolved "https://registry.npmjs.org/interpret/-/interpret-1.4.0.tgz#665ab8bc4da27a774a40584e812e3e0fa45b1a1e"
-  integrity sha512-agE4QfB2Lkp9uICn7BAqoscw4SZP9kTE2hxiFI3jBPmXJfdqiahTbUuKGsMoN2GtqL9AxhYioAcVvgsb1HvRbA==
 
 invariant@2:
   version "2.2.4"
@@ -10614,13 +10609,6 @@ lines-and-columns@^1.1.6:
   resolved "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
   integrity sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==
 
-link-module-alias@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/link-module-alias/-/link-module-alias-1.2.0.tgz#6a3b7b014cfe18b2759a1222fffce6a40fc120e4"
-  integrity sha512-ahPjXepbSVKbahTB6LxR//VHm8HPfI+QQygCH+E82spBY4HR5VPJTvlhKBc9F7muVxnS6C1rRfoPOXAbWO/fyw==
-  dependencies:
-    chalk "^2.4.1"
-
 linkify-it@^3.0.1:
   version "3.0.3"
   resolved "https://registry.npmjs.org/linkify-it/-/linkify-it-3.0.3.tgz#a98baf44ce45a550efb4d49c769d07524cc2fa2e"
@@ -11306,7 +11294,7 @@ minimist-options@4.1.0:
     is-plain-obj "^1.1.0"
     kind-of "^6.0.3"
 
-minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.3, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6, minimist@~1.2.5:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -13018,13 +13006,6 @@ readonly-date@^1.0.0:
   resolved "https://registry.npmjs.org/readonly-date/-/readonly-date-1.0.0.tgz#5af785464d8c7d7c40b9d738cbde8c646f97dcd9"
   integrity sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==
 
-rechoir@^0.6.2:
-  version "0.6.2"
-  resolved "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
-  integrity sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==
-  dependencies:
-    resolve "^1.1.6"
-
 redent@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz#e557b7998316bb53c9f1f56fa626352c6963059f"
@@ -13221,7 +13202,7 @@ resolve.exports@^1.1.0:
   resolved "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz#5ce842b94b05146c0e03076985d1d0e7e48c90c9"
   integrity sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==
 
-resolve@^1.0.0, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0:
+resolve@^1.0.0, resolve@^1.10.0, resolve@^1.14.2, resolve@^1.20.0, resolve@^1.22.0:
   version "1.22.1"
   resolved "https://registry.npmjs.org/resolve/-/resolve-1.22.1.tgz#27cb2ebb53f91abb49470a928bba7558066ac177"
   integrity sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==
@@ -13652,15 +13633,6 @@ shell-quote@^1.6.1:
   resolved "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.3.tgz#aa40edac170445b9a431e17bb62c0b881b9c4123"
   integrity sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==
 
-shelljs@^0.8.5:
-  version "0.8.5"
-  resolved "https://registry.npmjs.org/shelljs/-/shelljs-0.8.5.tgz#de055408d8361bed66c669d2f000538ced8ee20c"
-  integrity sha512-TiwcRcrkhHvbrZbnRcFYMLl30Dfov3HKqzp5tO5b4pt6G/SezKcYhmDg15zXVBswHmctSAQKznqNW2LO5tTDow==
-  dependencies:
-    glob "^7.0.0"
-    interpret "^1.0.0"
-    rechoir "^0.6.2"
-
 shiki@^0.10.1:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/shiki/-/shiki-0.10.1.tgz#6f9a16205a823b56c072d0f1a0bcd0f2646bef14"
@@ -13669,14 +13641,6 @@ shiki@^0.10.1:
     jsonc-parser "^3.0.0"
     vscode-oniguruma "^1.6.1"
     vscode-textmate "5.2.0"
-
-shx@^0.3.2, shx@^0.3.3:
-  version "0.3.4"
-  resolved "https://registry.npmjs.org/shx/-/shx-0.3.4.tgz#74289230b4b663979167f94e1935901406e40f02"
-  integrity sha512-N6A9MLVqjxZYcVn8hLmtneQWIJtp8IKzMP4eMnx+nqkvXoqinUPCbUFLp2UcWTEIUONhlk0ewxr/jaVGlc+J+g==
-  dependencies:
-    minimist "^1.2.3"
-    shelljs "^0.8.5"
 
 side-channel@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
This PR makes the executionSide property visible on trade objects so we can use it to filter for either `maker` or `taker` side in our products.