### PR TITLE
feat: utility methods for explorer

### DIFF
--- a/packages/sdk-ui-ts/src/types/explorer.ts
+++ b/packages/sdk-ui-ts/src/types/explorer.ts
@@ -1,0 +1,6 @@
+export enum SupportedChains {
+  Injective = 'injective',
+  Cosmos = 'cosmos',
+  Ethereum = 'ethereum',
+  Solana = 'solana',
+}

--- a/packages/sdk-ui-ts/src/types/index.ts
+++ b/packages/sdk-ui-ts/src/types/index.ts
@@ -1,3 +1,4 @@
 export * from './cosmos'
+export * from './explorer'
 export * from './token'
 export * from './bridge'

--- a/packages/sdk-ui-ts/src/utils/explorer.ts
+++ b/packages/sdk-ui-ts/src/utils/explorer.ts
@@ -1,0 +1,47 @@
+import { SupportedChains } from '../types/explorer'
+import { getCosmosExplorerUrl } from './bridge'
+import { BridgingNetwork } from '../types/bridge'
+import { getEthereumExplorerUrl, getNetworkFromAddress } from './bridge'
+import { Network } from '@injectivelabs/networks'
+
+export const getSupportedNetworkFromAddress = (
+  address: string,
+): SupportedChains | BridgingNetwork => {
+  if (address.includes('inj')) {
+    return SupportedChains.Injective
+  }
+
+  if (address.startsWith('0x')) {
+    return SupportedChains.Ethereum
+  }
+
+  return getNetworkFromAddress(address)
+}
+
+export const getBlockExplorerPathFromNetworkType = ({
+  network,
+  chain,
+  address,
+}: {
+  network: Network
+  chain: SupportedChains | BridgingNetwork
+  address: string
+}) => {
+  if (chain === SupportedChains.Injective) {
+    return undefined
+  }
+
+  if (Object.values(BridgingNetwork).includes(chain as BridgingNetwork)) {
+    const mintscanPath = getCosmosExplorerUrl(chain as BridgingNetwork, network)
+
+    return `${mintscanPath}/account/${address}`
+  }
+
+  if (chain === SupportedChains.Ethereum) {
+    const ethereumExplorerPath = getEthereumExplorerUrl(network)
+
+    return `${ethereumExplorerPath}/address/${address}`
+  }
+
+  return undefined
+}

--- a/packages/sdk-ui-ts/src/utils/index.ts
+++ b/packages/sdk-ui-ts/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './bridge'
 export * from './derivatives'
+export * from './explorer'
 export * from './spot'
 export * from './helpers'


### PR DESCRIPTION
## Changes
Utility method `getBlockExplorerPathFromNetworkType` can now be used across products to grab the appropriate block explorer url for a given address across Injective, Ethereum, and Cosmos block explorers. It can also easily be extended to other chains such as Solana.