### PR TITLE
chore: update yml files for ibc tokens script

### DIFF
--- a/.github/workflows/canary.yml
+++ b/.github/workflows/canary.yml
@@ -24,6 +24,11 @@ jobs:
       - name: 'Setup lerna@6.6.1'
         run: yarn global add lerna@6.6.1  --ignore-engines
 
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Build dependencies
         run: |
           node etc/bootstrapEnv
@@ -35,13 +40,14 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: 'Commit ibcTokenMetadata.json if changed'
+        run: |
+          git diff --exit-code -- packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json || (git add packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json && git commit -m "Automatically update ibcTokenMetadata.json")
+
       - name: Version and publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor}}@users.noreply.github.com"
-
           lerna version prerelease --preid dev --force-git-tag --no-changelog --yes
           lerna publish from-git --force-git-tag --dist-tag dev --yes --summary-file
 

--- a/.github/workflows/dev.yaml
+++ b/.github/workflows/dev.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: 'Setup lerna@6.6.1'
         run: yarn global add lerna@6.6.1 --ignore-engines
 
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Build dependencies
         run: |
           node etc/bootstrapEnv
@@ -35,13 +40,14 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: 'Commit ibcTokenMetadata.json if changed'
+        run: |
+          git diff --exit-code -- packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json || (git add packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json && git commit -m "Automatically update ibcTokenMetadata.json")
+
       - name: Version and publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor}}@users.noreply.github.com"
-
           lerna version prerelease --preid beta --force-git-tag --no-changelog --yes
           lerna publish from-git --force-git-tag --dist-tag next --yes --summary-file
 

--- a/.github/workflows/stable.yaml
+++ b/.github/workflows/stable.yaml
@@ -24,6 +24,11 @@ jobs:
       - name: 'Setup lerna@6.6.1'
         run: yarn global add lerna@6.6.1  --ignore-engines
 
+      - name: Set up Git user
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+
       - name: Build dependencies
         run: |
           node etc/bootstrapEnv
@@ -35,13 +40,14 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: 'Commit ibcTokenMetadata.json if changed'
+        run: |
+          git diff --exit-code -- packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json || (git add packages/sdk-ui-ts/src/services/ibc/ibcTokenMetadata.json && git commit -m "Automatically update ibcTokenMetadata.json")
+
       - name: Version and publish
         env:
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
-          git config user.name "${{ github.actor }}"
-          git config user.email "${{ github.actor}}@users.noreply.github.com"
-
           lerna version patch --conventional-commits --conventional-graduate --force-git-tag --yes
           lerna publish from-git --force-git-tag --dist-tag latest --yes --summary-file
 

--- a/packages/sdk-ui-ts/package.json
+++ b/packages/sdk-ui-ts/package.json
@@ -18,7 +18,7 @@
   },
   "scripts": {
     "postinstall": "link-module-alias",
-    "build": "tsc --build tsconfig.build.json && tsc --build tsconfig.build.esm.json && yarn build:post && link-module-alias && yarn copy-files",
+    "build": "tsc --build tsconfig.build.json && tsc --build tsconfig.build.esm.json && yarn build:post && link-module-alias && yarn copy-files && yarn get-ibc-tokens",
     "build:watch": "tsc --build -w tsconfig.build.json && tsc -w --build tsconfig.build.esm.json && yarn build:post && link-module-alias",
     "build:post": "shx cp ../../etc/stub/package.json.stub dist/cjs/package.json && shx cp ../../etc/stub/package.esm.json.stub dist/esm/package.json",
     "clean": "tsc --build tsconfig.build.json --clean && tsc --build tsconfig.build.esm.json --clean && shx rm -rf coverage *.log junit.xml dist && jest --clearCache && shx mkdir -p dist",


### PR DESCRIPTION
## Changes
-- yaml build scripts will now check if there was any updates to `ibcTokenMetadata.json` during the build. if so, it will push a new commit to handle the update, which should propogate along with the publish step

## How the 'Commit ibcTokenMetadata.json if changed' step works
1. checks if there is any new diff between the previous `ibcTokenMetadata.json` and the potentially updated one from the build
2. if there is a diff, the `git add`/ `git commit` logic will execute
3. if there is no diff, then the `git diff --exit-code` command will return `0`, so the `git add`/`git commit` steps will not execute
Note: took some time to come up with this but seems to work nicely


## Testing Completed
- forked `injective-ts` -> updated package names to where they would publish to `@shane-moore/...` instead of to `@injectivelabs/`. then, I updated the `ibcTokenMetadata.json` to test the change. I pushed the update to my forked repo under a `test` branch, which kicked off the github actions pipeline, and it published the new `@shane-moore/sdk-ui-ts`. I also tried a few more times to verify that it would work over time