### PR TITLE
Add signer pubkey type

### DIFF
--- a/packages/sdk-ts/src/core/modules/tx/types/tx.ts
+++ b/packages/sdk-ts/src/core/modules/tx/types/tx.ts
@@ -1,3 +1,4 @@
+import { Any } from 'google-protobuf/google/protobuf/any_pb'
 import { BroadcastModeMap } from '@injectivelabs/chain-api/cosmos/tx/v1beta1/service_pb'
 import {
   SignDoc,
@@ -60,7 +61,7 @@ export type MsgArg = {
 }
 
 export interface SignerDetails {
-  pubKey: string // the pubKey of the signer of the transaction in base64
+  pubKey: string | Any // the pubKey of the signer of the transaction in base64 or protobuf Any
   sequence: number // the sequence (nonce) of the signer of the transaction
   accountNumber: number // the account number of the signer of the transaction
 }

--- a/packages/sdk-ts/src/core/modules/tx/utils/tx.ts
+++ b/packages/sdk-ts/src/core/modules/tx/utils/tx.ts
@@ -1,3 +1,4 @@
+import { Any } from 'google-protobuf/google/protobuf/any_pb'
 import { PubKey } from '@injectivelabs/chain-api/cosmos/crypto/secp256k1/keys_pb'
 import { PubKey as CosmosPubKey } from '@injectivelabs/chain-api/cosmos/crypto/secp256k1/keys_pb'
 import { createAny, createAnyMessage } from './helpers'
@@ -22,8 +23,12 @@ export const getPublicKey = ({
   key,
 }: {
   chainId: string
-  key: string
+  key: string | Any
 }) => {
+  if (key instanceof Any) {
+    return key
+  }
+
   let proto
   let path
 
@@ -102,7 +107,7 @@ export const createSigners = ({
   signers,
 }: {
   chainId: string
-  signers: { pubKey: string; sequence: number }[]
+  signers: { pubKey: string | Any; sequence: number }[]
   mode: SignModeMap[keyof SignModeMap]
 }) => {
   return signers.map((s) =>
@@ -122,7 +127,7 @@ export const createSignerInfo = ({
   mode,
 }: {
   chainId: string
-  publicKey: string
+  publicKey: string | Any
   sequence: number
   mode: SignModeMap[keyof SignModeMap]
 }) => {


### PR DESCRIPTION
Each chain can have several different key types.  For some case,  I use '/cosmos.crypto.secp256k1.PubKey' for Injective chain
 

I'm also considering making a new pubKeyType field - pass the Proto Any object directly to the pubKey field. What do you think about it? 