### PR TITLE
chore: increase wasm tsx gas

### DIFF
--- a/packages/sdk-ts/src/utils/msgs.ts
+++ b/packages/sdk-ts/src/utils/msgs.ts
@@ -20,7 +20,7 @@ export const getGasPriceBasedOnMessage = (msgs: Msgs[]): number => {
 
   if (messageType.includes('MsgExecuteContract')) {
     return new BigNumberInBase(DEFAULT_GAS_LIMIT)
-      .times(2.5)
+      .times(4)
       .times(messages.length)
       .decimalPlaces(0)
       .toNumber()


### PR DESCRIPTION
## Changes
- this should resolve issue from [slack](https://injectivelabsinc.slack.com/archives/C03A9FKG878/p1707321227410239?thread_ts=1707319623.888269&cid=C03A9FKG878)
- the tsx was using more gas than we are assigning for `MsgExecuteContractCompat` messages in `getGasPriceBasedOnMessage`. I tried to bump it up by small amounts, and changing the multiplier from `2.5` to `4` seems to work fine for now