### PR TITLE
chore: msgExternalTransfer examples

### DIFF
--- a/.gitbook/core-modules/auction.md
+++ b/.gitbook/core-modules/auction.md
@@ -23,7 +23,7 @@ const auctionApi = new ChainGrpcAuctionApi(endpointsForNetwork.grpc);
 const injectiveAddress = "inj1...";
 /* format amount for bid, note that bid amount has to be higher than the current highest bid */
 const amount = {
-  denom: INJ,
+  denom: INJ_DENOM,
   amount: new BigNumberInBase(1).toWei(),
 };
 
@@ -38,20 +38,83 @@ const latestRound = uiLatestAuctionModuleState.auctionRound;
 const msg = MsgBid.fromJSON({
   amount,
   injectiveAddress,
-  round: latestRound,
+  round: latestRound
 });
 
 const privateKey = "0x...";
 
 /* broadcast transaction */
 const txHash = await new MsgBroadcasterWithPk({
-  privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+network: Network.Mainnet,
+privateKey,
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
-});
+msgs: msg
+})
+
 
 console.log(txHash);
+```
+
+### Burn Auction Deposit via MsgExternalTransfer
+
+If you would like to grow the burn auction's pool size, you can directly send funds to the Auction subaccount.
+
+Notes:
+  -  You will need to send funds to the pool's subaccount `0x1111111111111111111111111111111111111111111111111111111111111111`.
+  -  Be aware that any funds you send will be reflected in the next auction, not the current one.
+  - You cannot transfer from your default subaccountId since that balance is now associated with your Injective address in the bank module. Therefore, in order for `MsgExternalTransfer` to work, you will need to transfer from a non-default subaccountId.
+
+ How to find the subaccountId that you will be transferring from:
+   - you can query your existing subaccountIds via the [account portfolio api](../querying/querying-api/querying-indexer-portfolio.md).
+
+How to use funds that are currently associated with your Injective Address in bank module:
+   - If you have existing non-default subaccounts, you'll want to do a [MsgDeposit](./exchange.md#MsgDeposit) to one of your existing non-default subaccountIds and use that subaccountId as the `srcSubaccountId` below.
+  - If you don't have existing non-default subaccounts, you can do a [MsgDeposit](./exchange.md#MsgDeposit) to a new default subaccountId, which would be done via importing `getSubaccountId` from `sdk-ts` and setting the `subaccountId` field in [MsgDeposit](./exchange.md#MsgDeposit) to `getSubaccountId(injectiveAddress, 1)`.
+
+For more info, check out the [burn auction pool docs](https://docs.injective.network/develop/tech-concepts/auction_pool/).
+
+```ts
+import {
+  DenomClient,
+  MsgExternalTransfer,
+  MsgBroadcasterWithPk,
+} from '@injectivelabs/sdk-ts'
+import { BigNumberInBase } from '@injectivelabs/utils'
+import {  Network } from '@injectivelabs/networks'
+
+const denomClient = new DenomClient(Network.Mainnet);
+
+const injectiveAddress = 'inj1...'
+const srcSubaccountId = '0x...'
+const POOL_SUBACCOUNT_ID = `0x1111111111111111111111111111111111111111111111111111111111111111`
+const USDT_TOKEN_SYMBOL='USDT'
+const tokenMeta = denomClient.getTokenMetaDataBySymbol(USDT_TOKEN_SYMBOL);
+const tokenDenom = `peggy${tokenMeta.erc20.address}`;
+
+/* format amount to add to the burn auction pool */
+const amount = {
+  denom: tokenDenom,
+  amount: new BigNumberInBase(1).toWei(tokenMeta.decimals).toFixed()
+}
+
+/* create message in proto format */
+const msg = MsgExternalTransfer.fromJSON({
+  amount,
+  srcSubaccountId,
+  injectiveAddress,
+  dstSubaccountId: POOL_SUBACCOUNT_ID
+})
+
+const privateKey = '0x...'
+
+/* broadcast transaction */
+const txHash = await new MsgBroadcasterWithPk({
+network: Network.Mainnet,
+privateKey
+}).broadcast({
+msgs: msg
+})
+
+
+console.log(txHash)
 ```

--- a/.gitbook/core-modules/authz.md
+++ b/.gitbook/core-modules/authz.md
@@ -31,7 +31,7 @@ Per [cosmos sdk docs](https://docs.cosmos.network/main/modules/authz), "Authoriz
 
 ```ts
 import { MsgGrant, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKeyOfGranter = '0x...'
 const grantee = 'inj...'
@@ -46,11 +46,9 @@ const msg = MsgGrant.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey: privateKeyOfGranter,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress: granter,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -63,7 +61,7 @@ When a grantee wants to execute a transaction on behalf of a granter, they must 
 ```ts
 import { MsgExec, MsgSend, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKeyOfGrantee = '0x...'
 const grantee = 'inj...'
@@ -85,11 +83,9 @@ const msg = MsgExec.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey: privateKeyOfGrantee,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress: grantee,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -101,7 +97,7 @@ A grant can be removed with the MsgRevoke message.
 
 ```ts
 import { MsgRevoke, MsgBroadcasterWithPk, getEthereumAddress } from '@injectivelabs/sdk-ts'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKeyOfGranter = '0x...'
 const grantee = 'inj...'
@@ -116,11 +112,9 @@ const msg = MsgRevoke.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey: privateKeyOfGranter,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress: granter,
+  msgs: msg
 })
 
 console.log(txHash)

