### PR TITLE
chore: perp markets token metadata

### DIFF
--- a/packages/sdk-ui-ts/src/denom/DenomClientAsync.ts
+++ b/packages/sdk-ui-ts/src/denom/DenomClientAsync.ts
@@ -21,6 +21,7 @@ import {
 import { Web3Client } from '../services/web3/Web3Client'
 import type { Token } from '@injectivelabs/token-metadata'
 import {
+  TokenType,
   TokenMetaBase,
   getUnknownTokenWithSymbol,
   getIbcTokenFromDenomTrace,
@@ -220,6 +221,23 @@ export class DenomClientAsync {
 
   getCoinGeckoId(denom: string): string {
     return this.denomClient.getCoinGeckoId(denom)
+  }
+
+  /**
+   * Find derivative market's base token metadata based on the symbol
+   */
+  getDerivativeBaseToken(symbol: string) {
+    const tokenMeta = this.denomClient.getTokenMetaDataBySymbol(symbol)
+
+    return {
+      denom: symbol,
+      tokenType: TokenType.Unknown,
+      decimals: tokenMeta?.decimals || 0,
+      logo: tokenMeta?.logo || 'unknown.png',
+      coinGeckoId: tokenMeta?.coinGeckoId || '',
+      name: tokenMeta?.name || symbol.toUpperCase(),
+      symbol: tokenMeta?.symbol || symbol.toUpperCase(),
+    }
   }
 
   private async getFactoryDenomMetadata(

--- a/packages/sdk-ui-ts/src/denom/DenomClientAsync.ts
+++ b/packages/sdk-ui-ts/src/denom/DenomClientAsync.ts
@@ -224,9 +224,9 @@ export class DenomClientAsync {
   }
 
   /**
-   * Find derivative market's base token metadata based on the symbol
+   * TODO: refactor
    */
-  getDerivativeBaseToken(symbol: string) {
+  getTokenBySymbol(symbol: string): Token {
     const tokenMeta = this.denomClient.getTokenMetaDataBySymbol(symbol)
 
     return {

--- a/packages/sdk-ui-ts/src/token/TokenService.ts
+++ b/packages/sdk-ui-ts/src/token/TokenService.ts
@@ -245,7 +245,10 @@ export class TokenService {
       .replaceAll(' ', '-')
       .toLowerCase()
     const [baseTokenSymbol] = slug.split('-')
-    const baseToken = await this.denomClient.getDenomToken(baseTokenSymbol)
+    const baseToken = await this.denomClient.getDerivativeBaseToken(
+      baseTokenSymbol,
+    )
+
     const quoteToken = await this.denomClient.getDenomToken(market.quoteDenom)
 
     return {

--- a/packages/sdk-ui-ts/src/token/TokenService.ts
+++ b/packages/sdk-ui-ts/src/token/TokenService.ts
@@ -245,7 +245,7 @@ export class TokenService {
       .replaceAll(' ', '-')
       .toLowerCase()
     const [baseTokenSymbol] = slug.split('-')
-    const baseToken = await this.denomClient.getDerivativeBaseToken(
+    const baseToken = await this.denomClient.getTokenBySymbol(
       baseTokenSymbol,
     )
 

--- a/packages/token-metadata/src/tokens/tokens/tokens.ts
+++ b/packages/token-metadata/src/tokens/tokens/tokens.ts
@@ -191,16 +191,28 @@ export default {
       },
     ],
 
-    ibcs: [{
-      decimals: 6,
-      symbol: 'USDCnb',
-      baseDenom: 'uusdc',
-      isNative: true,
-      channelId: 'channel-148',
-      path: 'transfer/channel-148',
-      hash: '2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E',
-      source: TokenSource.Cosmos
-    }],
+    ibcs: [
+      {
+        decimals: 6,
+        symbol: 'USDCnb',
+        baseDenom: 'uusdc',
+        isNative: true,
+        channelId: 'channel-148',
+        path: 'transfer/channel-148',
+        hash: '2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E',
+        source: TokenSource.Cosmos
+      },
+      {
+        decimals: 6,
+        symbol: 'USDCgw',
+        baseDenom: 'factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/GGh9Ufn1SeDGrhzEkMyRKt5568VbbxZK2yvWNsd6PbXt',
+        isNative: false,
+        path: 'transfer/channel-183',
+        channelId: 'channel-183',
+        hash: '7BE71BB68C781453F6BB10114F8E2DF8DC37BA791C502F5389EA10E7BEA68323',
+        source: TokenSource.EthereumWh
+      }
+    ],
 
     spl: {
       decimals: 6,
@@ -1141,7 +1153,6 @@ export default {
   AVAX: {
     name: 'AVAX',
     logo: 'avax.webp',
-    symbol: 'AVAX',
     coinGeckoId: 'avalanche-2',
 
     cw20s: [
@@ -1156,7 +1167,6 @@ export default {
   BONK: {
     name: 'BONK',
     logo: 'bonk.jpeg',
-    symbol: 'BONK',
     coinGeckoId: 'bonk',
 
     cw20s: [
@@ -1282,6 +1292,19 @@ export default {
         source: TokenSource.Arbitrum,
       },
     ],
+
+    ibcs: [
+      {
+        decimals: 8,
+        symbol: 'ARBgw',
+        baseDenom: 'factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/4jq5m8FR6W6nJygDj8NMMbB48mqX4LQHc3j5uEb9syDe',
+        isNative: false,
+        path: 'transfer/channel-183',
+        channelId: 'channel-183',
+        hash: '8CF0E4184CA3105798EDB18CAA3981ADB16A9951FE9B05C6D830C746202747E1',
+        source: TokenSource.Arbitrum
+      }
+    ]
   },
 
   EUR: {
@@ -1403,6 +1426,19 @@ export default {
         source: TokenSource.Polygon,
       },
     ],
+
+    ibcs: [
+      {
+        decimals: 8,
+        symbol: 'WMATICgw',
+        baseDenom: 'factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/4gn1J9pchUGh63ez1VwiuTmU4nfJ8Rr8o5HgBC5TMdMk',
+        isNative: false,
+        path: 'transfer/channel-183',
+        channelId: 'channel-183',
+        hash: '4DEFEB42BAAB2788723759D95B7550BCE460855563ED977036248F5B94C842FC',
+        source: TokenSource.Polygon
+      }
+    ]
   },
 
   '1MPEPE': {
@@ -1875,7 +1911,7 @@ export default {
       },
     ],
 
-      ibcs: [{
+    ibcs: [{
       symbol: 'Pyth',
       decimals: 6,
       isNative: false,


### PR DESCRIPTION
## Changes
- For perp markets, we don't have a `denom` for the base symbol. We just know the `base symbol`, and we're trying to derive the token metadata from `token-metadata` package using `DenomClient.getDenomToken` in the same way that we would if we were trying to derive the metadata via passing the denom. This leads to edge cases and complexity
- In this PR, I propose that simply the flow by grabbing token metadata for derivatives markets "base tokens" via `DenomClient.getTokenMetaDataBySymbol` and then adding a few required fields to return a proper `Token` type. Note that it seems like the only useful fields for a derivative base token is the `name` / `symbol` / `logo` properties. The rest don't seem to be used, which is why I feel like the simplification I'm making here with the new `getDerivativesToken` could be justified

## Note
Placed this in draft because we should test some more before merging, but I'm curious your thoughts on this approach