### PR TITLE
feat: implement grpc oracle stream for prices by markets

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -42,7 +42,7 @@
     "@improbable-eng/grpc-web-react-native-transport": "^0.15.0",
     "@injectivelabs/chain-api": "1.9.6",
     "@injectivelabs/exceptions": "^1.0.54",
-    "@injectivelabs/indexer-api": "1.9.1",
+    "@injectivelabs/indexer-api": "1.9.3",
     "@injectivelabs/networks": "^1.0.87",
     "@injectivelabs/ninja-api": "^1.0.11",
     "@injectivelabs/token-metadata": "^1.0.156",

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerOracleStreamTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerOracleStreamTransformer.ts
@@ -1,5 +1,8 @@
 import { StreamOperation } from '../../../types'
-import { StreamPricesResponse } from '@injectivelabs/indexer-api/injective_oracle_rpc_pb'
+import {
+  StreamPricesResponse,
+  StreamPricesByMarketsResponse,
+} from '@injectivelabs/indexer-api/injective_oracle_rpc_pb'
 
 /**
  * @category Indexer Stream Transformer
@@ -8,6 +11,14 @@ export class IndexerOracleStreamTransformer {
   static pricesStreamCallback = (response: StreamPricesResponse) => ({
     price: response.getPrice(),
     operation: StreamOperation.Update as StreamOperation,
+    timestamp: response.getTimestamp(),
+  })
+
+  static pricesByMarketsCallback = (
+    response: StreamPricesByMarketsResponse,
+  ) => ({
+    price: response.getPrice(),
+    marketId: response.getMarketId(),
     timestamp: response.getTimestamp(),
   })
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2101,10 +2101,10 @@
     "@improbable-eng/grpc-web" "^0.13.0"
     google-protobuf "^3.13.0"
 
-"@injectivelabs/indexer-api@1.9.1":
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/@injectivelabs/indexer-api/-/indexer-api-1.9.1.tgz#3b6b60f3132488657c5d34a36473862d34814b1f"
-  integrity sha512-WWuNel6KnawkTBX0e1C3tP4knI8V5vLkofnO6obFq13bzTFFyC9JIM+Smn80ZrggqqR2rEBcTx0e65/6GRrRgg==
+"@injectivelabs/indexer-api@1.9.3":
+  version "1.9.3"
+  resolved "https://registry.npmjs.org/@injectivelabs/indexer-api/-/indexer-api-1.9.3.tgz#dfd87c8b776c4206f38a11732718680abc605ba9"
+  integrity sha512-JNZ7Ga0TznbKDSKbTAKrHI/EAhkBF0mZQm6wOlVUNJUXQvk9npPaOZA69c9m96p1c++G3yrLgnoXylonSTWw0Q==
   dependencies:
     "@improbable-eng/grpc-web" "^0.14.0"
     google-protobuf "^3.14.0"


### PR DESCRIPTION
## This PR:
- add supports for the latest indexer grpc oracle stream for prices by marketIds

### Tested this against staging locally, the stream works as designed.