--- a/.gitbook/core-modules/bank.md
+++ b/.gitbook/core-modules/bank.md
@@ -15,8 +15,7 @@ This Message is used to send coins from one address to another.
 ```ts
 import { MsgSend, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase } from '@injectivelabs/utils'
-import { ChainId } from '@injectivelabs/ts-types'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -27,16 +26,14 @@ const amount = {
 const msg = MsgSend.fromJSON({
   amount,
   srcInjectiveAddress: injectiveAddress,
-  dstInjectiveAddress: injectiveAddress,
+  dstInjectiveAddress: injectiveAddress
 });
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)

--- a/.gitbook/core-modules/distribution.md
+++ b/.gitbook/core-modules/distribution.md
@@ -13,10 +13,7 @@ import {
   MsgBroadcasterWithPk,
   MsgWithdrawDelegatorReward,
 } from "@injectivelabs/sdk-ts";
-import { ChainId } from "@injectivelabs/ts-types";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-
-const endpointsForNetwork = getNetworkEndpoints(Network.Mainnet);
+import {  Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const validatorAddress = "inj1...";
@@ -32,11 +29,9 @@ const privateKey = "0x...";
 /* broadcast transaction */
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -51,10 +46,7 @@ import {
   MsgBroadcasterWithPk,
   MsgWithdrawValidatorCommission,
 } from "@injectivelabs/sdk-ts";
-import { ChainId } from "@injectivelabs/ts-types";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-
-const endpointsForNetwork = getNetworkEndpoints(Network.Mainnet);
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const validatorAddress = "inj1...";
@@ -69,11 +61,9 @@ const privateKey = "0x...";
 /* broadcast transaction */
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);

--- a/.gitbook/core-modules/exchange.md
+++ b/.gitbook/core-modules/exchange.md
@@ -15,7 +15,7 @@ This Message is used to send coins from the Bank module to a wallet's subaccount
 ```ts
 import { MsgDeposit, MsgBroadcasterWithPk, getEthereumAddress } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -33,16 +33,14 @@ const subaccountId = ethereumAddress + suffix
 const msg = MsgDeposit.fromJSON({
   amount,
   subaccountId,
-  injectiveAddress,
+  injectiveAddress
 });
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -55,7 +53,7 @@ This Message is used to send coins from the wallet's subaccount back to the user
 ```ts
 import { MsgWithdraw, MsgBroadcasterWithPk, getEthereumAddress } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -73,16 +71,14 @@ const subaccountId = ethereumAddress + suffix
 const msg = MsgWithdraw.fromJSON({
   amount,
   subaccountId,
-  injectiveAddress,
+  injectiveAddress
 });
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -100,7 +96,7 @@ import {
   getDerivativeMarketTensMultiplier
 } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase, spotPriceToChainPriceToFixed, spotQuantityToChainQuantityToFixed } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -141,16 +137,14 @@ const msg = MsgCreateSpotLimitOrder.fromJSON({
     baseDecimals: market.baseDecimals
   }),
   marketId: market.marketId,
-  feeRecipient: feeRecipient,
+  feeRecipient: feeRecipient
 })
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -168,7 +162,7 @@ import {
   getDerivativeMarketTensMultiplier
 } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase, spotPriceToChainPriceToFixed, spotQuantityToChainQuantityToFixed } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -213,11 +207,9 @@ const msg = MsgCreateSpotMarketOrder.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -240,7 +232,7 @@ import {
   derivativeQuantityToChainQuantityToFixed,
   derivativeMarginToChainMarginToFixed
 } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -285,11 +277,9 @@ const msg = MsgCreateDerivativeLimitOrder.fromJSON(
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -312,7 +302,7 @@ import {
   derivativeQuantityToChainQuantityToFixed,
   derivativeMarginToChainMarginToFixed
 } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -362,11 +352,9 @@ const msg = MsgCreateDerivativeMarketOrder.fromJSON(
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -389,7 +377,7 @@ import {
   derivativeQuantityToChainQuantityToFixed,
   derivativeMarginToChainMarginToFixed
 } from '@injectivelabs/utils'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -469,11 +457,9 @@ const msg = MsgBatchUpdateOrders.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)
@@ -485,7 +471,7 @@ This Message is used to batch cancel spot orders on the chain
 
 ```ts
 import { MsgBatchCancelSpotOrders, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -517,11 +503,9 @@ const messages = orders.map((order) =>
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: messages,
-  injectiveAddress,
+  msgs: messages
 })
 
 console.log(txHash)
