### PR TITLE
fix: token meta not populated on devnet env

### DIFF
--- a/packages/sdk-ts/src/core/utils/Denom/DenomClient.ts
+++ b/packages/sdk-ts/src/core/utils/Denom/DenomClient.ts
@@ -109,9 +109,18 @@ export class DenomClient {
         : undefined
     }
 
-    const denomTrace = await this.ibcApi.fetchDenomTrace(hash)
+    try {
+      const denomTrace = await this.ibcApi.fetchDenomTrace(hash)
 
-    if (!denomTrace) {
+      const token = this.tokenFactory.toToken(denomTrace.baseDenom)
+
+      return token
+        ? {
+            ...token,
+            denom,
+          }
+        : undefined
+    } catch (e) {
       throw new GeneralException(
         new Error(`Denom trace not found for ${denom}`),
         {
@@ -119,15 +128,6 @@ export class DenomClient {
         },
       )
     }
-
-    const token = this.tokenFactory.toToken(denomTrace.baseDenom)
-
-    return token
-      ? {
-          ...token,
-          denom,
-        }
-      : undefined
   }
 
   private async fetchAndCacheDenomTraces() {

--- a/packages/token-metadata/src/tokens/network/devnet.ts
+++ b/packages/token-metadata/src/tokens/network/devnet.ts
@@ -19,10 +19,6 @@ export const tokensBySymbolForDevnet = (
   const tokenSymbol = token as keyof typeof devnetSymbolToAddressMap
   const testnetAddressFromMap = devnetSymbolToAddressMap[tokenSymbol]
 
-  if (!testnetAddressFromMap) {
-    return result
-  }
-
   if (!tokens[token].erc20) {
     return result
   }
@@ -32,8 +28,8 @@ export const tokensBySymbolForDevnet = (
     [token.toUpperCase()]: {
       ...tokens[token],
       erc20: {
+        ...(testnetAddressFromMap ? { address: testnetAddressFromMap } : {}),
         ...tokens[token].erc20,
-        address: testnetAddressFromMap,
       },
     },
   }
@@ -45,10 +41,6 @@ export const tokensBySymbolForDevnet1 = (
   const tokenSymbol = token as keyof typeof devnet1SymbolToAddressMap
   const testnetAddressFromMap = devnet1SymbolToAddressMap[tokenSymbol]
 
-  if (!testnetAddressFromMap) {
-    return result
-  }
-
   if (!tokens[token].erc20) {
     return result
   }
@@ -59,7 +51,7 @@ export const tokensBySymbolForDevnet1 = (
       ...tokens[token],
       erc20: {
         ...tokens[token].erc20,
-        address: testnetAddressFromMap,
+        ...(testnetAddressFromMap ? { address: testnetAddressFromMap } : {}),
       },
     },
   }
@@ -71,10 +63,6 @@ export const tokensBySymbolForDevnet2 = (
   const tokenSymbol = token as keyof typeof devnet2SymbolToAddressMap
   const testnetAddressFromMap = devnet2SymbolToAddressMap[tokenSymbol]
 
-  if (!testnetAddressFromMap) {
-    return result
-  }
-
   if (!tokens[token].erc20) {
     return result
   }
@@ -85,7 +73,7 @@ export const tokensBySymbolForDevnet2 = (
       ...tokens[token],
       erc20: {
         ...tokens[token].erc20,
-        address: testnetAddressFromMap,
+        ...(testnetAddressFromMap ? { address: testnetAddressFromMap } : {}),
       },
     },
   }

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -32,7 +32,11 @@ export const awaitForAll = async <T, S>(
   const result = [] as S[]
 
   for (let i = 0; i < array.length; i += 1) {
-    result.push(await callback(array[i]))
+    try {
+      result.push(await callback(array[i]))
+    } catch (e: any) {
+      throw Error(e)
+    }
   }
 
   return result

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -35,7 +35,7 @@ export const awaitForAll = async <T, S>(
     try {
       result.push(await callback(array[i]))
     } catch (e: any) {
-      throw Error(e)
+      // throw Error(e)
     }
   }
 


### PR DESCRIPTION
## This PR:
- resolves token metadata not populating on devnet issue
- resolves `ibcApi.fetchDenomTrace(hash)` onError halts `awaitForAll` utils function 