### PR TITLE
chore: add proposal id to wasmCodeToExplorerWasmCode transformer

### DIFF
--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerRestExplorerTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerRestExplorerTransformer.ts
@@ -222,6 +222,7 @@ export class IndexerRestExplorerTransformer {
       creationDate: wasmCode.created_at,
       checksum: wasmCode.checksum,
       permission: wasmCode.permission,
+      proposalId: wasmCode.proposal_id,
     }
   }
 

--- a/packages/sdk-ts/src/client/indexer/types/explorer-rest.ts
+++ b/packages/sdk-ts/src/client/indexer/types/explorer-rest.ts
@@ -145,6 +145,7 @@ export interface WasmCodeExplorerApiResponse {
   permission: CosmWasmPermission
   tx_hash: string
   version: string
+  proposal_id?: number
 }
 
 export interface ContractExplorerApiResponse {

--- a/packages/sdk-ts/src/client/indexer/types/explorer.ts
+++ b/packages/sdk-ts/src/client/indexer/types/explorer.ts
@@ -273,6 +273,7 @@ export interface WasmCode {
   creationDate: number
   checksum?: CosmWasmChecksum
   permission?: CosmWasmPermission
+  proposalId?: number
 }
 
 export { GrpcIBCTransferTx, GrpcPeggyDepositTx, GrpcPeggyWithdrawalTx }


### PR DESCRIPTION
Add proposal Id property to the `wasmCodeToExplorerWasmCode` transformer. The `proposal_id` property is already being returned via the indexer rest explorer api. Now, we will expose it to the UI via the transformer.  This will allow us to get the governance proposal id associated with a wasm code, for us to show on the explorer's code details page and will link to the appropriate governance proposal on the hub.