### PR TITLE
Fix eip712 for date type and feePayer

### DIFF
--- a/packages/sdk-ts/src/core/modules/authz/msgs/MsgGrant.spec.ts
+++ b/packages/sdk-ts/src/core/modules/authz/msgs/MsgGrant.spec.ts
@@ -1,0 +1,121 @@
+import { MsgGrant as BaseMsgGrant } from '@injectivelabs/chain-api/cosmos/authz/v1beta1/tx_pb'
+import MsgGrant from './MsgGrant'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const { injectiveAddress, injectiveAddress2 } = mockFactory
+
+const params: MsgGrant['params'] = {
+  grantee: injectiveAddress,
+  granter: injectiveAddress2,
+  messageType: '/cosmos.bank.v1beta1.MsgSend',
+  expiration: 1679416772
+}
+
+const protoType = '/cosmos.authz.v1beta1.MsgGrant'
+const protoTypeShort = 'cosmos-sdk/MsgGrant'
+const protoParams = {
+  grantee: params.grantee,
+  granter: params.granter,
+  grant: {
+    authorization: {
+      typeUrl: '/cosmos.authz.v1beta1.GenericAuthorization',
+      value: 'ChwvY29zbW9zLmJhbmsudjFiZXRhMS5Nc2dTZW5k'
+    },
+    expiration: {
+      nanos: 0,
+      seconds: params.expiration,
+    }
+  },
+}
+
+const protoParamsAmino = snakecaseKeys({
+  grantee: params.grantee,
+  granter: params.granter,
+  grant: {
+    authorization: {
+      type: 'cosmos-sdk/GenericAuthorization',
+      value: {
+        msg: params.messageType
+      }
+    },
+    expiration: new Date(params.expiration! * 1000)
+  }
+})
+const message = MsgGrant.fromJSON(params)
+
+describe('MsgCreateInsuranceFund', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto instanceof BaseMsgGrant).toBe(true)
+    expect(proto.toObject()).toStrictEqual({
+      ...protoParams,
+    })
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      TypeGrant: [
+        { name: 'authorization', type: 'TypeGrantAuthorization' },
+        { name: 'expiration', type: 'string' },
+      ],
+      TypeGrantAuthorization: [
+        { name: 'type', type: 'string' },
+        { name: 'value', type: 'TypeGrantAuthorizationValue' },
+      ],
+      TypeGrantAuthorizationValue: [
+        { name: 'msg', type: 'string' },
+      ],
+      MsgValue: [
+        { name: 'granter', type: 'string' },
+        { name: 'grantee', type: 'string' },
+        { name: 'grant', type: 'TypeGrant' }
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeShort,
+      value: snakecaseKeys({
+        ...protoParamsAmino,
+        grant: {
+          ...protoParamsAmino.grant,
+          expiration: protoParamsAmino.grant.expiration.toJSON().split('.')[0] +  "Z"
+        }
+      }),
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/authz/msgs/MsgGrant.ts
+++ b/packages/sdk-ts/src/core/modules/authz/msgs/MsgGrant.ts
@@ -83,8 +83,8 @@ export default class MsgGrant extends MsgBase<
       grant: {
         ...message.grant,
         authorization: {
-          msg: params.messageType,
-          '@type': genericAuthorizationType,
+          'type': 'cosmos-sdk/GenericAuthorization',
+          value: { msg: params.messageType },
         },
         expiration: timestamp.toDate(),
       },

--- a/packages/sdk-ts/src/core/modules/tx/eip712/maps.ts
+++ b/packages/sdk-ts/src/core/modules/tx/eip712/maps.ts
@@ -24,7 +24,7 @@ export const objectKeysToEip712Types = ({
   for (const property in snakecaseKeys(object)) {
     const propertyValue = snakecaseKeys(object)[property]
 
-    if (property === '@type' || property === 'type') {
+    if (property === '@type') {
       continue
     }
 
@@ -91,6 +91,8 @@ export const objectKeysToEip712Types = ({
             new Error('Array with elements of unknown type found'),
           )
         }
+      } else if (propertyValue instanceof Date) {
+        types.push({ name: property, type: 'string' })
       } else {
         const propertyType = getObjectEip712PropertyType({
           property: snakeToPascal(property),
@@ -221,6 +223,12 @@ export const mapValuesToProperValueType = <T extends Record<string, unknown>>(
     }
 
     if (typeof value === 'object') {
+      if (value instanceof Date) {
+        return {
+          ...result,
+          [key]: value.toJSON().split('.')[0] +  "Z",
+        }
+      }
       if (Array.isArray(value)) {
         return {
           ...result,

--- a/packages/sdk-ts/src/core/modules/tx/eip712/utils.ts
+++ b/packages/sdk-ts/src/core/modules/tx/eip712/utils.ts
@@ -76,9 +76,9 @@ export const getEip712Fee = (
 
   return {
     fee: {
+      feePayer: feePayer,
       gas,
       amount,
-      feePayer: feePayer,
     },
   }
 }
@@ -98,7 +98,7 @@ export const getTypesIncludingFeePayer = ({
     return types
   }
 
-  types.types['Fee'].push({ name: 'feePayer', type: 'string' })
+  types.types['Fee'].unshift({ name: 'feePayer', type: 'string' })
 
   return types
 }


### PR DESCRIPTION
Hello,

These changes have been made to fix the MsgGrant message
https://github.com/InjectiveLabs/injective-ts/blob/master/packages/sdk-ts/src/core/modules/authz/msgs/MsgGrant.ts


I'm not sure about this change. Maybe this condition has been added for different messages. Do you know?
```
-   if (property === '@type' || property === 'type') {
+    if (property === '@type') {
```


Also, I have fixed feepayer for transaction of type eip 712 