### PR TITLE
chore: nft service

### DIFF
--- a/packages/sdk-ts/src/client/wasm/index.ts
+++ b/packages/sdk-ts/src/client/wasm/index.ts
@@ -1,3 +1,4 @@
 export * from './swap'
 export * from './types'
 export * from './nameservice'
+export * from './nft'

--- a/packages/sdk-ts/src/client/wasm/nft/index.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/index.ts
@@ -1,0 +1,3 @@
+export * from './queries'
+export * from './transformer'
+export * from './types'

--- a/packages/sdk-ts/src/client/wasm/nft/queries/QueryIpfs.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/queries/QueryIpfs.ts
@@ -1,0 +1,36 @@
+import BaseRestConsumer from '../../../BaseRestConsumer'
+import {
+  HttpRequestException,
+  UnspecifiedErrorCode,
+} from '@injectivelabs/exceptions'
+import { IpfsTokenResponse } from '../types'
+import { RestApiResponse } from '../../../chain/types'
+
+export class QueryIpfs extends BaseRestConsumer {
+  constructor(endpoint: string) {
+    super(endpoint)
+  }
+
+  public async fetchJson(ipfsPath: string): Promise<IpfsTokenResponse> {
+    try {
+      const response = await this.retry<RestApiResponse<IpfsTokenResponse>>(
+        () => {
+          return this.get(ipfsPath)
+        },
+        3,
+        1000,
+      )
+
+      return response.data
+    } catch (e: unknown) {
+      if (e instanceof HttpRequestException) {
+        throw e
+      }
+
+      throw new HttpRequestException(new Error((e as any).message), {
+        code: UnspecifiedErrorCode,
+        context: `${this.endpoint}/${ipfsPath}`,
+      })
+    }
+  }
+}

--- a/packages/sdk-ts/src/client/wasm/nft/queries/QueryNftCollection.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/queries/QueryNftCollection.ts
@@ -1,0 +1,14 @@
+import { BaseWasmQuery } from '../../BaseWasmQuery'
+import { toBase64 } from '../../../../utils'
+
+export declare namespace CollectionQueryArg {
+  export interface Params {}
+}
+
+export class QueryNftCollection extends BaseWasmQuery<CollectionQueryArg.Params> {
+  toPayload() {
+    return toBase64({
+      contract_info: {},
+    })
+  }
+}

--- a/packages/sdk-ts/src/client/wasm/nft/queries/QueryNftToken.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/queries/QueryNftToken.ts
@@ -1,0 +1,24 @@
+import { BaseWasmQuery } from '../../BaseWasmQuery'
+import { toBase64 } from '../../../../utils'
+
+export declare namespace TokenQueryArg {
+  export interface Params {
+    owner: string
+    limit: number
+    verbose: boolean
+    start_after?: string
+  }
+}
+
+export class QueryNftToken extends BaseWasmQuery<TokenQueryArg.Params> {
+  toPayload() {
+    return toBase64({
+      tokens: {
+        owner: this.params.owner,
+        limit: this.params.limit,
+        verbose: this.params.verbose,
+        start_after: this.params.start_after,
+      },
+    })
+  }
+}

--- a/packages/sdk-ts/src/client/wasm/nft/queries/index.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/queries/index.ts
@@ -1,0 +1,3 @@
+export { QueryNftToken } from './QueryNftToken'
+export { QueryNftCollection } from './QueryNftCollection'
+export { QueryIpfs } from './QueryIpfs'

--- a/packages/sdk-ts/src/client/wasm/nft/transformer.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/transformer.ts
@@ -1,0 +1,56 @@
+import { WasmContractQueryResponse } from '../types'
+import {
+  NftToken,
+  NftTokenMetadata,
+  IpfsTokenResponse,
+  NftCollectionMetadata,
+  QueryNftTokenResponse,
+} from './types'
+import { toUtf8 } from '../../../utils'
+
+export class NftQueryTransformer {
+  static tokensResponseToTokens(
+    response: WasmContractQueryResponse,
+  ): NftTokenMetadata[] | undefined {
+    const { tokens } = JSON.parse(toUtf8(response.data))
+
+    if (tokens.length === 0) {
+      return
+    }
+
+    return tokens.map(this.tokenResponseToToken)
+  }
+
+  static tokenResponseToToken(token: QueryNftTokenResponse): NftTokenMetadata {
+    return {
+      owner: token.owner,
+      tokenId: token.token_id,
+      metadataUri: token.metadata_uri,
+    }
+  }
+
+  static ipfsTokenResponseToToken(token: IpfsTokenResponse): NftToken {
+    return {
+      title: token.title,
+      description: token.description,
+      rarity: token.rarity,
+      rank: token.rank,
+      release: token.release,
+      style: token.style,
+      license: token.license,
+      media: token.media,
+      tags: token.tags,
+    }
+  }
+
+  static collectionResponseToCollection(
+    response: WasmContractQueryResponse,
+  ): NftCollectionMetadata {
+    const collection = JSON.parse(toUtf8(response.data))
+
+    return {
+      name: collection.name,
+      symbol: collection.symbol,
+    }
+  }
+}

