### PR TITLE
chore: add optional errorLog to Transaction types

### DIFF
--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerRestExplorerTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerRestExplorerTransformer.ts
@@ -100,6 +100,7 @@ export class IndexerRestExplorerTransformer {
         type: message.type,
         message: message.value,
       })),
+      errorLog: transaction.error_log,
     }
   }
 

--- a/packages/sdk-ts/src/client/indexer/types/explorer-rest.ts
+++ b/packages/sdk-ts/src/client/indexer/types/explorer-rest.ts
@@ -65,6 +65,7 @@ export interface TransactionFromExplorerApiResponse {
   events: Array<any>
   codespace: string
   messages: Array<{ value: any; type: string }>
+  error_log?: string
 }
 
 export interface BlockFromExplorerApiResponse {
@@ -99,6 +100,7 @@ export interface ExplorerTransaction extends Omit<BaseTransaction, 'messages'> {
   memo: string
   messages: Message[]
   parsedMessages?: Message[]
+  errorLog?: string
 }
 
 export interface ExplorerBlockWithTxs extends Omit<BaseBlockWithTxs, 'txs'> {

--- a/packages/sdk-ts/src/client/indexer/types/explorer.ts
+++ b/packages/sdk-ts/src/client/indexer/types/explorer.ts
@@ -128,6 +128,7 @@ export interface Transaction {
   }>
   codespace: string
   messages?: Array<TxMessage>
+  errorLog?: string
 }
 
 export interface IndexerStreamTransaction {


### PR DESCRIPTION
## Changes 
Add `errorLog` to the transformed response when querying for transaction details by tsx ID.