### PR TITLE
Fix Cosmostation

### DIFF
--- a/packages/wallet-ts/src/broadcaster/MsgBroadcaster.ts
+++ b/packages/wallet-ts/src/broadcaster/MsgBroadcaster.ts
@@ -634,7 +634,7 @@ export class MsgBroadcaster {
       address: tx.injectiveAddress,
       txRaw: createTxRawFromSigResponse(directSignResponse),
       signature: directSignResponse.signature.signature,
-      pubKey: directSignResponse.signature.pub_key,
+      pubKey: { value: pubKey },
     })
 
     // Re-enable tx gas check removed above


### PR DESCRIPTION
Hello, 

We found a bug.  Cosmostation wallet doesn't work on Injective DAaps (Helix, etc.).  This wallet doesn't pass public_key to directSignResponse.  

Team: Qwerty.Exchange