@@ -533,7 +517,7 @@ This Message is used to batch cancel spot orders on the chain
 
 ```ts
 import { MsgBatchCancelDerivativeOrders, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -565,11 +549,9 @@ const messages = orders.map((order) =>
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: messages,
-  injectiveAddress,
+  msgs: messages
 })
 
 console.log(txHash)
@@ -584,7 +566,7 @@ import {
   MsgRewardsOptOut,
   MsgBroadcasterWithPk,
 } from '@injectivelabs/sdk-ts'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj...'
@@ -594,11 +576,68 @@ const msg = MsgRewardsOptOut.fromJSON(
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  network: Network.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet)
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
+  msgs: msg
+})
+
+console.log(txHash)
+```
+
+### MsgExternalTransfer
+
+This message is used to transfer balance from one subaccount to another subaccount.
+
+Note:
+- You cannot transfer from your default subaccountId since that balance is now associated with your Injective address in the bank module. Therefore, in order for `MsgExternalTransfer` to work, you will need to transfer from a non-default subaccountId.
+
+How to find the subaccountId that you will be transferring from:
+- you can query your existing subaccountIds via the [account portfolio api](../querying/querying-api/querying-indexer-portfolio.md).
+
+How to use funds that are currently associated with your Injective Address in bank module:
+- If you have existing non-default subaccounts, you'll want to do a [MsgDeposit](./exchange.md#MsgDeposit) to one of your existing non-default subaccountIds and use that subaccountId as the `srcSubaccountId` below.
+- If you don't have existing non-default subaccounts, you can do a [MsgDeposit](./exchange.md#MsgDeposit) to a new default subaccountId, which would be done via importing `getSubaccountId` from `sdk-ts` and setting the `subaccountId` field in [MsgDeposit](./exchange.md#MsgDeposit) to `getSubaccountId(injectiveAddress, 1)`.
+
+```ts
+import {
+  DenomClient,
+  MsgExternalTransfer,
+  MsgBroadcasterWithPk,
+} from '@injectivelabs/sdk-ts'
+import { BigNumberInBase } from '@injectivelabs/utils'
+import { Network } from '@injectivelabs/networks'
+
+const denomClient = new DenomClient(Network.Testnet)
+
+const injectiveAddress = 'inj...'
+const srcSubaccountId = '0x...'
+const dstSubaccountId = `0x...`
+const INJ_TOKEN_SYMBOL = 'INJ'
+const tokenMeta = denomClient.getTokenMetaDataBySymbol(INJ_TOKEN_SYMBOL)
+const tokenDenom = `inj`
+
+/* format amount to add to the burn auction pool */
+const amount = {
+  denom: tokenDenom,
+  amount: new BigNumberInBase(1).toWei(tokenMeta.decimals).toFixed(),
+}
+
+/* create message in proto format */
+const msg = MsgExternalTransfer.fromJSON({
+  amount,
+  dstSubaccountId,
+  srcSubaccountId,
   injectiveAddress,
+})
+
+const privateKey = '0x...'
+
+/* broadcast transaction */
+const txHash = await new MsgBroadcasterWithPk({
+  network: Network.Testnet,
+  privateKey,
+}).broadcast({
+  msgs: msg
 })
 
 console.log(txHash)

--- a/.gitbook/core-modules/governance.md
+++ b/.gitbook/core-modules/governance.md
@@ -18,8 +18,7 @@ import {
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
+import { Network } from "@injectivelabs/networks";
 
 const INJ_DENOM = 'inj'
 const amount = new BigNumberInBase(1).toWei().toFixed()
@@ -39,11 +38,9 @@ const message = MsgGovDeposit.fromJSON({
 /* broadcast transaction */
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress,
+  msgs: message
 });
 ```
 
