### PR TITLE
chore: add lists of leap and cosmostation supported networks

### DIFF
--- a/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
+++ b/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
@@ -38,7 +38,7 @@ import {
 import { getInjectiveAddress } from '@injectivelabs/sdk-ts'
 import { UiBridgeTransactionWithToken } from '../../types'
 
-export const convertKeplrToUiBridgeTransaction = async ({
+export const convertCosmosWalletToUiBridgeTransaction = async ({
   transaction,
   network,
 }: {
@@ -460,8 +460,10 @@ export class UiBridgeTransformer {
   static removeDuplicatedInProgressIbxTransfers =
     removeDuplicatedInProgressIbxTransfers
 
-  async convertKeplrToUiBridgeTransaction(transaction: KeplrWalletResponse) {
-    return convertKeplrToUiBridgeTransaction({
+  async convertCosmosWalletToUiBridgeTransaction(
+    transaction: KeplrWalletResponse,
+  ) {
+    return convertCosmosWalletToUiBridgeTransaction({
       transaction,
       network: this.network,
     })

--- a/packages/sdk-ui-ts/src/utils/bridge.ts
+++ b/packages/sdk-ui-ts/src/utils/bridge.ts
@@ -40,6 +40,27 @@ export const KeplrNetworks = [
   BridgingNetwork.Stride,
 ]
 
+export const LeapNetworks = [
+  BridgingNetwork.CosmosHub,
+  BridgingNetwork.Osmosis,
+  BridgingNetwork.Axelar,
+  BridgingNetwork.Juno,
+  BridgingNetwork.Persistence,
+  BridgingNetwork.Stride,
+]
+
+export const CosmostationNetworks = [
+  BridgingNetwork.CosmosHub,
+  BridgingNetwork.Chihuahua,
+  BridgingNetwork.Osmosis,
+  BridgingNetwork.Axelar,
+  BridgingNetwork.Juno,
+  BridgingNetwork.Persistence,
+  BridgingNetwork.Evmos,
+  BridgingNetwork.Secret,
+  BridgingNetwork.Stride,
+]
+
 export const tokenSelectorDisabledNetworks = [
   BridgingNetwork.Chihuahua,
   BridgingNetwork.CosmosHub,


### PR DESCRIPTION
## Changes
- add list of leap and Cosmosstation supported networks
- rename `convertKeplrToUiBridgeTransaction` to `convertCosmosWalletToUiBridgeTransaction` to be more inclusive of other cosmos wallets such as Leap. this method should get tested as part of QA as to whether this method will work for Leap as well