### PR TITLE
fix: puggo image suffix from jpeg to jpg

### DIFF
--- a/packages/token-metadata/src/tokens/tokens/tokens.ts
+++ b/packages/token-metadata/src/tokens/tokens/tokens.ts
@@ -1190,7 +1190,7 @@ export default {
     name: 'Puggo',
     symbol: 'PUG',
     decimals: 18,
-    logo: 'puggo.jpeg',
+    logo: 'puggo.jpg',
     coinGeckoId: '',
 
     erc20: {


### PR DESCRIPTION
Updates the puggo logo image suffix from .jpeg to .jpg to match the correct suffix of the puggo.jpg file.