### PR TITLE
Handle unhanded error in TxGrpcAPI

### DIFF
--- a/packages/sdk-ts/src/core/modules/tx/api/TxGrpcApi.ts
+++ b/packages/sdk-ts/src/core/modules/tx/api/TxGrpcApi.ts
@@ -207,12 +207,15 @@ export class TxGrpcApi implements TxConcreteApi {
               })
             }
 
-            const result = await this.fetchTxPoll(
-              txResponse.getTxhash(),
-              timeout,
-            )
-
-            return resolve(result)
+            try {
+              const result = await this.fetchTxPoll(
+                txResponse.getTxhash(),
+                timeout,
+              )
+              return resolve(result)
+            } catch (error) {
+              return reject(error)
+            }
           }),
       )
     } catch (e: unknown) {


### PR DESCRIPTION
FetchTxPoll throws an error if transaction has not been included in a block for a given timeout

This PR handles that error in Broadcast method. 