--- a/packages/sdk-ts/src/client/wasm/nft/types/index.ts
+++ b/packages/sdk-ts/src/client/wasm/nft/types/index.ts
@@ -1,0 +1,48 @@
+export interface QueryNftTokenResponse {
+  owner: string
+  token_id: string
+  metadata_uri: string
+}
+
+export interface NftTokenMetadata {
+  owner: string
+  tokenId: string
+  metadataUri: string
+}
+
+export interface IpfsTokenResponse {
+  title: string
+  description: string
+  rarity: string
+  rank: string
+  release: string
+  style: string
+  license: string
+  media: string
+  tags: string
+}
+
+export interface NftToken {
+  title: string
+  description: string
+  rarity: string
+  rank: string
+  release: string
+  style: string
+  license: string
+  media: string
+  tags: string
+}
+
+export interface NftTokenWithAddress extends NftToken {
+  collectionAddress: string
+}
+
+export interface NftCollectionMetadata {
+  name: string
+  symbol: string
+}
+
+export interface NftCollectionWithAddress extends NftCollectionMetadata {
+  collectionAddress: string
+}

--- a/packages/sdk-ui-ts/src/services/index.ts
+++ b/packages/sdk-ui-ts/src/services/index.ts
@@ -1,3 +1,4 @@
 export * from './web3'
 export * from './gas'
 export * from './nameservice'
+export * from './nft'

