### PR TITLE
chore: add helper method for getting cw account balance token metadata

### DIFF
--- a/packages/sdk-ui-ts/src/token/TokenService.ts
+++ b/packages/sdk-ui-ts/src/token/TokenService.ts
@@ -5,6 +5,7 @@ import {
   ExplorerCW20BalanceWithToken,
   Denom,
   tokenMetaToToken,
+  ContractAccountBalance,
 } from '@injectivelabs/sdk-ts'
 import {
   BankBalances,
@@ -21,6 +22,7 @@ import {
 } from '../client/types'
 import {
   BankBalanceWithToken,
+  ContractAccountBalanceWithToken,
   Cw20BalanceWithToken,
   DenomTrace,
   IbcBankBalanceWithToken,
@@ -195,6 +197,26 @@ export class TokenService {
         }
       }),
     )
+  }
+
+  async getCW20AccountsBalanceWithToken({
+    contractAccountsBalance,
+    contractAddress,
+  }: {
+    contractAccountsBalance: ContractAccountBalance[]
+    contractAddress: string
+  }): Promise<ContractAccountBalanceWithToken[]> {
+    const token = await this.getDenomToken(contractAddress)
+
+    return contractAccountsBalance.map((balance) => {
+      return {
+        ...balance,
+        token: {
+          ...token,
+          type: TokenType.Cw20,
+        },
+      }
+    })
   }
 
   async getSupplyWithLabel({

--- a/packages/sdk-ui-ts/src/types/token.ts
+++ b/packages/sdk-ui-ts/src/types/token.ts
@@ -1,6 +1,7 @@
 /* eslint-disable camelcase */
 import { Token, TokenMeta } from '@injectivelabs/token-metadata'
 import { UiBridgeTransaction } from './bridge'
+import { ContractAccountBalance } from '@injectivelabs/sdk-ts'
 
 export interface CoinPriceFromInjectiveService {
   id: string
@@ -84,6 +85,11 @@ export interface Cw20BalanceWithToken {
   contractDetails: {
     address: string
   }
+}
+
+export interface ContractAccountBalanceWithToken
+  extends ContractAccountBalance {
+  token: Token
 }
 
 export interface SubaccountBalanceWithToken {


### PR DESCRIPTION
## Changes
A helper method `getCW20AccountsBalanceWithToken` was added to the `TokenService` in support of explorer [PR](https://github.com/InjectiveLabs/injective-explorer/pull/207).