### PR TITLE
chore: mapBySymbol support multiple token types

### DIFF
--- a/packages/token-metadata/src/tokens/mappings/mapBySymbol.ts
+++ b/packages/token-metadata/src/tokens/mappings/mapBySymbol.ts
@@ -8,9 +8,13 @@ export const getMappedTokensBySymbol = (tokens: Record<string, TokenMeta>) =>
       const symbol = tokenMeta.symbol.toUpperCase()
       const symbolDiffs = symbol !== symbolKey
 
+      let ibcResults = {}
+      let cw20Results = {}
+      let splResults = {}
+      let cw20sResults = {}
+
       if (tokenMeta.ibc && tokenMeta.ibc.baseDenom) {
-        return {
-          ...result,
+        ibcResults = {
           [tokenMeta.ibc.baseDenom.toUpperCase()]: tokenMeta,
           [symbol.toUpperCase()]: tokenMeta,
           ...(symbolDiffs && {
@@ -23,8 +27,7 @@ export const getMappedTokensBySymbol = (tokens: Record<string, TokenMeta>) =>
       }
 
       if (tokenMeta.cw20 && tokenMeta.cw20.address) {
-        return {
-          ...result,
+        cw20Results = {
           [tokenMeta.cw20.address.toUpperCase()]: tokenMeta,
           [symbol.toUpperCase()]: tokenMeta,
           ...(symbolDiffs && {
@@ -34,8 +37,7 @@ export const getMappedTokensBySymbol = (tokens: Record<string, TokenMeta>) =>
       }
 
       if (tokenMeta.spl && tokenMeta.spl.address) {
-        return {
-          ...result,
+        splResults = {
           [tokenMeta.spl.address.toUpperCase()]: tokenMeta,
           [symbol.toUpperCase()]: tokenMeta,
           ...(symbolDiffs && {
@@ -53,8 +55,7 @@ export const getMappedTokensBySymbol = (tokens: Record<string, TokenMeta>) =>
           {} as Record<string, TokenMeta>,
         )
 
-        return {
-          ...result,
+        cw20sResults = {
           ...cw20Maps,
           [symbol.toUpperCase()]: tokenMeta,
           ...(symbolDiffs && {
@@ -65,6 +66,10 @@ export const getMappedTokensBySymbol = (tokens: Record<string, TokenMeta>) =>
 
       return {
         ...result,
+        ...ibcResults,
+        ...cw20Results,
+        ...splResults,
+        ...cw20sResults,
         [symbol.toUpperCase()]: tokenMeta,
         ...(symbolDiffs && {
           [symbolKey.toUpperCase()]: tokenMeta,


### PR DESCRIPTION
## Changes
- it's possible for a `tokenMeta` object in `tokens.ts` to have multiple properties i.e. `ibc`/`spl`/`cw20s` in any combination, and each of these sub properties could be used to create a new `denom/`tokenMeta` pair in the `TokenMetaUtils` `this.tokens`. therefore, we need to extend `mapBySymbol` to return results for the various token types instead of returning early if it hits `if (tokenMeta.ibc && tokenMeta.ibc.baseDenom) ` for example, because there may also be a `cw20s` property associated with it, which is the case for `USDC`, which has `ibc` and `cw20s` tokens that need to be created

## Testing Completed
- hub bridge now shows USDCet. it's currently being omitted in latest published packages, since `mapBySymbol` is only returning the `ibc` property's token meta. I tested with this change, and USDCet shows again
- checked explorer assets page via `yarn link`, and all tokens looks good