### PR TITLE
fix: ledger sign arbitrary

### DIFF
--- a/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Ledger/Base.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/strategies/Ledger/Base.ts
@@ -232,7 +232,7 @@ export default class LedgerBase
       const ledger = await this.ledger.getInstance()
       const result = await ledger.signPersonalMessage(
         derivationPath,
-        bufferToHex(Buffer.from(toUtf8(data), 'utf8')),
+        Buffer.from(toUtf8(data), 'utf8').toString('hex'),
       )
 
       const combined = `${result.r}${result.s}${result.v.toString(16)}`


### PR DESCRIPTION
## Changes
- ledger's `signPersonalMessage` param should be in hex format but not be `0x` prefixed. current implementation results in an error upon signing