### PR TITLE
chore: add explorer link based on tsx for eth wh transfer

### DIFF
--- a/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
+++ b/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
@@ -25,6 +25,7 @@ import { UserDeposit } from '@injectivelabs/sdk-ts/dist/client'
 import {
   getExplorerUrl,
   getCosmosExplorerUrl,
+  getSolanaExplorerUrl,
   getEthereumExplorerUrl,
   getTerraExplorerUrl,
   FailedStates,
@@ -358,13 +359,30 @@ export const convertWormholeToUiBridgeTransaction = async ({
     (transaction.receiver.startsWith('0x') &&
       (transaction.source === BridgingNetwork.EthereumWh ||
         transaction.destination === BridgingNetwork.EthereumWh))
-  const isDeposit = transaction.sender.startsWith('0x')
-  const ethereumWhExplorerLink = isDeposit
+  const isSolanaTransfer =
+    transaction.source === BridgingNetwork.Solana ||
+    transaction.destination === BridgingNetwork.Solana
+  const isEthereumDeposit =
+    transaction.sender.startsWith('0x') &&
+    transaction.source === BridgingNetwork.EthereumWh
+  const isSolanaDeposit = transaction.source === BridgingNetwork.Solana
+
+  const solanaWhExplorerLink = isSolanaDeposit
+    ? `${getSolanaExplorerUrl(network)}/tx/${transaction.txHash}`
+    : `${getExplorerUrl(network)}/transaction/${transaction.txHash}/`
+
+  const ethereumWhExplorerLink = isEthereumDeposit
     ? `${getEthereumExplorerUrl(network)}/tx/${transaction.txHash}`
     : `${getExplorerUrl(network)}/transaction/${transaction.txHash}/`
-  const explorerLink = isEthereumWhTransfer
-    ? ethereumWhExplorerLink
-    : transaction.explorerLink || ''
+
+  const whExplorerLink = isSolanaTransfer
+    ? solanaWhExplorerLink
+    : ethereumWhExplorerLink
+
+  const explorerLink =
+    isEthereumWhTransfer || isSolanaTransfer
+      ? whExplorerLink
+      : transaction.explorerLink || ''
 
   return {
     type: getBridgeTransactionType(transaction.source, transaction.destination),

--- a/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
+++ b/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
@@ -354,7 +354,10 @@ export const convertWormholeToUiBridgeTransaction = async ({
   network: Network
 }): Promise<UiBridgeTransaction> => {
   const isEthereumWhTransfer =
-    transaction.sender.startsWith('0x') || transaction.receiver.startsWith('0x')
+    transaction.sender.startsWith('0x') ||
+    (transaction.receiver.startsWith('0x') &&
+      (transaction.source === BridgingNetwork.EthereumWh ||
+        transaction.destination === BridgingNetwork.EthereumWh))
   const isDeposit = transaction.sender.startsWith('0x')
   const ethereumWhExplorerLink = isDeposit
     ? `${getEthereumExplorerUrl(network)}/tx/${transaction.txHash}`

--- a/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
+++ b/packages/sdk-ui-ts/src/client/transformers/UiBridgeTransformer.ts
@@ -346,9 +346,23 @@ export const convertMoonbeamToUiBridgeTransaction = async (
   }
 }
 
-export const convertWormholeToUiBridgeTransaction = async (
-  transaction: WormholeTxResponse,
-): Promise<UiBridgeTransaction> => {
+export const convertWormholeToUiBridgeTransaction = async ({
+  transaction,
+  network,
+}: {
+  transaction: WormholeTxResponse
+  network: Network
+}): Promise<UiBridgeTransaction> => {
+  const isEthereumWhTransfer =
+    transaction.sender.startsWith('0x') || transaction.receiver.startsWith('0x')
+  const isDeposit = transaction.sender.startsWith('0x')
+  const ethereumWhExplorerLink = isDeposit
+    ? `${getEthereumExplorerUrl(network)}/tx/${transaction.txHash}`
+    : `${getExplorerUrl(network)}/transaction/${transaction.txHash}/`
+  const explorerLink = isEthereumWhTransfer
+    ? ethereumWhExplorerLink
+    : transaction.explorerLink || ''
+
   return {
     type: getBridgeTransactionType(transaction.source, transaction.destination),
     denom: transaction.denom,
@@ -356,7 +370,7 @@ export const convertWormholeToUiBridgeTransaction = async (
     receiver: transaction.receiver,
     sender: transaction.sender,
     txHash: transaction.txHash,
-    explorerLink: transaction.explorerLink || '',
+    explorerLink,
     timestamp: new BigNumberInBase(
       Math.floor(new BigNumberInBase(Date.now()).div(1000).toNumber()),
     )
@@ -555,7 +569,10 @@ export class UiBridgeTransformer {
   }
 
   async convertWormholeToUiBridgeTransaction(transaction: WormholeTxResponse) {
-    return convertWormholeToUiBridgeTransaction(transaction)
+    return convertWormholeToUiBridgeTransaction({
+      transaction,
+      network: this.network,
+    })
   }
 
   async convertPeggyToUiBridgeTransaction(

--- a/packages/sdk-ui-ts/src/types/bridge.ts
+++ b/packages/sdk-ui-ts/src/types/bridge.ts
@@ -42,6 +42,7 @@ export enum BridgeTransactionState {
   Cancelled = 'Cancelled',
   Completed = 'Completed',
   Confirm = 'Confirming',
+  Redeemable = 'Redeemable',
   Confirming = 'Confirming',
   EthereumConfirming = 'EthereumConfirming',
   Failed = 'Failed',

--- a/packages/sdk-ui-ts/src/utils/bridge.ts
+++ b/packages/sdk-ui-ts/src/utils/bridge.ts
@@ -428,6 +428,23 @@ export const getEthereumExplorerUrl = (network: Network): string => {
   }
 }
 
+export const getSolanaExplorerUrl = (network: Network): string => {
+  switch (network) {
+    case Network.Devnet:
+      return 'https://explorer.solana.com/?cluster=devnet'
+    case Network.Mainnet:
+      return 'https://explorer.solana.com/'
+    case Network.Public:
+      return 'https://explorer.solana.com/'
+    case Network.Local:
+      return 'https://explorer.solana.com/?cluster=devnet'
+    case Network.Testnet:
+      return 'https://explorer.solana.com/?cluster=testnet'
+    default:
+      return 'https://explorer.solana.com/'
+  }
+}
+
 export const getTerraExplorerUrl = (network: Network): string => {
   switch (network) {
     case Network.Devnet:

--- a/packages/sdk-ui-ts/src/utils/explorer.ts
+++ b/packages/sdk-ui-ts/src/utils/explorer.ts
@@ -1,5 +1,5 @@
 import { SupportedChains } from '../types/explorer'
-import { getCosmosExplorerUrl } from './bridge'
+import { getCosmosExplorerUrl, getSolanaExplorerUrl } from './bridge'
 import { BridgingNetwork } from '../types/bridge'
 import { getEthereumExplorerUrl, getNetworkFromAddress } from './bridge'
 import { Network } from '@injectivelabs/networks'
@@ -29,6 +29,12 @@ export const getBlockExplorerPathFromNetworkType = ({
 }) => {
   if (chain === SupportedChains.Injective) {
     return undefined
+  }
+
+  if (chain === SupportedChains.Solana) {
+    const solanaExplorerPath = getSolanaExplorerUrl(network)
+
+    return `${solanaExplorerPath}/address/${address}`
   }
 
   if (Object.values(BridgingNetwork).includes(chain as BridgingNetwork)) {


### PR DESCRIPTION
This PR makes it possible to get explorer link URL's attached to wormhole ethereum deposits.