### PR TITLE
Chore/explorer assets page helpers

### DIFF
--- a/packages/sdk-ts/src/client/indexer/rest/IndexerRestExplorerApi.ts
+++ b/packages/sdk-ts/src/client/indexer/rest/IndexerRestExplorerApi.ts
@@ -297,19 +297,21 @@ export class IndexerRestExplorerApi extends BaseRestConsumer {
   }
 
   async fetchContracts(params?: {
+    assets_only?: boolean
     from_number?: number
     limit?: number
-    to_number?: number
+    skip?: number
   }): Promise<{
     paging: Paging
     contracts: Contract[]
   }> {
     try {
-      const { from_number, limit, to_number } = params || { limit: 12 }
+      const { assets_only, from_number, limit, skip } = params || { limit: 12 }
       const response = (await this.get('/wasm/contracts', {
+        assets_only,
         from_number,
         limit,
-        to_number,
+        skip,
       })) as ExplorerApiResponseWithPagination<ContractExplorerApiResponse[]>
 
       const { paging, data } = response.data

--- a/packages/sdk-ts/src/utils/classes/Denom/DenomClient.ts
+++ b/packages/sdk-ts/src/utils/classes/Denom/DenomClient.ts
@@ -93,6 +93,12 @@ export class DenomClient {
         return tokenMetaToToken(byAddress, denom) as Token
       }
 
+      const byName = this.getTokenMetaDataByName(denom)
+
+      if (byName) {
+        return tokenMetaToToken(byName, denom) as Token
+      }
+
       return {
         denom,
         name: denom,
@@ -141,6 +147,12 @@ export class DenomClient {
     const { tokenMetaUtil } = this
 
     return tokenMetaUtil.getMetaByAddress(address)
+  }
+
+  getTokenMetaDataByName(name: string): TokenMeta | undefined {
+    const { tokenMetaUtil } = this
+
+    return tokenMetaUtil.getMetaByName(name)
   }
 
   fetchDenomTrace(denom: string) {

--- a/packages/token-metadata/src/TokenMetaUtil.ts
+++ b/packages/token-metadata/src/TokenMetaUtil.ts
@@ -1,4 +1,5 @@
 import { getMappedTokensByAddress } from './tokens/helpers/mapByAddress'
+import { getMappedTokensByName } from './tokens/helpers/mapByName'
 import { wormholeCw20Contracts } from './tokens/helpers'
 import { TokenMeta } from './types'
 
@@ -7,9 +8,12 @@ export class TokenMetaUtil {
 
   protected tokensByAddress: Record<string, TokenMeta>
 
+  protected tokensByName: Record<string, TokenMeta>
+
   constructor(tokens: Record<string, TokenMeta>) {
     this.tokens = tokens
     this.tokensByAddress = getMappedTokensByAddress(tokens)
+    this.tokensByName = getMappedTokensByName(tokens)
   }
 
   getMetaBySymbol(symbol: string): TokenMeta | undefined {
@@ -43,6 +47,27 @@ export class TokenMetaUtil {
     }
 
     return tokensByAddress[contractAddress]
+  }
+
+  getMetaByName(name: string): TokenMeta | undefined {
+    const { tokensByName } = this
+    const tokenName = name.toLowerCase() as keyof typeof tokensByName
+
+    if (!tokensByName[tokenName]) {
+      return
+    }
+
+    const tokenMeta = tokensByName[tokenName]
+
+    /** Wormhole CW20 versions can't have more than 8 decimals */
+    if (wormholeCw20Contracts.includes(tokenMeta.address || '')) {
+      return {
+        ...tokenMeta,
+        decimals: Math.max(0, Math.min(tokenMeta.decimals, 8)),
+      }
+    }
+
+    return tokensByName[tokenName]
   }
 
   getCoinGeckoIdFromSymbol(symbol: string): string {

--- a/packages/token-metadata/src/tokens/helpers/mapByName.ts
+++ b/packages/token-metadata/src/tokens/helpers/mapByName.ts
@@ -1,0 +1,10 @@
+import { TokenMeta } from '../../types'
+
+export const getMappedTokensByName = (tokens: Record<string, TokenMeta>) =>
+  (Object.keys(tokens) as Array<keyof typeof tokens>).reduce(
+    (result, token) => ({
+      ...result,
+      [tokens[token].name!.toLowerCase()]: tokens[token],
+    }),
+    {},
+  ) as Record<string, TokenMeta>


### PR DESCRIPTION
## Situation
This PR is a prerequesite for explorer [PR](https://github.com/InjectiveLabs/injective-explorer/pull/208) for the assets page revamp.

## Changes
- indexer rest explorer api `fetchContracts` was updated due to changes via api to support filtering out non-asset contracts if the `asset_only` flag is passed
- token metadata was updated to support finding a denom based off a token name. This will be used by the explorer global search bar to find the contract address associated with a token name and then route the user to the appropriate contract details screen.