### PR TITLE
chore: helper method for Solana getTxResponse

### DIFF
--- a/packages/bridge-ts/src/wormhole/clients/SolanaWormholeClient.ts
+++ b/packages/bridge-ts/src/wormhole/clients/SolanaWormholeClient.ts
@@ -196,6 +196,24 @@ export class SolanaWormholeClient extends WormholeClient {
     }
   }
 
+  async getTxResponse(txHash: string) {
+    const { solanaHostUrl } = this
+
+    if (!solanaHostUrl) {
+      throw new GeneralException(new Error(`Please provide solanaHostUrl`))
+    }
+
+    const connection = new Connection(solanaHostUrl, 'confirmed')
+
+    const txResponse = await getSolanaTransactionInfo(txHash, connection)
+
+    if (!txResponse) {
+      throw new Error('An error occurred while fetching the transaction info')
+    }
+
+    return txResponse
+  }
+
   async getSignedVAA(txResponse: TransactionResponse) {
     const { network, wormholeRpcUrl } = this
 

--- a/packages/sdk-ui-ts/src/types/bridge.ts
+++ b/packages/sdk-ui-ts/src/types/bridge.ts
@@ -50,6 +50,7 @@ export enum BridgeTransactionState {
   EthereumConfirming = 'EthereumConfirming',
   Failed = 'Failed',
   InjectiveConfirming = 'InjectiveConfirming',
+  RequestingVAA = 'RequestingVAA',
   Submitted = 'Submitted',
   FailedCancelled = 'failed-cancelled',
   InProgress = 'in-progress',

--- a/packages/sdk-ui-ts/src/utils/bridge.ts
+++ b/packages/sdk-ui-ts/src/utils/bridge.ts
@@ -21,6 +21,8 @@ export const InProgressStates = [
   BridgeTransactionState.Submitted,
   BridgeTransactionState.InjectiveConfirming,
   BridgeTransactionState.EthereumConfirming,
+  BridgeTransactionState.RequestingVAA,
+  BridgeTransactionState.Redeemable,
 ]
 
 export const FailedStates = [


### PR DESCRIPTION
## Changes
- the new `getTxResponse` for the `SolanaWormholeClient` will fetch a `TransactionResponse` based on a passed in `txHash.
- `RequestingVAA`  was added to the `BridgeTransactionState` in order to mark a transaction on the hub's bridge as being in a state of about to request a VAA. Therefore, if the user refreshes the page, they can see their order in the order details table, and the flow will go back to the point of trying to request a VAA from the WH guardians so that their transfer can be redeemed on the appropriate network end.