### PR TITLE
chore: msgCancelUnbondingDelegation created

### DIFF
--- a/.gitbook/core-modules/staking.md
+++ b/.gitbook/core-modules/staking.md
@@ -78,34 +78,36 @@ const txHash = await new MsgBroadcasterWithPk({
 console.log(txHash);
 ```
 
-### MsgDelegate
+### MsgCancelUnbondingDelegation
 
-This Message is used to Delegate INJ to a validator.
+This message is used to cancel unbonding from a validator, reset the bonding period, and delegate back to the previous validator.
 
 ```ts
-import { MsgUndelegate, MsgBroadcasterWithPk } from "@injectivelabs/sdk-ts";
+import { MsgCancelUnbondingDelegation, MsgBroadcasterWithPk } from "@injectivelabs/sdk-ts";
 import { BigNumberInBase } from "@injectivelabs/utils";
 import { Network } from "@injectivelabs/networks";
 
-const injectiveAddress = "inj1...";
+const delegatorAddress = "inj1...";
 const privateKey = "0x...";
 const amount = new BigNumberInBase(5);
 const validatorAddress = "inj1...";
+const creationHeight = "123456"; // the height at which the unbonding was initiated
 
-const msg = MsgUndelegate.fromJSON({
-  injectiveAddress,
+const msg = MsgCancelUnbondingDelegation.fromJSON({
+  delegatorAddress,
   validatorAddress,
   amount: {
     denom: INJ_DENOM,
     amount: amount.toWei().toFixed(),
   },
+  creationHeight,
 });
 
 const txHash = await new MsgBroadcasterWithPk({
-  privateKey,
-  network: Network.Testnet
+privateKey,
+network: Network.Testnet
 }).broadcast({
-  msgs: msg
+msgs: msg
 });
 
 console.log(txHash);

--- a/packages/sdk-ts/src/core/modules/msgs.ts
+++ b/packages/sdk-ts/src/core/modules/msgs.ts
@@ -37,6 +37,7 @@ import MsgUndelegate from './staking/msgs/MsgUndelegate'
 import MsgEditValidator from './staking/msgs/MsgEditValidator'
 import MsgCreateValidator from './staking/msgs/MsgCreateValidator'
 import MsgBeginRedelegate from './staking/msgs/MsgBeginRedelegate'
+import MsgCancelUnbondingDelegation from './staking/msgs/MsgCancelUnbondingDelegation'
 import MsgExecuteContract from './wasm/msgs/MsgExecuteContract'
 import MsgExecuteContractCompat from './wasm/msgs/MsgExecuteContractCompat'
 import MsgMigrateContract from './wasm/msgs/MsgMigrateContract'
@@ -89,6 +90,7 @@ export type Msgs =
   | MsgDelegate
   | MsgUndelegate
   | MsgBeginRedelegate
+  | MsgCancelUnbondingDelegation
   | MsgExecuteContract
   | MsgExecuteContractCompat
   | MsgMigrateContract

--- a/packages/sdk-ts/src/core/modules/staking/index.ts
+++ b/packages/sdk-ts/src/core/modules/staking/index.ts
@@ -3,6 +3,7 @@ import MsgUndelegate from './msgs/MsgUndelegate'
 import MsgEditValidator from './msgs/MsgEditValidator'
 import MsgCreateValidator from './msgs/MsgCreateValidator'
 import MsgBeginRedelegate from './msgs/MsgBeginRedelegate'
+import MsgCancelUnbondingDelegation from './msgs/MsgCancelUnbondingDelegation'
 
 export {
   MsgDelegate,
@@ -10,4 +11,5 @@ export {
   MsgEditValidator,
   MsgCreateValidator,
   MsgBeginRedelegate,
+  MsgCancelUnbondingDelegation,
 }

--- a/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.spec.ts
+++ b/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.spec.ts
@@ -1,0 +1,86 @@
+import { BigNumberInBase } from '@injectivelabs/utils'
+import MsgCancelUnbondingDelegation from './MsgCancelUnbondingDelegation'
+import { mockFactory } from '@injectivelabs/test-utils'
+import snakecaseKeys from 'snakecase-keys'
+
+const params: MsgCancelUnbondingDelegation['params'] = {
+  validatorAddress: mockFactory.validatorAddress,
+  delegatorAddress: mockFactory.injectiveAddress,
+  amount: {
+    amount: new BigNumberInBase(1).toFixed(),
+    denom: 'inj',
+  },
+  creationHeight: '123456',
+}
+
+const protoType = '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation'
+const protoTypeAmino = 'cosmos-sdk/MsgCancelUnbondingDelegation'
+const protoParams = {
+  validatorAddress: params.validatorAddress,
+  delegatorAddress: params.delegatorAddress,
+  amount: params.amount,
+  creationHeight: params.creationHeight,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCancelUnbondingDelegation.fromJSON(params)
+
+describe('MsgCancelUnbondingDelegation', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeAmino,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper Eip712 types', () => {
+    const eip712Types = message.toEip712Types()
+
+    expect(Object.fromEntries(eip712Types)).toStrictEqual({
+      TypeAmount: [
+        { name: 'denom', type: 'string' },
+        { name: 'amount', type: 'string' },
+      ],
+      MsgValue: [
+        { name: 'delegator_address', type: 'string' },
+        { name: 'validator_address', type: 'string' },
+        { name: 'amount', type: 'TypeAmount' },
+        { name: 'creation_height', type: 'string' },
+      ],
+    })
+  })
+
+  it('generates proper Eip712 values', () => {
+    const eip712 = message.toEip712()
+
+    expect(eip712).toStrictEqual({
+      type: protoTypeAmino,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3', () => {
+    const web3 = message.toWeb3()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.spec.ts
+++ b/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.spec.ts
@@ -61,7 +61,7 @@ describe('MsgCancelUnbondingDelegation', () => {
         { name: 'delegator_address', type: 'string' },
         { name: 'validator_address', type: 'string' },
         { name: 'amount', type: 'TypeAmount' },
-        { name: 'creation_height', type: 'string' },
+        { name: 'creation_height', type: 'int64' },
       ],
     })
   })

--- a/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.ts
+++ b/packages/sdk-ts/src/core/modules/staking/msgs/MsgCancelUnbondingDelegation.ts
@@ -1,0 +1,98 @@
+import { MsgBase } from '../../MsgBase'
+import snakecaseKeys from 'snakecase-keys'
+import {
+  CosmosBaseV1Beta1Coin,
+  CosmosStakingV1Beta1Tx,
+} from '@injectivelabs/core-proto-ts'
+
+export declare namespace MsgCancelUnbondingDelegation {
+  export interface Params {
+    amount: {
+      denom: string
+      amount: string
+    }
+    validatorAddress: string
+    delegatorAddress: string
+    creationHeight: string
+  }
+
+  export type Proto = CosmosStakingV1Beta1Tx.MsgCancelUnbondingDelegation
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCancelUnbondingDelegation extends MsgBase<
+  MsgCancelUnbondingDelegation.Params,
+  MsgCancelUnbondingDelegation.Proto
+> {
+  static fromJSON(
+    params: MsgCancelUnbondingDelegation.Params,
+  ): MsgCancelUnbondingDelegation {
+    return new MsgCancelUnbondingDelegation(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const coinAmount = CosmosBaseV1Beta1Coin.Coin.create()
+    coinAmount.denom = params.amount.denom
+    coinAmount.amount = params.amount.amount
+
+    const message = CosmosStakingV1Beta1Tx.MsgCancelUnbondingDelegation.create()
+    message.amount = coinAmount
+    message.delegatorAddress = params.delegatorAddress
+    message.validatorAddress = params.validatorAddress
+    message.creationHeight = params.creationHeight
+
+    return CosmosStakingV1Beta1Tx.MsgCancelUnbondingDelegation.fromPartial(
+      message,
+    )
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      ...snakecaseKeys(proto),
+    }
+
+    return {
+      type: 'cosmos-sdk/MsgCancelUnbondingDelegation',
+      value: message,
+    }
+  }
+
+  public toWeb3() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/cosmos.staking.v1beta1.MsgCancelUnbondingDelegation',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return CosmosStakingV1Beta1Tx.MsgCancelUnbondingDelegation.encode(
+      this.toProto(),
+    ).finish()
+  }
+}

--- a/packages/sdk-ts/src/core/modules/tx/eip712/maps.ts
+++ b/packages/sdk-ts/src/core/modules/tx/eip712/maps.ts
@@ -28,6 +28,7 @@ export const objectKeysToEip712Types = ({
     'expiry',
     'option',
     'proposal_id',
+    'creation_height',
   ]
   const output = new Map<string, TypedDataField[]>()
   const types = new Array<TypedDataField>()
@@ -160,6 +161,8 @@ export const numberTypeToReflectionNumberType = (property?: string) => {
     case 'oracle_scale_factor':
       return 'uint64'
     case 'expiry':
+      return 'int64'
+    case 'creation_height':
       return 'int64'
     case 'option':
       return 'int32'

--- a/packages/ts-types/src/enums.ts
+++ b/packages/ts-types/src/enums.ts
@@ -32,6 +32,7 @@ export enum MsgType {
   MsgDelegate = 'cosmos.staking.v1beta1.MsgDelegate',
   MsgEditValidator = 'cosmos.staking.v1beta1.MsgEditValidator',
   MsgUndelegate = 'cosmos.staking.v1beta1.MsgUndelegate',
+  MsgCancelUnbondingDelegation = 'cosmos.staking.v1beta1.MsgCancelUnbondingDelegation',
   MsgExecuteContract = 'cosmwasm.wasm.v1.MsgExecuteContract',
   MsgInstantiateContract = 'cosmwasm.wasm.v1.MsgInstantiateContract',
   MsgInstantiateContract2 = 'cosmwasm.wasm.v1.MsgInstantiateContract2',


### PR DESCRIPTION
## Changes
- `MsgCancelUnbondingDelegation` allows you to cancel any amount you are currently unbonding. Then, it will reset the bonding period and redelegate to the same validator. This PR adds support for this message
- unit tests & git book examples were also created
- small addition to eip712 mappings for `creation_height` property to convert type to `int64`