@@ -56,8 +53,7 @@ import {
   MsgVote,
   MsgBroadcasterWithPk
 } from "@injectivelabs/sdk-ts";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
+import { Network } from "@injectivelabs/networks";
 import { VoteOption } from '@injectivelabs/sdk-ts';
 
 const injectiveAddress = "inj...";
@@ -73,11 +69,9 @@ const message = MsgVote.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress,
+  msgs: message
 });
 ```
 
@@ -90,8 +84,7 @@ import {
   MsgSubmitTextProposal,
   MsgBroadcasterWithPk
 } from "@injectivelabs/sdk-ts";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
+import { Network } from "@injectivelabs/networks";
 import { BigNumberInBase } from "@injectivelabs/utils";
 
 const injectiveAddress = "inj...";
@@ -111,11 +104,9 @@ const message = MsgSubmitTextProposal.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress,
+  msgs: message
 });
 ```
 
@@ -125,13 +116,12 @@ This message allows you to propose a new spot market. Ensure that the ticker is 
 
 ```ts
 import {
-  DenomClient,
+  DenomClientAsync,
   MsgBroadcasterWithPk,
   MsgSubmitProposalSpotMarketLaunch
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase, BigNumberInWei } from "@injectivelabs/utils";
 import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
 
 const injectiveAddress = "inj...";
 const privateKey = "0x...";
@@ -150,7 +140,8 @@ const market = {
   minQuantityTickSize: '0.001'
 }
 
-const denomClient = new DenomClient(
+const denomClient = new DenomClientAsync
+(
   NETWORK.Testnet,
   { endpoints: getNetworkEndpoints(Network.Testnet) }
 )
@@ -191,11 +182,9 @@ const message = MsgSubmitProposalSpotMarketLaunch.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress
+  msgs: message
 });
 ```
 
