### PR TITLE
chore: add supported chainId check to cosmostation getAddresses

### DIFF
--- a/packages/wallet-ts/src/strategies/cosmos-wallet-strategy/strategies/Cosmostation.ts
+++ b/packages/wallet-ts/src/strategies/cosmos-wallet-strategy/strategies/Cosmostation.ts
@@ -57,8 +57,16 @@ export default class Cosmostation implements ConcreteCosmosWalletStrategy {
   async getAddresses(): Promise<string[]> {
     const { chainName } = this
     const cosmostationWallet = await this.getCosmostationWallet()
+    const cosmostationWalletUtil = new CosmostationWallet(this.chainId)
 
     try {
+      if (!(await cosmostationWalletUtil.checkChainIdSupport())) {
+        throw new CosmosWalletException(
+          new Error(`The ${this.chainId} is not supported on Cosmostation.`),
+          { type: ErrorType.WalletError },
+        )
+      }
+
       const accounts = await cosmostationWallet.requestAccount(chainName)
 
       return [accounts.address]

--- a/packages/wallet-ts/src/utils/wallets/cosmostation/CosmostationWallet.ts
+++ b/packages/wallet-ts/src/utils/wallets/cosmostation/CosmostationWallet.ts
@@ -29,7 +29,9 @@ export class CosmostationWallet {
     try {
       const supportedChainIds = await provider.getSupportedChainIds()
 
-      return !!supportedChainIds.official.find((chainId) => chainId === chainId)
+      return !!supportedChainIds.official.find(
+        (chainId) => chainId === actualChainId,
+      )
     } catch (e) {
       throw new CosmosWalletException(
         new Error(


### PR DESCRIPTION
## Changes
- added `checkChainIdSupport` check to cosmostation `getAddresses`, similar to `keplr` and `leap`


## Testing
- tried `Migaloo` network with cosmostation and got error message as expected:
<img width="969" alt="image" src="https://github.com/InjectiveLabs/injective-ts/assets/41407272/33f01108-d127-4144-bc29-93e4afc25d3f">