### PR TITLE
chore: docs for calculating market price quantity tick size

### DIFF
--- a/.gitbook/calulations/README.md
+++ b/.gitbook/calulations/README.md
@@ -1,0 +1,10 @@
+# Calculations
+
+Here are some formula formatting values between the chain and UI human-readable.
+
+### Bridges Supported
+
+| Topic                                                   | Description                             |
+| ------------------------------------------------------- | --------------------------------------- |
+| [Market min price tick size](minPriceTickSize.md)       | Minimum market order price tick size    |
+| [Market min quantity tick size](minQuantityTickSzie.md) | Minimum market order quantity tick size |

--- a/.gitbook/calulations/minPriceTickSize.md
+++ b/.gitbook/calulations/minPriceTickSize.md
@@ -1,0 +1,47 @@
+# Market min price tick size
+
+The min market price tick size for an order price - if a market has an minPriceTickSick of `0.001` and order submission with the price of `0.0011` will be rejected.
+
+Note that calculating the formula for calculating a spot and quote market price tick size are different.
+
+### Spot market
+
+1.  UI human readable to chain format:
+    Using INJ/USDT market which has 18 base decimals and 6 quote decimals as an example, here's how we convert the value to the chain format:
+
+```js
+const chainFormat = new BigNumberInBase(10)
+  .pow(quoteDecimal - baseDecimal)
+  .times(value)
+  .toFixed()
+```
+
+1. Chain format to UI human readable format:
+   Using INJ/USDT market which has 18 base decimals and 6 quote decimals as an example, here's how we convert the value to the UI human readable format:
+
+```js
+const humanReadableFormat = new BigNumber(value)
+  .shiftedBy(baseDecimals - quoteDecimals)
+  .toFixed()
+```
+
+### Derivative market
+
+1.  UI human readable to chain format:
+    Using INJ/USDT perp market which has 6 quote decimals as an example, here's how we convert the value to the chain format:
+
+```js
+const chainFormat = new BigNumberInBase(10)
+  .pow(-quoteDecimal)
+  .times(value)
+  .toFixed()
+```
+
+1. Chain format to UI human readable format:
+   Using INJ/USDT perp market which has 6 quote decimals as an example, here's how we convert the value to the UI human readable format:
+
+```js
+const humanReadableFormat = new BigNumber(value)
+  .shiftedBy(-quoteDecimals)
+  .toFixed()
+```

--- a/.gitbook/calulations/minQuantityTickSize.md
+++ b/.gitbook/calulations/minQuantityTickSize.md
@@ -1,0 +1,23 @@
+# Market min quantity tick size
+
+The min market quantity tick size for an order price - if a market has an minQuantityTickSize of `0.001` and order submission with the quantity of `0.0011` will be rejected.
+
+Note that derivate markets shares the same format for minQuantityTickSize between UI and the chain, so no formatting is required.
+
+### Spot market
+
+1.  UI human readable to chain format:
+    Using on a INJ/USDT market which has 18 base decimals and 6 quote decimals as an example, here's how we convert the value to the chain format:
+
+```js
+const chainFormat = new BigNumberInWei(value).toBase(baseDecimals)
+```
+
+1. Chain format to UI human readable format:
+   Using INJ/USDT market which has 18 base decimals and 6 quote decimals as an example, here's how we convert the value to the UI human readable format:
+
+```js
+const humanReadableFormat = new BigNumber(minQuantityTickSize)
+  .shiftedBy(-baseDecimals)
+  .toFixed()
+```


### PR DESCRIPTION
## This PR: 
- adds docs for calculating market min price tick size
- adds docs for calculating market min quantity tick size