### PR TITLE
chore: tokenMetaUtils extended

### DIFF
--- a/packages/token-metadata/src/ExtendedTokenMetaUtils.ts
+++ b/packages/token-metadata/src/ExtendedTokenMetaUtils.ts
@@ -1,0 +1,27 @@
+import { TokenMetaUtils } from './TokenMetaUtils'
+import { TokenMeta } from './types'
+import {
+  getMappedTokensByErc20Address,
+  getMappedTokensByCw20Address,
+} from './tokens/mappings/mapByAddress'
+import { getMappedTokensByName } from './tokens/mappings/mapByName'
+import { getMappedTokensByHash } from './tokens/mappings/mapByHash'
+
+export class ExtendedTokenMetaUtils extends TokenMetaUtils {
+  constructor(tokens: Record<string, TokenMeta>) {
+    super(tokens)
+
+    this.tokens = this.correctedMappedTokensBySymbol(tokens, this.tokens)
+    this.tokensByErc20Address = getMappedTokensByErc20Address(this.tokens)
+    this.tokensByCw20Address = getMappedTokensByCw20Address(this.tokens)
+    this.tokensByHash = getMappedTokensByHash(this.tokens)
+    this.tokensByName = getMappedTokensByName(this.tokens)
+  }
+
+  correctedMappedTokensBySymbol(
+    originalTokens: Record<string, TokenMeta>,
+    tokens: Record<string, TokenMeta>,
+  ): Record<string, TokenMeta> {
+    return { ...tokens, ...originalTokens }
+  }
+}

--- a/packages/token-metadata/src/TokenFactory.ts
+++ b/packages/token-metadata/src/TokenFactory.ts
@@ -2,7 +2,8 @@ import { Network, isTestnet } from '@injectivelabs/networks'
 import { GeneralException } from '@injectivelabs/exceptions'
 import { INJ_DENOM } from '@injectivelabs/utils'
 import { TokenInfo } from './TokenInfo'
-import { TokenMetaUtils } from './TokenMetaUtils'
+import { ExtendedTokenMetaUtils } from './ExtendedTokenMetaUtils'
+
 import {
   getTokensBySymbolForDevnet,
   getTokensBySymbolForDevnet1,
@@ -14,30 +15,38 @@ import tokensBySymbol from './tokens/tokens'
 import { getTokenFromMeta } from './utils'
 
 export class TokenFactory {
-  public tokenMetaUtils: TokenMetaUtils
+  public tokenMetaUtils: ExtendedTokenMetaUtils
 
-  constructor(tokenMetaUtils: TokenMetaUtils) {
+  constructor(tokenMetaUtils: ExtendedTokenMetaUtils) {
     this.tokenMetaUtils = tokenMetaUtils
   }
 
   static make(network: Network = Network.Mainnet): TokenFactory {
     if (isTestnet(network)) {
-      return new TokenFactory(new TokenMetaUtils(getTokensBySymbolForTestnet()))
+      return new TokenFactory(
+        new ExtendedTokenMetaUtils(getTokensBySymbolForTestnet()),
+      )
     }
 
     if (network === Network.Devnet) {
-      return new TokenFactory(new TokenMetaUtils(getTokensBySymbolForDevnet()))
+      return new TokenFactory(
+        new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet()),
+      )
     }
 
     if (network === Network.Devnet1) {
-      return new TokenFactory(new TokenMetaUtils(getTokensBySymbolForDevnet1()))
+      return new TokenFactory(
+        new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet1()),
+      )
     }
 
     if (network === Network.Devnet2) {
-      return new TokenFactory(new TokenMetaUtils(getTokensBySymbolForDevnet2()))
+      return new TokenFactory(
+        new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet2()),
+      )
     }
 
-    return new TokenFactory(new TokenMetaUtils(tokensBySymbol))
+    return new TokenFactory(new ExtendedTokenMetaUtils(tokensBySymbol))
   }
 
   toToken(denom: string): Token | undefined {

--- a/packages/token-metadata/src/TokenMetaUtilsFactory.ts
+++ b/packages/token-metadata/src/TokenMetaUtilsFactory.ts
@@ -1,5 +1,5 @@
 import { Network, isTestnet } from '@injectivelabs/networks'
-import { TokenMetaUtils } from './TokenMetaUtils'
+import { ExtendedTokenMetaUtils } from './ExtendedTokenMetaUtils'
 import {
   getTokensBySymbolForDevnet,
   getTokensBySymbolForDevnet1,
@@ -9,23 +9,23 @@ import {
 import tokensBySymbol from './tokens/tokens'
 
 export class TokenMetaUtilsFactory {
-  static make(network: Network = Network.Mainnet): TokenMetaUtils {
+  static make(network: Network = Network.Mainnet): ExtendedTokenMetaUtils {
     if (isTestnet(network)) {
-      return new TokenMetaUtils(getTokensBySymbolForTestnet())
+      return new ExtendedTokenMetaUtils(getTokensBySymbolForTestnet())
     }
 
     if (network === Network.Devnet) {
-      return new TokenMetaUtils(getTokensBySymbolForDevnet())
+      return new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet())
     }
 
     if (network === Network.Devnet1) {
-      return new TokenMetaUtils(getTokensBySymbolForDevnet1())
+      return new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet1())
     }
 
     if (network === Network.Devnet2) {
-      return new TokenMetaUtils(getTokensBySymbolForDevnet2())
+      return new ExtendedTokenMetaUtils(getTokensBySymbolForDevnet2())
     }
 
-    return new TokenMetaUtils(tokensBySymbol)
+    return new ExtendedTokenMetaUtils(tokensBySymbol)
   }
 }

--- a/packages/token-metadata/src/index.ts
+++ b/packages/token-metadata/src/index.ts
@@ -1,5 +1,6 @@
 import { TokenFactory } from './TokenFactory'
 import { TokenMetaUtils } from './TokenMetaUtils'
+import { ExtendedTokenMetaUtils } from './ExtendedTokenMetaUtils'
 import { TokenMetaUtilsFactory } from './TokenMetaUtilsFactory'
 import { TokenInfo } from './TokenInfo'
 
@@ -10,4 +11,10 @@ export * from './utils'
 export const tokenMetaUtils = TokenMetaUtilsFactory.make()
 export const tokenFactory = TokenFactory.make()
 
-export { TokenMetaUtils, TokenInfo, TokenFactory, TokenMetaUtilsFactory }
+export {
+  TokenMetaUtils,
+  ExtendedTokenMetaUtils,
+  TokenInfo,
+  TokenFactory,
+  TokenMetaUtilsFactory,
+}


### PR DESCRIPTION
## Changes
- This PR attempts to resolve collision scenarios, as described in [notion](https://www.notion.so/injective/Token-Metadata-Collisions-d39de15c08404e4386c5286eb1d250e8?pvs=4). Another potential fix is documented there, and I'm sure others are possible. Just wanted to showcase this solution as a possibility.

We could also do something like a `TokenMetaUtilsFactory` where we pass a value in a value to decide whether to instantiate the `ExtendedTokenMetaUtils` class or `TokenMetaUtils` class.

## Testing Complete
- linked up to the explorer and checked that the assets list looks as expected