### PR TITLE
fix: sdk-ts README.md

### DIFF
--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -149,7 +149,7 @@ import { BigNumberInBase } from "@injectivelabs/utils";
   const privateKey = PrivateKey.fromPrivateKey(privateKeyHash);
   const injectiveAddress = privateKey.toBech32();
   const publicKey = privateKeyToPublicKeyBase64(
-    Buffer.from(privateKeyHash, "hex")
+    Buffer.from(privateKeyHash.replace("0x", ""), "hex")
   );
 
   /** Account Details **/

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -174,7 +174,7 @@ import { BigNumberInBase } from "@injectivelabs/utils";
     message: msg.toDirectSign(),
     memo: "",
     fee: DEFAULT_STD_FEE,
-    pubKey: Buffer.from(publicKey).toString("base64"),
+    pubKey: publicKey,
     sequence: parseInt(accountDetails.account.base_account.sequence, 10),
     accountNumber: parseInt(
       accountDetails.account.base_account.account_number,

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -132,8 +132,8 @@ console.log(await exchangeGrpcClient.derivatives.fetchMarkets())
 ```ts
 import { getNetworkInfo, Network } from "@injectivelabs/networks";
 import { ChainRestAuthApi } from "@injectivelabs/sdk-ts";
-import { PrivateKey } from "@injectivelabs/sdk-ts/dist/local";
 import {
+  PrivateKey,
   privateKeyToPublicKeyBase64,
   MsgSend,
   DEFAULT_STD_FEE,

--- a/packages/sdk-ts/README.md
+++ b/packages/sdk-ts/README.md
@@ -169,7 +169,7 @@ import { BigNumberInBase } from "@injectivelabs/utils";
     dstInjectiveAddress: injectiveAddress,
   });
 
-  /** Prepare the Transaction **/
+  /** Prepare the Transaction */
   const { signBytes, txRaw } = createTransaction({
     message: msg.toDirectSign(),
     memo: "",


### PR DESCRIPTION
### changes
- pubkey type
`publicKey` in the example is already Base64.
- PrivateKey import path
fix PrivateKey import path.
- format
fix comment format.
- hex string type
it would be better to remove `'0x'` for those who use `privateKeyHash` with `'0x'`.