@@ -205,13 +194,12 @@ This message allows you to propose a new perpetual market. perpetual futures con
 
 ```ts
 import {
-  DenomClient,
+  DenomClientAsync,
   MsgBroadcasterWithPk,
   MsgSubmitProposalPerpetualMarketLaunch
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
 import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
 
 const injectiveAddress = "inj...";
 const privateKey = "0x...";
@@ -235,7 +223,7 @@ const market = {
   minQuantityTickSize: '0.01'
 }
 
-const denomClient = new DenomClient(
+const denomClient = new DenomClientAsync(
   NETWORK.Testnet,
   { endpoints: getNetworkEndpoints(Network.Testnet) }
 )
@@ -266,11 +254,9 @@ const message = MsgSubmitProposalPerpetualMarketLaunch.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress
+  msgs: message
 });
 ```
 
@@ -280,13 +266,12 @@ An expiry futures contract is an agreement between two counterparties to buy and
 
 ```ts
 import {
-  DenomClient,
+  DenomClientAsync,
   MsgBroadcasterWithPk,
   MsgSubmitProposalExpiryFuturesMarketLaunch
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
 import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
 
 const injectiveAddress = "inj...";
 const privateKey = "0x...";
@@ -311,7 +296,7 @@ const market = {
   minQuantityTickSize: '0.01'
 }
 
-const denomClient = new DenomClient(
+const denomClient = new DenomClientAsync(
   NETWORK.Testnet,
   { endpoints: getNetworkEndpoints(Network.Testnet) }
 )
@@ -342,11 +327,9 @@ const message = MsgSubmitProposalExpiryFuturesMarketLaunch.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress
+  msgs: message
 });
 ```
 
@@ -360,8 +343,7 @@ import {
   MsgSubmitProposalSpotMarketParamUpdate
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
-import { ChainId } from "@injectivelabs/ts-types";
+import {  Network } from "@injectivelabs/networks";
 import { MarketStatusMap } from '@injectivelabs/chain-api';
 
 const injectiveAddress = "inj...";
@@ -392,10 +374,8 @@ const message = MsgSubmitProposalSpotMarketParamUpdate.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: message,
-  injectiveAddress
+  msgs: message
 });
 ```

--- a/.gitbook/core-modules/ibc.md
+++ b/.gitbook/core-modules/ibc.md
@@ -105,11 +105,9 @@ const privateKey = '0x...'
 /* broadcast transaction */
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)

--- a/.gitbook/core-modules/insurance.md
+++ b/.gitbook/core-modules/insurance.md
@@ -16,8 +16,7 @@ import {
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -41,11 +40,9 @@ const msg = MsgCreateInsuranceFund.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -61,8 +58,7 @@ import {
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -81,11 +77,9 @@ const msg = MsgRequestRedemption.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -98,8 +92,7 @@ This Message is used to underwrite to an insurance fund.
 ```ts
 import { MsgUnderwrite, MsgBroadcasterWithPk } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -118,11 +111,9 @@ const msg = MsgUnderwrite.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);

--- a/.gitbook/core-modules/peggy.md
+++ b/.gitbook/core-modules/peggy.md
@@ -10,7 +10,7 @@ Note that a $10 USD bridge fee will be charged for this transaction to cover for
 
 ```ts
 import {
-  DenomClient,
+  DenomClientAsync,
   MsgSendToEth,
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
@@ -27,7 +27,7 @@ const tokenService = new TokenService({
 
 const ETH_BRIDGE_FEE_IN_USD = 10;
 const endpointsForNetwork = getNetworkEndpoints(Network.Mainnet);
-const denomClient = new DenomClient(Network.Mainnet, {
+const denomClient = new DenomClientAsync(Network.Mainnet, {
   endpoints: endpointsForNetwork,
 });
 
@@ -39,13 +39,15 @@ const injectiveAddress = "inj1...";
 const destinationAddress = "0x..."; // ethereum address
 const tokenDenom = `peggy${tokenMeta.erc20.address}`;
 
-if (!tokenDenom) {
+if (!tokenMeta) {
   return;
 }
 
-const tokenUsdPrice = tokenService.fetchUsdTokenPrice(tokenDenom.coinGeckoId);
+const tokenUsdPrice = tokenService.fetchUsdTokenPrice(tokenMeta
+.coinGeckoId);
 const amountToFixed = new BigNumberInBase(amount)
-  .toWei(tokenDenom.decimals)
+  .toWei(tokenMeta
+.decimals)
   .toFixed();
 const bridgeFeeInToken = new BigNumberInBase(ETH_BRIDGE_FEE_IN_USD)
   .dividedBy(tokenUsdPrice)
@@ -66,10 +68,8 @@ const msg = MsgSendToEth.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 ```

