### PR TITLE
chore: fetchAtomicSwapHistory added to sdk-ts

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -42,7 +42,7 @@
     "@injectivelabs/grpc-web": "^0.0.1",
     "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
     "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-    "@injectivelabs/indexer-proto-ts": "1.10.8-rc.4",
+    "@injectivelabs/indexer-proto-ts": "1.11.2",
     "@injectivelabs/mito-proto-ts": "1.0.23",
     "@injectivelabs/networks": "^1.12.0-beta.10",
     "@injectivelabs/test-utils": "^1.12.0-beta.1",

--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.spec.ts
@@ -234,4 +234,38 @@ describe('IndexerGrpcSpotApi', () => {
       )
     }
   })
+
+  /**
+   * Resurrect this test once fetchAtomicSwapHistory hits mainnet
+   * Since this test suite is pointed at mainnet
+   */
+  // test('fetchAtomicSwapHistory', async () => {
+  //   try {
+  //     const response = await indexerGrpcSpotApi.fetchAtomicSwapHistory({
+  //       address: injectiveAddress,
+  //       contractAddress: swapContractAddress,
+  //       pagination: {
+  //         fromNumber: 1,
+  //         toNumber: 11,
+  //       },
+  //     })
+  //     console.log({ response })
+  //     if (response.swapHistory.length === 0) {
+  //       console.warn('fetchAtomicSwapHistory.swapHistoryIsEmptyArray')
+  //     }
+
+  //     expect(response).toBeDefined()
+  //     expect(response).toEqual(
+  //       expect.objectContaining<
+  //         ReturnType<
+  //           typeof IndexerGrpcSpotTransformer.grpcAtomicSwapHistoryListToAtomicSwapHistoryList
+  //         >
+  //       >(response),
+  //     )
+  //   } catch (e) {
+  //     console.error(
+  //       'IndexerGrpcSpotApi.fetchAtomicSwapHistory => ' + (e as any).message,
+  //     )
+  //   }
+  // })
 })

--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.ts
@@ -569,4 +569,59 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
       })
     }
   }
