### PR TITLE
fix: fixes walletconnect signed tx type

### DIFF
--- a/packages/wallet-ts/src/strategies/wallet/strategies/WalletConnect.ts
+++ b/packages/wallet-ts/src/strategies/wallet/strategies/WalletConnect.ts
@@ -110,7 +110,8 @@ export default class WalletConnect
 
     try {
       return await this.walletConnectProvider!.request({
-        method: 'eth_signTypedData',
+        jsonrpc: '2.0',
+        method: 'eth_signTypedData_v4',
         params: [address, eip712json],
       })
     } catch (e: unknown) {


### PR DESCRIPTION
Updates the type of request sent to Wallet Connect to allow for Metamask and many other wallets to properly sign transactions