--- a/.gitbook/core-modules/staking.md
+++ b/.gitbook/core-modules/staking.md
@@ -16,8 +16,7 @@ import {
   MsgBroadcasterWithPk
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -38,11 +37,9 @@ const msg = MsgBeginRedelegate.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -55,8 +52,7 @@ This Message is used to Delegate INJ to a validator.
 ```ts
 import { MsgDelegate, MsgBroadcasterWithPk } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -74,11 +70,9 @@ const msg = MsgDelegate.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -91,8 +85,7 @@ This Message is used to Delegate INJ to a validator.
 ```ts
 import { MsgUndelegate, MsgBroadcasterWithPk } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -110,11 +103,9 @@ const msg = MsgUndelegate.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);

--- a/.gitbook/core-modules/token-factory.md
+++ b/.gitbook/core-modules/token-factory.md
@@ -19,8 +19,7 @@ import {
   MsgCreateDenom,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -33,11 +32,9 @@ const msg = MsgCreateDenom.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -52,8 +49,7 @@ import {
   MsgMint,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -70,11 +66,9 @@ const msg = MsgMint.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -89,8 +83,7 @@ import {
   MsgBurn,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -107,11 +100,9 @@ const msg = MsgBurn.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -126,8 +117,7 @@ import {
   MsgSetDenomMetadata,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -155,7 +145,7 @@ const denomUnitsIfTokenHas6Decimals = [
   },
 ]
 const displayIfTokenHas6Decimals = subdenom
-const displayIfTokenHas0Decimals = 
+const displayIfTokenHas0Decimals =
 
 const msg = MsgSetDenomMetadata.fromJSON({
   sender: injectiveAddress,
@@ -172,11 +162,9 @@ const msg = MsgSetDenomMetadata.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -191,8 +179,7 @@ import {
   MsgSetDenomMetadata,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -237,11 +224,9 @@ const msgSetDenomMetadata = MsgSetDenomMetadata.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: [msgCreateDenom, msgMint, msgSetDenomMetadata],
-  injectiveAddress,
+  msgs: [msgCreateDenom, msgMint, msgSetDenomMetadata]
 });
 
 console.log(txHash);

--- a/.gitbook/core-modules/tokenfactory.md
+++ b/.gitbook/core-modules/tokenfactory.md
@@ -17,8 +17,7 @@ import {
   MsgCreateDenom,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -31,11 +30,9 @@ const msg = MsgCreateDenom.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -50,8 +47,7 @@ import {
   MsgMint,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -68,11 +64,9 @@ const msg = MsgMint.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
   msgs: msg,
-  injectiveAddress,
 });
 
 console.log(txHash);
@@ -87,8 +81,7 @@ import {
   MsgBurn,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -105,11 +98,9 @@ const msg = MsgBurn.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -125,8 +116,7 @@ import {
   MsgSetDenomMetadata,
 } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
-import { ChainId } from "@injectivelabs/ts-types";
-import { Network, getNetworkEndpoints } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const privateKey = "0x...";
@@ -169,11 +159,9 @@ const msg = MsgSetDenomMetadata.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);

--- a/.gitbook/core-modules/wasm.md
+++ b/.gitbook/core-modules/wasm.md
@@ -11,8 +11,7 @@ import {
   MsgExecuteContract,
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
-import { ChainId } from "@injectivelabs/ts-types";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const recipientAddress = "inj2...";
@@ -32,11 +31,9 @@ const msg = MsgExecuteContract.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -54,8 +51,7 @@ import {
   MsgBroadcasterWithPk,
 } from "@injectivelabs/sdk-ts";
 import { INJ_DENOM } from "@injectivelabs/sdk-ui-ts";
-import { ChainId } from "@injectivelabs/ts-types";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const contractAddress = "cw...";
@@ -76,11 +72,9 @@ const msg = MsgExecuteContract.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);
@@ -119,8 +113,7 @@ import {
   MsgExecuteContractCompact,
 } from "@injectivelabs/sdk-ts";
 import { INJ_DENOM } from "@injectivelabs/sdk-ui-ts";
-import { ChainId } from "@injectivelabs/ts-types";
-import { getNetworkEndpoints, Network } from "@injectivelabs/networks";
+import { Network } from "@injectivelabs/networks";
 
 const injectiveAddress = "inj1...";
 const contractAddress = "cw...";
@@ -141,11 +134,9 @@ const msg = MsgExecuteContractCompact.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Mainnet,
-  endpoints: endpointsForNetwork,
+  network: Network.Mainnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 });
 
 console.log(txHash);

--- a/.gitbook/transactions/private-key.md
+++ b/.gitbook/transactions/private-key.md
@@ -225,8 +225,7 @@ You can use the `MsgBroadcasterWithPk` class from the `@injectivelabs/sdk-ts` pa
 ```ts
 import { MsgSend, MsgBroadcasterWithPk } from '@injectivelabs/sdk-ts'
 import { BigNumberInBase } from '@injectivelabs/utils'
-import { ChainId } from '@injectivelabs/ts-types'
-import { Network, getNetworkEndpoints } from '@injectivelabs/networks'
+import { Network } from '@injectivelabs/networks'
 
 const privateKey = '0x...'
 const injectiveAddress = 'inj1...'
@@ -242,11 +241,9 @@ const msg = MsgSend.fromJSON({
 
 const txHash = await new MsgBroadcasterWithPk({
   privateKey,
-  chainId: ChainId.Testnet,
-  endpoints: getNetworkEndpoints(Network.Testnet),
+  network: Network.Testnet
 }).broadcast({
-  msgs: msg,
-  injectiveAddress,
+  msgs: msg
 })
 
 console.log(txHash)

--- a/packages/sdk-ts/src/core/modules/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
+++ b/packages/sdk-ts/src/core/modules/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
@@ -26,7 +26,7 @@ describe('MsgBroadcasterWithPk', () => {
       network,
       privateKey,
       simulateTx: true,
-    }).broadcast({ msgs: message, injectiveAddress })
+    }).broadcast({ msgs: message })
 
     expect(response.txHash).toBeDefined()
   }, 60000)
@@ -53,7 +53,7 @@ describe('MsgBroadcasterWithPk', () => {
       privateKey,
       simulateTx: true,
       ethereumChainId: EthereumChainId.Goerli,
-    }).broadcastWithFeeDelegation({ msgs: message, injectiveAddress })
+    }).broadcastWithFeeDelegation({ msgs: message })
 
     expect(response.txHash).toBeDefined()
   }, 60000)


### PR DESCRIPTION
## Changes
- examples were added for `MsgExternalTransfer` itself and also specifically for adding coins to the burn auction pool per [notion](https://www.notion.so/injective/Frontend-Team-Dashboard-cfa9a0cacd1c40afb5ab399d68bae83c?p=64a9cd97c3af4c2cb291ea756d24be45&pm=s).
- in addition, I noticed that some of the parameters passed to `MsgBroadcasterWithPk` in our examples are now deprecated, so I fixed that across the docs