+
+  async fetchAtomicSwapHistory(params: {
+    address: string
+    contractAddress: string
+    pagination?: PaginationOption
+  }) {
+    const { address, contractAddress, pagination } = params || {}
+    const request = InjectiveSpotExchangeRpc.AtomicSwapHistoryRequest.create()
+
+    request.address = address
+    request.contractAddress = contractAddress
+
+    if (pagination) {
+      if (pagination.fromNumber !== undefined) {
+        request.fromNumber = pagination.fromNumber
+      }
+
+      if (pagination.toNumber !== undefined) {
+        request.toNumber = pagination.toNumber
+      }
+
+      if (pagination.skip !== undefined) {
+        request.skip = pagination.skip
+      }
+
+      if (pagination.limit !== undefined) {
+        request.limit = pagination.limit
+      }
+    }
+
+    try {
+      const response =
+        await this.retry<InjectiveSpotExchangeRpc.AtomicSwapHistoryResponse>(
+          () => this.client.AtomicSwapHistory(request),
+        )
+
+      return IndexerGrpcSpotTransformer.grpcAtomicSwapHistoryListToAtomicSwapHistoryList(
+        response,
+      )
+    } catch (e: unknown) {
+      if (e instanceof InjectiveSpotExchangeRpc.GrpcWebError) {
+        throw new GrpcUnaryRequestException(new Error(e.toString()), {
+          code: e.code,
+          context: 'AtomicSwapHistory',
+          contextModule: this.module,
+        })
+      }
+
+      throw new GrpcUnaryRequestException(e as Error, {
+        code: UnspecifiedErrorCode,
+        context: 'AtomicSwapHistory',
+        contextModule: this.module,
+      })
+    }
+  }
 }

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcSpotTransformer.ts
@@ -7,6 +7,7 @@ import {
 } from '@injectivelabs/ts-types'
 import { BigNumber } from '@injectivelabs/utils'
 import {
+  AtomicSwap,
   SpotTrade,
   SpotMarket,
   GrpcSpotTrade,
@@ -15,6 +16,7 @@ import {
   GrpcSpotMarketInfo,
   GrpcSpotLimitOrder,
   GrpcSpotOrderHistory,
+  GrpcAtomicSwap,
 } from '../types/spot'
 import {
   Orderbook,
@@ -298,5 +300,36 @@ export class IndexerGrpcSpotTransformer {
     return trades.map((trade) =>
       IndexerGrpcSpotTransformer.grpcTradeToTrade(trade),
     )
+  }
+
+  static grpcAtomicSwapHistoryListToAtomicSwapHistoryList(
+    response: InjectiveSpotExchangeRpc.AtomicSwapHistoryResponse,
+  ) {
+    const swapHistory = response.data
+    const pagination = response.paging
+
+    return {
+      swapHistory: swapHistory.map(
+        IndexerGrpcSpotTransformer.grpcAtomicSwapHistoryToAtomicSwapHistory,
+      ),
+      pagination: grpcPagingToPaging(pagination),
+    }
+  }
+
+  static grpcAtomicSwapHistoryToAtomicSwapHistory(
+    swapHistory: GrpcAtomicSwap,
+  ): AtomicSwap {
+    return {
+      sender: swapHistory.sender,
+      route: swapHistory.route,
+      sourceCoin: swapHistory.sourceCoin,
+      destinationCoin: swapHistory.destCoin,
+      fees: swapHistory.fees,
+      contractAddress: swapHistory.contractAddress,
+      indexBySender: swapHistory.indexBySender,
+      indexBySenderContract: swapHistory.indexBySenderContract,
+      txHash: swapHistory.txHash,
+      executedAt: parseInt(swapHistory.executedAt, 10),
+    }
   }
 }

--- a/packages/sdk-ts/src/client/indexer/types/spot.ts
+++ b/packages/sdk-ts/src/client/indexer/types/spot.ts
@@ -9,6 +9,7 @@ import { GrpcOrderType } from '../../chain/types/exchange'
 import { PriceLevel } from './exchange'
 import { TokenMeta } from '@injectivelabs/token-metadata'
 import { InjectiveSpotExchangeRpc } from '@injectivelabs/indexer-proto-ts'
+import { Coin } from '@injectivelabs//ts-types'
 
 export interface SpotMarket {
   marketId: string
@@ -88,7 +89,21 @@ export interface BatchSpotOrderCancelParams {
   marketId: string
 }
 
+export interface AtomicSwap {
+  sender: string
+  route: string
+  sourceCoin: Coin | undefined
+  destinationCoin: Coin | undefined
+  fees: Coin[]
+  contractAddress: string
+  indexBySender: number
+  indexBySenderContract: number
+  txHash: string
+  executedAt: number
+}
+
 export type GrpcSpotTrade = InjectiveSpotExchangeRpc.SpotTrade
 export type GrpcSpotMarketInfo = InjectiveSpotExchangeRpc.SpotMarketInfo
 export type GrpcSpotLimitOrder = InjectiveSpotExchangeRpc.SpotLimitOrder
 export type GrpcSpotOrderHistory = InjectiveSpotExchangeRpc.SpotOrderHistory
+export type GrpcAtomicSwap = InjectiveSpotExchangeRpc.AtomicSwap

--- a/packages/sdk-ts/src/types/pagination.ts
+++ b/packages/sdk-ts/src/types/pagination.ts
@@ -4,8 +4,10 @@ export interface PaginationOption {
   skip?: number
   limit?: number
   reverse?: boolean
-  countTotal?: boolean,
+  countTotal?: boolean
   endTime?: number
+  fromNumber?: number
+  toNumber?: number
 }
 
 export interface PagePagination {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2156,10 +2156,10 @@
   dependencies:
     browser-headers "^0.4.1"
 
-"@injectivelabs/indexer-proto-ts@1.10.8-rc.4":
-  version "1.10.8-rc.4"
-  resolved "https://registry.yarnpkg.com/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.10.8-rc.4.tgz#ab8424cd713bb5a69ab130b64bf0b3f9f9089946"
-  integrity sha512-IwbepTfsHHAv3Z36As6yH/+HIplOEpUu6SFHBCVgdSIaQ8GuvTib4HETiVnV4mjYqoyVgWs+zLSAfih46rdMJQ==
+"@injectivelabs/indexer-proto-ts@1.11.2":
+  version "1.11.2"
+  resolved "https://registry.yarnpkg.com/@injectivelabs/indexer-proto-ts/-/indexer-proto-ts-1.11.2.tgz#a96819c7aeaf2875c02eec25c86b5955f8526cef"
+  integrity sha512-udQjAntxs7mceBdTQoXPoIlGD9dzYFALWLs+VPTPwgZL+SlInsfdfFjcL8A0aBlCmecmspSL3+oCMePBeDkvrw==
   dependencies:
     "@injectivelabs/grpc-web" "^0.0.1"
     google-protobuf "^3.14.0"


### PR DESCRIPTION
## Changes
- added `fetchAtomicSwapHistory` method to `IndexerGrpcSpotApi`