--- a/packages/sdk-ui-ts/src/services/nft/NftService.ts
+++ b/packages/sdk-ui-ts/src/services/nft/NftService.ts
@@ -1,0 +1,166 @@
+import {
+  QueryIpfs,
+  QueryNftToken,
+  NftTokenMetadata,
+  ChainGrpcWasmApi,
+  QueryNftCollection,
+  NftQueryTransformer,
+  NftTokenWithAddress,
+  NftCollectionWithAddress,
+} from '@injectivelabs/sdk-ts'
+import {
+  Network,
+  NetworkEndpoints,
+  getNetworkEndpoints,
+} from '@injectivelabs/networks'
+
+export class NftService {
+  protected chainGrpcWasmApiClient: ChainGrpcWasmApi
+  private ipfsQueryClient: QueryIpfs
+
+  constructor(
+    network: Network = Network.Testnet,
+    ipfsEndpoint: string,
+    endpoints?: NetworkEndpoints,
+  ) {
+    const networkEndpoints = endpoints || getNetworkEndpoints(network)
+    this.chainGrpcWasmApiClient = new ChainGrpcWasmApi(networkEndpoints.grpc)
+    this.ipfsQueryClient = new QueryIpfs(ipfsEndpoint)
+  }
+
+  private async accumulateTokens({
+    contractAddress,
+    injectiveAddress,
+    lastTokenId,
+    allTokens = [],
+  }: {
+    contractAddress: string
+    injectiveAddress: string
+    lastTokenId?: string
+    allTokens?: NftTokenMetadata[]
+  }): Promise<NftTokenMetadata[]> {
+    const MAX_ITEMS = 30
+
+    const queryNftTokenPayload = new QueryNftToken({
+      owner: injectiveAddress,
+      limit: MAX_ITEMS,
+      verbose: true,
+      ...(lastTokenId ? { start_after: lastTokenId } : undefined),
+    }).toPayload()
+
+    const response = await this.chainGrpcWasmApiClient.fetchSmartContractState(
+      contractAddress,
+      queryNftTokenPayload,
+    )
+
+    const tokens = NftQueryTransformer.tokensResponseToTokens(response)
+
+    if (!tokens) {
+      return allTokens
+    }
+
+    return await this.accumulateTokens({
+      contractAddress,
+      injectiveAddress,
+      lastTokenId: tokens[tokens.length - 1].tokenId,
+      allTokens: [...allTokens, ...tokens],
+    })
+  }
+
+  private async fetchAllTokensForContract(
+    contractAddress: string,
+    injectiveAddress: string,
+  ) {
+    return await this.accumulateTokens({ contractAddress, injectiveAddress })
+  }
+
+  public async fetchTokens(
+    {
+      codeId,
+      limit = 100_000,
+      injectiveAddress,
+    }: {
+      codeId: number
+      limit?: number
+      injectiveAddress: string
+    },
+    errorCallback?: (error: Error) => void,
+  ): Promise<NftTokenWithAddress[]> {
+    const collections =
+      await this.chainGrpcWasmApiClient.fetchContractCodeContracts(codeId, {
+        limit,
+      })
+
+    const allTokensList = await Promise.all(
+      collections.contractsList.map(async (contract) => ({
+        contract,
+        tokens: await this.fetchAllTokensForContract(
+          contract,
+          injectiveAddress,
+        ),
+      })),
+    )
+
+    const tokensWithContract = allTokensList.flatMap(({ contract, tokens }) =>
+      tokens.map((token) => ({ ...token, contract })),
+    )
+
+    const ipfsTokenMetadataPromises = await this.fetchIpfsTokenMetadata(
+      tokensWithContract,
+      errorCallback,
+    )
+
+    return (await Promise.allSettled(ipfsTokenMetadataPromises))
+      .filter((result) => result.status === 'fulfilled')
+      .map(
+        (result) =>
+          (result as PromiseFulfilledResult<NftTokenWithAddress | undefined>)
+            .value,
+      )
+      .filter((metadata) => metadata) as NftTokenWithAddress[]
+  }
+
+  private async fetchIpfsTokenMetadata(
+    allTokensList: Array<NftTokenMetadata & { contract: string }>,
+    errorCallback?: (error: Error) => void,
+  ) {
+    return allTokensList.map(async ({ metadataUri, contract }) => {
+      try {
+        const path = metadataUri.replace('ipfs://', '')
+        const tokenMetadata = await this.ipfsQueryClient.fetchJson(path)
+        const transformedTokenMetadata =
+          NftQueryTransformer.ipfsTokenResponseToToken(tokenMetadata)
+
+        return {
+          ...transformedTokenMetadata,
+          collectionAddress: contract,
+        }
+      } catch (e: any) {
+        /**
+         * Since we still want to pass the successful results, we handle ipfs timeouts on the client
+         **/
+        if (errorCallback) {
+          errorCallback(e)
+        }
+
+        return
+      }
+    })
+  }
+
+  public async fetchCollectionInfo(
+    contractAddress: string,
+  ): Promise<NftCollectionWithAddress> {
+    const queryNftCollectionPayload = new QueryNftCollection({}).toPayload()
+
+    const response = await this.chainGrpcWasmApiClient.fetchSmartContractState(
+      contractAddress,
+      queryNftCollectionPayload,
+    )
+
+    const collection =
+      NftQueryTransformer.collectionResponseToCollection(response)
+
+    return { ...collection, collectionAddress: contractAddress }
+  }
+}

--- a/packages/sdk-ui-ts/src/services/nft/index.ts
+++ b/packages/sdk-ui-ts/src/services/nft/index.ts
@@ -1,0 +1,1 @@
+export * from './NftService'


### PR DESCRIPTION
## Changes
- nft collection and token queries/types/transformers were added to `sdk-ts`
- NftService.ts was added to `sdk-ui-ts` as to make it easy to query for token metadata for nft's created via mainnet codeId `49` or testnet codeId `582`
  - the flow is as follows:
    1. query all smart contracts instantiated via the network specific `codeId` since each contract is a different NFT collection, and we pass the `injectiveAddress` to determine which nfts a user owns in each collection
    2. the contract calls return `ipfs` content identifiers (CIDs), which can then be used to query an ipfs gateway and get back metadata associated with each token as json. We also receive back a CID for the NFT's image, which can be used by the FE in an `img` tag for example
  - the `NftService` also provides a helper function for querying the contracts to obtain the name of the collection, as to be used for filtering on the FE
  
## Optimizations
- querying IPFS can be quite slow, so it's paramount that we make the calls consecutively. It's also possible that some of the calls fail or timeout. In this scenario, we send back the successful token metadata to the FE and allow the user to pass in an error handler callback function to the service, which triggers when an ipfs query fails.  Then, the FE can render the successful images and also show some error message to notify the user of missing NFTS from the query. Some additional context on IPFS complications and potential solutions are detailed in [notion doc](https://www.notion.so/injective/IPFS-NFT-Metadata-Retrieval-Limitations-a136fac750a24a4fba10e5ceb28f7dc0?pvs=4).
