### PR TITLE
Add Method for Signing Arbitrary Messages

### DIFF
--- a/packages/exceptions/src/types/modules.ts
+++ b/packages/exceptions/src/types/modules.ts
@@ -45,6 +45,7 @@ export enum WalletErrorActionModule {
   SignEthereumTransaction = 'sign-ethereum-transaction',
   SendTransaction = 'send-transaction',
   SendEthereumTransaction = 'send-ethereum-transaction',
+  SignArbitrary = 'sign-arbitrary',
   GetAccounts = 'get-accounts',
   GetNetworkId = 'get-network-id',
   GetChainId = 'get-chain-id',

--- a/packages/wallet-ts/src/strategies/types/strategy.ts
+++ b/packages/wallet-ts/src/strategies/types/strategy.ts
@@ -145,6 +145,8 @@ export interface ConcreteWalletStrategy
    */
   signEip712TypedData(eip712TypedData: string, address: string): Promise<string>
 
+  signArbitrary(signer: string, data: string | Uint8Array): Promise<string>
+
   getEthereumChainId(): Promise<string>
 
   getEthereumTransactionReceipt(txHash: string): void

--- a/packages/wallet-ts/src/strategies/wallet-strategy/WalletStrategy.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/WalletStrategy.ts
@@ -239,6 +239,12 @@ export default class WalletStrategy {
     return this.getStrategy().signCosmosTransaction(transaction)
   }
 
+  public async signArbitrary(signer: string, data: string | Uint8Array): Promise<string | void> {
+    if (this.getStrategy().signArbitrary) {
+      return this.getStrategy().signArbitrary!(signer, data)
+    }
+  }
+
   public onAccountChange(callback: onAccountChangeCallback): void {
     if (this.getStrategy().onAccountChange) {
       return this.getStrategy().onAccountChange!(callback)

--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Cosmostation.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Cosmostation.ts
@@ -219,6 +219,30 @@ export default class Cosmostation
     )
   }
 
+  async signArbitrary(signer: string, data: string | Uint8Array): Promise<string> {
+    try {
+      const provider = await this.getProvider()
+
+      if (data instanceof Uint8Array) {
+        const decoder = new TextDecoder('utf-8')
+        data = decoder.decode(data)
+      }
+
+      const signature = await provider.signMessage(
+        INJECTIVE_CHAIN_NAME,
+        signer,
+        data as string,
+      )
+
+      return signature.signature
+    } catch (e: unknown) {
+      throw new CosmosWalletException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        context: WalletAction.SignArbitrary,
+      })
+    }
+  }
+
   async getEthereumChainId(): Promise<string> {
     throw new CosmosWalletException(
       new Error('getEthereumChainId is not supported on Cosmostation'),

--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Keplr.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Keplr.ts
@@ -163,6 +163,22 @@ export default class Keplr
     )
   }
 
+  async signArbitrary(signer: string, data: string | Uint8Array): Promise<string> {
+    try {
+      const keplrWallet = this.getKeplrWallet()
+      const keplr = await keplrWallet.getKeplrWallet()
+
+      const signature = await keplr.signArbitrary(this.chainId, signer, data)
+
+      return signature.signature
+    } catch (e: unknown) {
+      throw new CosmosWalletException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        context: WalletAction.SignArbitrary,
+      })
+    }
+  }
+
   async getEthereumChainId(): Promise<string> {
     throw new CosmosWalletException(
       new Error('getEthereumChainId is not supported on Keplr'),

--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Leap.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Leap.ts
@@ -149,6 +149,22 @@ export default class Leap
     }
   }
 
+  async signArbitrary(signer: string, data: string | Uint8Array): Promise<string> {
+    try {
+      const leapWallet = this.getLeapWallet()
+      const leap = await leapWallet.getLeapWallet()
+
+      const signature = await leap.signArbitrary(this.chainId, signer, data)
+
+      return signature.signature
+    } catch (e: unknown) {
+      throw new CosmosWalletException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        context: WalletAction.SignArbitrary,
+      })
+    }
+  }
+
   async signEip712TypedData(
     _eip712TypedData: string,
     _address: AccountAddress,

--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Metamask.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Metamask.ts
@@ -172,6 +172,25 @@ export default class Metamask
     )
   }
 
+  async signArbitrary(signer: AccountAddress, data: string | Uint8Array): Promise<string> {
+    const ethereum = this.getEthereum()
+
+    try {
+      const signature = await ethereum.request({
+        method: 'personal_sign',
+        params: [data, signer],
+      })
+
+      return signature
+    } catch (e: unknown) {
+      throw new MetamaskException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        type: ErrorType.WalletError,
+        contextModule: WalletAction.SignArbitrary,
+      })
+    }
+  }
+
   async getEthereumChainId(): Promise<string> {
     const ethereum = this.getEthereum()
 

--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Torus.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Torus.ts
@@ -201,6 +201,31 @@ export default class Torus
     }
   }
 
+  async signArbitrary(signer: AccountAddress, data: string | Uint8Array): Promise<string> {
+    await this.connect()
+
+    try {
+      const signature = await this.torus.ethereum.request<string>({
+        method: 'personal_sign',
+        params: [data, signer],
+      })
+
+      if (!signature) {
+        throw new WalletException(
+          new Error('No signature returned'),
+        )
+      }
+
+      return signature
+    } catch (e: unknown) {
+      throw new WalletException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        type: ErrorType.WalletError,
+        contextModule: WalletAction.SignArbitrary,
+      })
+    }
+  }
+
   // eslint-disable-next-line class-methods-use-this
   async signCosmosTransaction(_transaction: {
     txRaw: TxRaw


### PR DESCRIPTION
This pull request introduces a new feature to the Injective TS SDK, enabling the signing of arbitrary messages. The addition of this method expands the functionality of the wallet strategy.

**Key Changes:**

New Method: **signArbitrary** - This pull request adds a new method to the Injective TS SDK. This method enables the signing of arbitrary messages using crypto wallets.