### PR TITLE
chore: add ibcs property to tokens

### DIFF
--- a/packages/sdk-ui-ts/src/utils/bridge.ts
+++ b/packages/sdk-ui-ts/src/utils/bridge.ts
@@ -18,7 +18,7 @@ import {
   PEGGY_TESTNET_GRAPH_URL,
 } from '../constants'
 import { CosmosChainId, TestnetCosmosChainId } from '@injectivelabs/ts-types'
-import { Token, tokenMetaUtils, TokenType } from '@injectivelabs/token-metadata'
+import { getTokenFromMeta, Token, TokenMetaBase, tokenMetaUtils, TokenType } from '@injectivelabs/token-metadata'
 import { TokenMetadataResponse } from 'alchemy-sdk'
 
 export const InProgressStates = [
@@ -324,201 +324,170 @@ export const tokenDenomsPerNetwork = [
 
 export const cosmosChainTokenMetaMap = {
   [CosmosChainId.Cosmoshub]: {
-    ...tokenMetaUtils.getMetaBySymbol('ATOM'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('ATOM') as TokenMetaBase),
     denom:
       'ibc/C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9',
   },
   [CosmosChainId.Osmosis]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('OSMO'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('OSMO') as TokenMetaBase),
       denom:
         'ibc/92E0120F15D037353CFB73C14651FC8930ADC05B93100FD7754D3A689E53B333',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('INJ'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('INJ') as TokenMetaBase),
       denom: 'inj',
     },
   ],
   [CosmosChainId.Terra]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('LUNA'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('LUNA') as TokenMetaBase),
       denom:
         'ibc/B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('UST'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('UST') as TokenMetaBase),
       denom:
         'ibc/B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C',
     },
   ],
   [CosmosChainId.Injective]: {
-    ...tokenMetaUtils.getMetaBySymbol('INJ'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('INJ') as TokenMetaBase),
     denom: 'inj',
   },
   [CosmosChainId.Chihuahua]: {
-    ...tokenMetaUtils.getMetaBySymbol('HUAHUA'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('HUAHUA') as TokenMetaBase),
     denom:
       'ibc/E7807A46C0B7B44B350DA58F51F278881B863EC4DCA94635DAB39E52C30766CB',
   },
   [CosmosChainId.Juno]: {
-    ...tokenMetaUtils.getMetaBySymbol('JUNO'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('JUNO') as TokenMetaBase),
     denom:
       'ibc/D50E26996253EBAA8C684B9CD653FE2F7665D7BDDCA3D48D5E1378CF6334F211',
   },
   [CosmosChainId.Axelar]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('AXL'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('AXL') as TokenMetaBase),
       denom:
         'ibc/B68C1D2682A8B69E20BB921E34C6A3A2B6D1E13E3E8C0092E373826F546DEE65',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('DOT'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('DOT') as TokenMetaBase),
       denom: 'dot-planck',
     },
   ],
   [CosmosChainId.Evmos]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('EVMOS'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('EVMOS') as TokenMetaBase),
       denom:
         'ibc/16618B7F7AC551F48C057A13F4CA5503693FBFF507719A85BC6876B8BD75F821',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('NEOK'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('NEOK') as TokenMetaBase),
       denom:
         'ibc/F6CC233E5C0EA36B1F74AB1AF98471A2D6A80E2542856639703E908B4D93E7C4',
     },
   ],
   [CosmosChainId.Persistence]: {
-    ...tokenMetaUtils.getMetaBySymbol('XPRT'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('XPRT') as TokenMetaBase),
     denom:
       'ibc/B786E7CBBF026F6F15A8DA248E0F18C62A0F7A70CB2DABD9239398C8B5150ABB',
   },
   [CosmosChainId.Secret]: {
-    ...tokenMetaUtils.getMetaBySymbol('SCRT'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('SCRT') as TokenMetaBase),
     denom:
       'ibc/0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A',
   },
   [CosmosChainId.Stride]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('STRD'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('STRD') as TokenMetaBase),
       denom:
         'ibc/3FDD002A3A4019B05A33D324B2F29748E77AF501BEA5C96D1F28B2D6755F9F25',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('INJ'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('INJ') as TokenMetaBase),
       denom: 'inj',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('STINJ'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('STINJ') as TokenMetaBase),
       denom:
         'ibc/AC87717EA002B0123B10A05063E69BCA274BA2C44D842AEEB41558D2856DCE93',
     },
   ],
   [CosmosChainId.Crescent]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('CRE'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('CRE') as TokenMetaBase),
       denom:
         'ibc/3A6DD3358D9F7ADD18CDE79BA10B400511A5DE4AE2C037D7C9639B52ADAF35C6',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('INJ'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('INJ') as TokenMetaBase),
       denom: 'inj',
     },
   ],
   [CosmosChainId.Sommelier]: {
-    ...tokenMetaUtils.getMetaBySymbol('SOMM'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('SOMM') as TokenMetaBase),
     denom:
       'ibc/34346A60A95EB030D62D6F5BDD4B745BE18E8A693372A8A347D5D53DBBB1328B',
   },
   [CosmosChainId.Canto]: {
-    ...tokenMetaUtils.getMetaBySymbol('CANTO'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('CANTO') as TokenMetaBase),
     denom:
       'ibc/D91A2C4EE7CD86BBAFCE0FA44A60DDD9AFBB7EEB5B2D46C0984DEBCC6FEDFAE8',
   },
   [CosmosChainId.Kava]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('KAVA'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('KAVA') as TokenMetaBase),
       denom:
         'ibc/57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205',
     },
     {
-      ...tokenMetaUtils.getMetaBySymbol('USDTkv'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('USDTkv') as TokenMetaBase),
       denom:
         'ibc/4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB',
     },
   ],
   [CosmosChainId.Oraichain]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('ORAI'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('ORAI') as TokenMetaBase),
       denom:
         'ibc/C20C0A822BD22B2CEF0D067400FCCFB6FAEEE9E91D360B4E0725BD522302D565',
     },
   ],
   [TestnetCosmosChainId.Cosmoshub]: {
-    ...tokenMetaUtils.getMetaBySymbol('ATOM'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('ATOM') as TokenMetaBase),
     // TODO: change when IBC connection established
     denom:
       'ibc/48BC9C6ACBDFC1EBA034F1859245D53EA4BF74147189D66F27C23BF966335DFB',
   },
   [TestnetCosmosChainId.Injective]: {
-    ...tokenMetaUtils.getMetaBySymbol('INJ'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('INJ') as TokenMetaBase),
     denom: 'inj',
   },
   [CosmosChainId.Noble]: {
-    ...tokenMetaUtils.getMetaBySymbol('USDCnb'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('USDCnb') as TokenMetaBase),
     denom:
       'ibc/2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E',
   },
   [CosmosChainId.Celestia]: {
-    ...tokenMetaUtils.getMetaBySymbol('TIA'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('TIA') as TokenMetaBase),
     denom:
       'ibc/F51BB221BAA275F2EBF654F70B005627D7E713AFFD6D86AFD1E43CAA886149F4',
   },
   [CosmosChainId.Migaloo]: [
     {
-      ...tokenMetaUtils.getMetaBySymbol('WHALE'),
-      tokenType: TokenType.Ibc,
+      ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('WHALE') as TokenMetaBase),
       denom:
         'ibc/D6E6A20ABDD600742D22464340A7701558027759CE14D12590F8EA869CCCF445',
     },
   ],
   [CosmosChainId.Kujira]: {
-    ...tokenMetaUtils.getMetaBySymbol('KUJI'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('KUJI') as TokenMetaBase),
     denom:
       'ibc/9A115B56E769B92621FFF90567E2D60EFD146E86E867491DB69EEDA9ADC36204',
   },
   [CosmosChainId.Andromeda]: {
-    ...tokenMetaUtils.getMetaBySymbol('ANDR'),
-    tokenType: TokenType.Ibc,
+    ...getTokenFromMeta(tokenMetaUtils.getMetaBySymbol('ANDR') as TokenMetaBase),
     denom:
       'ibc/61FA42C3F0B0F8768ED2CE380EDD3BE0E4CB7E67688F81F70DE9ECF5F8684E1E',
   },

--- a/packages/token-metadata/src/tokens/mappings/mapByHash.ts
+++ b/packages/token-metadata/src/tokens/mappings/mapByHash.ts
@@ -1,16 +1,22 @@
 import { TokenMetaBase } from '../../types'
 
-export const getMappedTokensByHash = (tokens: Record<string, TokenMetaBase>) =>
+  export const getMappedTokensByHash = (tokens: Record<string, TokenMetaBase>) =>
   (Object.keys(tokens) as Array<keyof typeof tokens>).reduce(
     (result, token) => {
-      if (!tokens[token].ibc) {
-        return result
+
+      if (!tokens[token].ibcs || tokens[token].ibcs?.length === 0) {
+        return result;
       }
 
-      return {
-        ...result,
-        [tokens[token].ibc!.hash.toUpperCase()]: tokens[token],
-      }
+      tokens[token].ibcs?.forEach(ibc => {
+        if (ibc.hash) {
+          const hashKey = ibc.hash.toUpperCase();
+
+          result[hashKey] = tokens[token];
+        }
+      });
+
+      return result;
     },
-    {},
-  ) as Record<string, TokenMetaBase>
+    {} as Record<string, TokenMetaBase>
+  );

--- a/packages/token-metadata/src/tokens/mappings/mapBySymbol.ts
+++ b/packages/token-metadata/src/tokens/mappings/mapBySymbol.ts
@@ -11,25 +11,22 @@ export const getMappedTokensBySymbol = (
       const symbolDiffs = symbol !== symbolKey
       const existingKeys = Object.keys(result)
 
-      let ibcResults = {}
-      let cw20Results = {}
-      let splResults = {}
-      let evmResults = {}
-      let erc20Results = {}
-      let cw20sResults = {}
+      let ibcResults = {} as Record<string, TokenMetaBase>
+      let cw20Results = {} as Record<string, TokenMetaBase>
+      let splResults = {} as Record<string, TokenMetaBase>
+      let evmResults = {} as Record<string, TokenMetaBase>
+      let erc20Results = {} as Record<string, TokenMetaBase>
+      let cw20sResults = {} as Record<string, TokenMetaBase>
 
-      if (
-        tokenMeta.ibc &&
-        tokenMeta.ibc.baseDenom &&
-        !existingKeys.includes(tokenMeta.ibc.baseDenom.toUpperCase()) &&
-        !existingKeys.includes(tokenMeta.ibc.symbol.toUpperCase())
-      ) {
-        ibcResults = {
-          [tokenMeta.ibc.baseDenom.toUpperCase()]: tokenMeta,
-          ...(tokenMeta.ibc.symbol && {
-            [tokenMeta.ibc.symbol.toUpperCase()]: tokenMeta,
-          }),
-        }
+      if (tokenMeta.ibcs) {
+        tokenMeta.ibcs.forEach(ibc => {
+          if (ibc.baseDenom && !existingKeys.includes(ibc.baseDenom.toUpperCase())) {
+            ibcResults[ibc.baseDenom.toUpperCase()] = tokenMeta;
+          }
+          if (ibc.symbol && !existingKeys.includes(ibc.symbol.toUpperCase())) {
+            ibcResults[ibc.symbol.toUpperCase()] = tokenMeta;
+          }
+        });
       }
 
       if (tokenMeta.cw20s) {

--- a/packages/token-metadata/src/tokens/tokens/index.ts
+++ b/packages/token-metadata/src/tokens/tokens/index.ts
@@ -8,8 +8,8 @@ import tokens from './tokens'
 const allTokens = { ...tokens, ...cw20Tokens }
 
 export const ibcBaseDenoms = Object.keys(allTokens)
-  .filter((token) => allTokens[token].ibc)
-  .map((token) => allTokens[token].ibc!.baseDenom)
+  .filter((token) => allTokens[token].ibcs)
+  .flatMap((token) => allTokens[token].ibcs!.map(({baseDenom}) => baseDenom))
 
 export default allTokens as Record<string, TokenMeta>
 

--- a/packages/token-metadata/src/tokens/tokens/testnet-tokens.ts
+++ b/packages/token-metadata/src/tokens/tokens/testnet-tokens.ts
@@ -91,13 +91,13 @@ export const testnetTokens = () =>
 
     ASTRO: {
       ...tokens.ASTRO,
-      ibc: {
-        ...tokens.ASTRO.ibc,
+      ibcs: [{
+        ...(tokens.ASTRO.ibcs ? tokens.ASTRO.ibcs[0] : {}),
         hash: 'E8AC6B792CDE60AB208CA060CA010A3881F682A7307F624347AB71B6A0B0BF89',
         path: 'transfer/channel-13',
         channelId: 'channel-13',
         baseDenom: 'ASTRO',
-      },
+      }],
     },
 
     SOL: {

--- a/packages/token-metadata/src/tokens/tokens/tokens.ts
+++ b/packages/token-metadata/src/tokens/tokens/tokens.ts
@@ -108,7 +108,7 @@ export default {
       address: '0xdAC17F958D2ee523a2206206994597C13D831ec7',
     },
 
-    ibc: {
+    ibcs: [{
       decimals: 6,
       symbol: 'USDTkv',
       isNative: true,
@@ -116,7 +116,8 @@ export default {
       path: 'transfer/channel-143',
       channelId: 'channel-143',
       hash: '4ABBEF4C8926DDDB320AE5188CFD63267ABBCEFC0583E4AE05D6E5AA2401DDAB',
-    },
+      source: TokenSource.Cosmos
+    }],
 
     cw20s: [
       {
@@ -190,7 +191,7 @@ export default {
       },
     ],
 
-    ibc: {
+    ibcs: [{
       decimals: 6,
       symbol: 'USDCnb',
       baseDenom: 'uusdc',
@@ -198,7 +199,8 @@ export default {
       channelId: 'channel-148',
       path: 'transfer/channel-148',
       hash: '2CBC2EA121AE42563B08028466F37B600F2D7D4282342DE938283CC3FB2BC00E',
-    },
+      source: TokenSource.Cosmos
+    }],
 
     spl: {
       decimals: 6,
@@ -639,7 +641,7 @@ export default {
       address: '0x8D983cb9388EaC77af0474fA441C4815500Cb7BB',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'ATOM',
       decimals: 6,
       isNative: true,
@@ -647,7 +649,8 @@ export default {
       path: 'transfer/channel-1',
       channelId: 'channel-1',
       hash: 'C4CFF46FD6DE35CA4CF4CE031E643C8FDC9BA4B99AE598E9B0ED98FE3A2319F9',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   UPHOTON: {
@@ -661,7 +664,7 @@ export default {
       address: '0x8D983cb9388EaC77af0474fA441C4815500Cb7BB',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'UPHOTON',
       decimals: 6,
       isNative: true,
@@ -669,7 +672,8 @@ export default {
       path: 'transfer/channel-2',
       channelId: 'channel-2',
       hash: '48BC9C6ACBDFC1EBA034F1859245D53EA4BF74147189D66F27C23BF966335DFB',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   LUNA: {
@@ -683,7 +687,7 @@ export default {
       address: '0xd2877702675e6cEb975b4A1dFf9fb7BAF4C91ea9',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'LUNA',
       decimals: 6,
       isNative: true,
@@ -691,7 +695,8 @@ export default {
       path: 'transfer/channel-4',
       channelId: 'channel-4',
       hash: 'B8AF5D92165F35AB31F3FC7C7B444B9D240760FA5D406C49D24862BD0284E395',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   UST: {
@@ -705,7 +710,7 @@ export default {
       address: '0xa47c8bf37f92aBed4A126BDA807A7b7498661acD',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'UST',
       decimals: 18,
       isNative: true,
@@ -713,7 +718,8 @@ export default {
       path: 'transfer/channel-4',
       channelId: 'channel-4',
       hash: 'B448C0CA358B958301D328CCDC5D5AD642FC30A6D3AE106FF721DB315F3DDE5C',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   GF: {
@@ -745,7 +751,7 @@ export default {
     coinGeckoId: 'osmosis',
     logo: 'osmo.png',
 
-    ibc: {
+    ibcs: [{
       symbol: 'OSMO',
       decimals: 6,
       isNative: true,
@@ -753,7 +759,8 @@ export default {
       path: 'transfer/channel-8',
       channelId: 'channel-8',
       hash: '92E0120F15D037353CFB73C14651FC8930ADC05B93100FD7754D3A689E53B333',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   TAB: {
@@ -773,7 +780,7 @@ export default {
     logo: 'chihuahua.jpeg',
     coinGeckoId: 'chihuahua-token',
 
-    ibc: {
+    ibcs: [{
       symbol: 'HUAHUA',
       decimals: 6,
       isNative: true,
@@ -781,7 +788,8 @@ export default {
       path: 'transfer/channel-76',
       channelId: 'channel-76',
       hash: 'E7807A46C0B7B44B350DA58F51F278881B863EC4DCA94635DAB39E52C30766CB',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   JUNO: {
@@ -789,7 +797,7 @@ export default {
     logo: 'juno.jpeg',
     coinGeckoId: 'juno-network',
 
-    ibc: {
+    ibcs: [{
       symbol: 'JUNO',
       decimals: 6,
       isNative: true,
@@ -797,7 +805,8 @@ export default {
       path: 'transfer/channel-78',
       channelId: 'channel-78',
       hash: 'D50E26996253EBAA8C684B9CD653FE2F7665D7BDDCA3D48D5E1378CF6334F211',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   WHALE: {
@@ -805,7 +814,7 @@ export default {
     logo: 'whale.png',
     coinGeckoId: 'white-whale',
 
-    ibc: {
+    ibcs: [{
       symbol: 'WHALE',
       decimals: 6,
       isNative: true,
@@ -813,7 +822,8 @@ export default {
       path: 'transfer/channel-102',
       channelId: 'channel-102',
       hash: 'D6E6A20ABDD600742D22464340A7701558027759CE14D12590F8EA869CCCF445',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   NOIS: {
@@ -821,7 +831,7 @@ export default {
     coinGeckoId: 'nois',
     logo: 'nois.png',
 
-    ibc: {
+    ibcs: [{
       symbol: 'NOIS',
       decimals: 6,
       isNative: true,
@@ -829,7 +839,8 @@ export default {
       path: 'transfer/channel-138',
       channelId: 'channel-138',
       hash: 'DD9182E8E2B13C89D6B4707C7B43E8DB6193F9FF486AFA0E6CF86B427B0D231A',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   AXL: {
@@ -843,7 +854,7 @@ export default {
       address: '0x3eacbDC6C382ea22b78aCc158581A55aaF4ef3Cc',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'AXL',
       decimals: 6,
       isNative: true,
@@ -851,7 +862,8 @@ export default {
       path: 'transfer/channel-84',
       channelId: 'channel-84',
       hash: 'B68C1D2682A8B69E20BB921E34C6A3A2B6D1E13E3E8C0092E373826F546DEE65',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   BAYC: {
@@ -880,7 +892,7 @@ export default {
     logo: 'scrt.png',
     coinGeckoId: 'secret',
 
-    ibc: {
+    ibcs: [{
       symbol: 'SCRT',
       decimals: 6,
       isNative: true,
@@ -888,7 +900,8 @@ export default {
       path: 'transfer/channel-88',
       channelId: 'channel-88',
       hash: '0954E1C28EB7AF5B72D24F3BC2B47BBB2FDF91BDDFD57B74B99E133AED40972A',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   XPRT: {
@@ -896,7 +909,7 @@ export default {
     logo: 'xprt.png',
     coinGeckoId: 'persistence',
 
-    ibc: {
+    ibcs: [{
       symbol: 'XPRT',
       decimals: 6,
       isNative: true,
@@ -904,7 +917,8 @@ export default {
       path: 'transfer/channel-82',
       channelId: 'channel-82',
       hash: 'B786E7CBBF026F6F15A8DA248E0F18C62A0F7A70CB2DABD9239398C8B5150ABB',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   EVMOS: {
@@ -912,7 +926,7 @@ export default {
     logo: 'evmos.png',
     coinGeckoId: 'evmos',
 
-    ibc: {
+    ibcs: [{
       symbol: 'EVMOS',
       decimals: 18,
       isNative: true,
@@ -920,7 +934,8 @@ export default {
       path: 'transfer/channel-83',
       channelId: 'channel-83',
       hash: '16618B7F7AC551F48C057A13F4CA5503693FBFF507719A85BC6876B8BD75F821',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   STX: {
@@ -943,7 +958,7 @@ export default {
       address: '0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'DOT',
       decimals: 10,
       isNative: false,
@@ -951,7 +966,8 @@ export default {
       path: 'transfer/channel-84',
       channelId: 'channel-84',
       hash: '624BA9DD171915A2B9EA70F69638B2CEA179959850C1A586F6C485498F29EDD4',
-    },
+      source: TokenSource.Cosmos
+    }],
 
     cw20s: [
       {
@@ -967,7 +983,7 @@ export default {
     logo: 'stride.png',
     coinGeckoId: 'stride',
 
-    ibc: {
+    ibcs: [{
       symbol: 'STRD',
       decimals: 6,
       isNative: true,
@@ -975,7 +991,8 @@ export default {
       path: 'transfer/channel-89',
       channelId: 'channel-89',
       hash: '3FDD002A3A4019B05A33D324B2F29748E77AF501BEA5C96D1F28B2D6755F9F25',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   CRE: {
@@ -983,7 +1000,7 @@ export default {
     logo: 'crescent.jpeg',
     coinGeckoId: 'crescent-network',
 
-    ibc: {
+    ibcs: [{
       symbol: 'CRE',
       decimals: 6,
       isNative: true,
@@ -991,7 +1008,8 @@ export default {
       path: 'transfer/channel-90',
       channelId: 'channel-90',
       hash: '3A6DD3358D9F7ADD18CDE79BA10B400511A5DE4AE2C037D7C9639B52ADAF35C6',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   ASTRO: {
@@ -999,7 +1017,7 @@ export default {
     logo: 'astroport.png',
     coinGeckoId: 'astroport-fi',
 
-    ibc: {
+    ibcs: [{
       symbol: 'ASTRO',
       decimals: 6,
       isNative: true,
@@ -1008,7 +1026,8 @@ export default {
       path: 'transfer/channel-104',
       channelId: 'channel-104',
       hash: 'EBD5A24C554198EBAF44979C5B4D2C2D312E6EBAB71962C92F735499C7575839',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   SOL: {
@@ -1032,7 +1051,7 @@ export default {
       },
     ],
 
-    ibc: {
+    ibcs: [{
       symbol: 'SOLgw',
       // symbol: 'SOL',
       decimals: 8,
@@ -1042,7 +1061,8 @@ export default {
       path: 'transfer/channel-183',
       channelId: 'channel-183',
       hash: 'A8B0B746B5AB736C2D8577259B510D56B8AF598008F68041E3D634BCDE72BE97',
-    },
+      source: TokenSource.Solana
+    }],
   },
 
   SOMM: {
@@ -1056,7 +1076,7 @@ export default {
       address: '0xa670d7237398238DE01267472C6f13e5B8010FD1',
     },
 
-    ibc: {
+    ibcs: [{
       symbol: 'SOMM',
       decimals: 6,
       isNative: true,
@@ -1064,7 +1084,8 @@ export default {
       path: 'transfer/channel-93',
       channelId: 'channel-93',
       hash: '34346A60A95EB030D62D6F5BDD4B745BE18E8A693372A8A347D5D53DBBB1328B',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   ETHBTCTREND: {
@@ -1171,7 +1192,7 @@ export default {
     logo: 'canto.webp',
     coinGeckoId: 'canto',
 
-    ibc: {
+    ibcs: [{
       symbol: 'CANTO',
       decimals: 18,
       isNative: true,
@@ -1179,7 +1200,8 @@ export default {
       path: 'transfer/channel-99',
       channelId: 'channel-99',
       hash: 'D91A2C4EE7CD86BBAFCE0FA44A60DDD9AFBB7EEB5B2D46C0984DEBCC6FEDFAE8',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   QAT: {
@@ -1459,7 +1481,7 @@ export default {
     logo: 'stinj.png',
     coinGeckoId: 'stride-staked-injective',
 
-    ibc: {
+    ibcs: [{
       symbol: 'STINJ',
       decimals: 18,
       isNative: true,
@@ -1467,7 +1489,8 @@ export default {
       path: 'transfer/channel-89',
       channelId: 'channel-89',
       hash: 'AC87717EA002B0123B10A05063E69BCA274BA2C44D842AEEB41558D2856DCE93',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   XRP: {
@@ -1621,7 +1644,7 @@ export default {
     logo: 'kava.webp',
     coinGeckoId: 'kava',
 
-    ibc: {
+    ibcs: [{
       symbol: 'KAVA',
       decimals: 6,
       isNative: true,
@@ -1629,7 +1652,8 @@ export default {
       path: 'transfer/channel-143',
       channelId: 'channel-143',
       hash: '57AA1A70A4BC9769C525EBF6386F7A21536E04A79D62E1981EFCEF9428EBB205',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   SEI: {
@@ -1696,7 +1720,7 @@ export default {
     logo: 'neok.png',
     coinGeckoId: '',
 
-    ibc: {
+    ibcs: [{
       symbol: 'NEOK',
       decimals: 18,
       isNative: true,
@@ -1704,7 +1728,8 @@ export default {
       path: 'transfer/channel-83',
       channelId: 'channel-83',
       hash: 'F6CC233E5C0EA36B1F74AB1AF98471A2D6A80E2542856639703E908B4D93E7C4',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   ORAI: {
@@ -1712,7 +1737,7 @@ export default {
     logo: 'orai.png',
     coinGeckoId: 'oraichain-token',
 
-    ibc: {
+    ibcs: [{
       symbol: 'ORAI',
       decimals: 6,
       isNative: true,
@@ -1720,7 +1745,8 @@ export default {
       path: 'transfer/channel-147',
       channelId: 'channel-147',
       hash: 'C20C0A822BD22B2CEF0D067400FCCFB6FAEEE9E91D360B4E0725BD522302D565',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   EVINDEX: {
@@ -1746,7 +1772,7 @@ export default {
     logo: 'tia.webp',
     coinGeckoId: 'celestia',
 
-    ibc: {
+    ibcs: [{
       symbol: 'TIA',
       decimals: 6,
       isNative: true,
@@ -1754,7 +1780,8 @@ export default {
       path: 'transfer/channel-152',
       channelId: 'channel-152',
       hash: 'F51BB221BAA275F2EBF654F70B005627D7E713AFFD6D86AFD1E43CAA886149F4',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   TALIS: {
@@ -1802,7 +1829,7 @@ export default {
     logo: 'kuji.webp',
     coinGeckoId: 'kujira',
 
-    ibc: {
+    ibcs: [{
       symbol: 'KUJI',
       decimals: 6,
       isNative: true,
@@ -1810,7 +1837,8 @@ export default {
       path: 'transfer/channel-98',
       channelId: 'channel-98',
       hash: '9A115B56E769B92621FFF90567E2D60EFD146E86E867491DB69EEDA9ADC36204',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   'USDC-MPL': {
@@ -1845,6 +1873,18 @@ export default {
         address: 'inj1tjcf9497fwmrnk22jfu5hsdq82qshga54ajvzy',
       },
     ],
+
+      ibcs: [{
+      symbol: 'Pyth',
+      decimals: 6,
+      isNative: false,
+      baseDenom:
+        'factory/wormhole14ejqjyq8um4p3xfqj74yld5waqljf88fz25yxnma0cngspxe3les00fpjx/B8ohBnfisop27exk2gtNABJyYjLwQA7ogrp5uNzvZCoy',
+      path: 'transfer/channel-183',
+      channelId: 'channel-183',
+      hash: 'F3330C1B8BD1886FE9509B94C7B5398B892EA41420D2BC0B7C6A53CB8ED761D6',
+      source: TokenSource.Solana
+    }],
   },
 
   TIX: {
@@ -2257,7 +2297,7 @@ export default {
     coinGeckoId: 'levana-protocol',
     logo: 'lvn.png',
 
-    ibc: {
+    ibcs: [{
       symbol: 'LVN',
       decimals: 6,
       isNative: true,
@@ -2265,7 +2305,8 @@ export default {
       path: 'transfer/channel-8',
       channelId: 'channel-8',
       hash: '4971C5E4786D5995EC7EF894FCFA9CF2E127E95D5D53A982F6A062F3F410EDB8',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   KINJA: {
@@ -2764,7 +2805,7 @@ export default {
     logo: 'orne.png',
     coinGeckoId: 'orne',
 
-    ibc: {
+    ibcs: [{
       symbol: 'ORNE',
       decimals: 6,
       isNative: true,
@@ -2773,14 +2814,15 @@ export default {
       path: 'transfer/channel-116',
       channelId: 'channel-116',
       hash: '3D99439444ACDEE71DBC4A774E49DB74B58846CCE31B9A868A7A61E4C14D321E',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   DROGO: {
     name: 'DROGO',
     logo: 'drogo.png',
 
-    ibc: {
+    ibcs: [{
       symbol: 'DROGO',
       decimals: 6,
       isNative: true,
@@ -2789,7 +2831,8 @@ export default {
       path: 'transfer/channel-118',
       channelId: 'channel-118',
       hash: 'ibc/565FE65B82C091F8BAD1379FA1B4560C036C07913355ED4BD8D156DA63F43712',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   RAMEN: {
@@ -2883,7 +2926,7 @@ export default {
     logo: 'WOSMO.png',
     coinGeckoId: '',
 
-    ibc: {
+    ibcs: [{
       symbol: 'WOSMO',
       decimals: 6,
       isNative: true,
@@ -2891,7 +2934,8 @@ export default {
       path: 'transfer/channel-8',
       channelId: 'channel-8',
       hash: 'DD648F5D3CDA56D0D8D8820CF703D246B9FC4007725D8B38D23A21FF1A1477E3',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   IKINGS: {
@@ -2973,7 +3017,7 @@ export default {
     logo: 'andromeda.webp',
     coinGeckoId: 'andromeda-2',
 
-    ibc: {
+    ibcs: [{
       symbol: 'ANDR',
       decimals: 6,
       isNative: true,
@@ -2981,7 +3025,8 @@ export default {
       path: 'transfer/channel-213',
       channelId: 'channel-213',
       hash: '61FA42C3F0B0F8768ED2CE380EDD3BE0E4CB7E67688F81F70DE9ECF5F8684E1E',
-    },
+      source: TokenSource.Cosmos
+    }],
   },
 
   hINJ: {

--- a/packages/token-metadata/src/types.ts
+++ b/packages/token-metadata/src/types.ts
@@ -93,6 +93,10 @@ export interface Cw20TokenMetaWithSource extends Cw20TokenMeta {
   source?: TokenSource
 }
 
+export interface IbcTokenMetaWithSource extends IbcTokenMeta {
+  source?: TokenSource
+}
+
 export interface TokenMetaBase {
   name?: string
   logo?: string
@@ -102,7 +106,7 @@ export interface TokenMetaBase {
   tokenVerification?: TokenVerification
   coinGeckoId?: string
 
-  ibc?: Omit<IbcTokenMeta, 'tokenType'>
+  ibcs?: Array<Omit<IbcTokenMetaWithSource, 'tokenType'>>
   spl?: Omit<SplTokenMeta, 'tokenType'>
   cw20s?: Array<Omit<Cw20TokenMetaWithSource, 'tokenType'>>
   erc20?: Omit<Erc20TokenMeta, 'tokenType'>
@@ -158,6 +162,10 @@ export interface Cw20TokenSingle extends BaseToken {
 
 export interface Cw20TokenMultiple extends BaseToken {
   cw20s: Cw20TokenMetaWithSource[]
+}
+
+export interface IbcTokenMultiple extends BaseToken {
+  ibcs: IbcTokenMetaWithSource[]
 }
 
 export interface Cw20Token extends BaseToken {

--- a/packages/token-metadata/src/utils/helpers.ts
+++ b/packages/token-metadata/src/utils/helpers.ts
@@ -71,9 +71,9 @@ export const getIbcDenomFromSymbolOrName = (
     return `ibc/${ibcHash}`
   }
 
-
+  const defaultIbcHash = meta.ibcs?.find((ibc) => ibc.source === TokenSource.Cosmos)?.hash
   const [ibc] = meta.ibcs || []
-  const ibcHash = ibc?.hash
+  const ibcHash = defaultIbcHash || ibc?.hash
 
   return `ibc/${ibcHash}`
 }
@@ -128,8 +128,9 @@ export const getIbcMeta = (
   const ibcMetaFromIbcs = token.ibcs?.find((meta) =>
     denomToLowerCase.includes(meta.hash.toLowerCase()),
   )
+  const defaultIbcMeta = token.ibcs?.find((meta) => meta.source === TokenSource.Cosmos)
 
-  return ibcMetaFromIbcs || token.ibcs?.[0] || undefined
+  return ibcMetaFromIbcs || defaultIbcMeta ||  token.ibcs?.[0] || undefined
 }
 
 export const getNativeTokenFactoryMeta = (

--- a/packages/token-metadata/src/utils/helpers.ts
+++ b/packages/token-metadata/src/utils/helpers.ts
@@ -11,6 +11,7 @@ import {
   IbcTokenMeta,
   Cw20TokenMeta,
   TokenVerification,
+  IbcTokenMetaWithSource,
   Cw20TokenMetaWithSource,
   NativeTokenFactoryMeta,
 } from '../types'
@@ -48,6 +49,7 @@ export const getPeggyDenomFromSymbolOrName = (
 export const getIbcDenomFromSymbolOrName = (
   symbolOrName: string,
   network: Network = Network.Mainnet,
+  source?: TokenSource,
 ) => {
   const tokenMetaUtils = TokenMetaUtilsFactory.make(network)
   const metaFromName = tokenMetaUtils.getMetaBySymbol(symbolOrName)
@@ -57,11 +59,23 @@ export const getIbcDenomFromSymbolOrName = (
     return
   }
 
-  if (!metaFromSymbol?.ibc && !metaFromName?.ibc) {
+  if (!metaFromSymbol?.ibcs && !metaFromName?.ibcs) {
     return
   }
 
-  return `ibc/${(metaFromSymbol || metaFromName)?.ibc?.hash}`
+  const meta = (metaFromSymbol || metaFromName)!
+
+    if (source) {
+    const ibcHash = meta?.ibcs?.find((ibc) => ibc.source === source)?.hash
+
+    return `ibc/${ibcHash}`
+  }
+
+
+  const [ibc] = meta.ibcs || []
+  const ibcHash = ibc?.hash
+
+  return `ibc/${ibcHash}`
 }
 
 export const getCw20FromSymbolOrName = (
@@ -105,6 +119,17 @@ export const getCw20Meta = (
   )
 
   return cw20MetaFromCw20s || token.cw20s?.[0] || undefined
+}
+
+export const getIbcMeta = (
+  token: TokenBase,
+): IbcTokenMetaWithSource | IbcTokenMeta | undefined => {
+  const denomToLowerCase = token.denom.toLowerCase()
+  const ibcMetaFromIbcs = token.ibcs?.find((meta) =>
+    denomToLowerCase.includes(meta.hash.toLowerCase()),
+  )
+
+  return ibcMetaFromIbcs || token.ibcs?.[0] || undefined
 }
 
 export const getNativeTokenFactoryMeta = (

--- a/packages/token-metadata/src/utils/meta.ts
+++ b/packages/token-metadata/src/utils/meta.ts
@@ -5,8 +5,10 @@ import {
   TokenBase,
   TokenType,
   Cw20TokenMetaWithSource,
+  IbcTokenMetaWithSource,
 } from '../types'
 import {
+  getIbcMeta,
   getCw20Meta,
   isCw20ContractAddress,
   getNativeTokenFactoryMeta,
@@ -152,7 +154,9 @@ export const getTokenDecimals = (token: Token) => {
   }
 
   if (token.denom.startsWith('ibc')) {
-    return token.ibc?.decimals || token.decimals
+    const meta = getIbcMeta(token)
+
+    return meta?.decimals || token.decimals
   }
 
   if (token.denom.startsWith('peggy')) {
@@ -259,12 +263,15 @@ export const getTokenInfo = (token: TokenBase) => {
   }
 
   // Including tokens that can be searched by baseDenom symbol
-  if (token.denom.startsWith('ibc') || token.ibc) {
+  if (token.denom.startsWith('ibc') || token.ibcs) {
+    const meta = getIbcMeta(token) as IbcTokenMetaWithSource
+
+
     return {
-      symbol: token.ibc?.symbol || token.symbol || '',
-      name: token.ibc?.name || token.name || '',
-      logo: token.ibc?.logo || token.logo || '',
-      decimals: token.ibc?.decimals || token.decimals || 6,
+      symbol: meta?.symbol || token.symbol || '',
+      name: meta?.name || token.name || '',
+      logo: meta?.logo || token.logo || '',
+      decimals: meta?.decimals || token.decimals || 6,
       tokenType,
     }
   }

--- a/packages/token-metadata/src/utils/token.ts
+++ b/packages/token-metadata/src/utils/token.ts
@@ -28,6 +28,7 @@ export const getTokenFromMetaIncludingIbcBaseDenoms = (
     tokenType: isBaseIbcDenom ? TokenType.Ibc : tokenMeta.tokenType,
     denom: denom || '',
     ...(token.cw20s && { cw20: getCw20Meta(token) }),
+    ...(token.ibcs && { ibc: getIbcMeta(token) }),
   } as Token
 }
 

--- a/packages/token-metadata/src/utils/token.ts
+++ b/packages/token-metadata/src/utils/token.ts
@@ -1,6 +1,6 @@
 import { ibcBaseDenoms } from '../tokens/tokens'
 import { Token, TokenMetaBase, TokenType } from '../types'
-import { getCw20Meta } from './helpers'
+import { getCw20Meta, getIbcMeta } from './helpers'
 import { getTokenInfo } from './meta'
 
 /**
@@ -13,7 +13,7 @@ export const getTokenFromMetaIncludingIbcBaseDenoms = (
   denom?: string,
 ): Token => {
   const isBaseIbcDenom =
-    ibcBaseDenoms.includes(denom || '') || meta.ibc?.baseDenom === denom
+    ibcBaseDenoms.includes(denom || '') || meta.ibcs?.find(ibc => ibc.baseDenom.includes(denom || ''))
 
   const tokenMeta = getTokenFromMeta(meta, denom)
 
@@ -45,5 +45,6 @@ export const getTokenFromMeta = (
     ...token,
     ...tokenInfo,
     ...(token.cw20s && { cw20: getCw20Meta(token) }),
+    ...(token.ibcs && { ibc: getIbcMeta(token) }),
   } as Token
 }


### PR DESCRIPTION
## Situation
- tokens coming from networks such as `Ethereum`/`Solana`/ etc via WH will now be minted on Injective as `ibc` bank denoms, i.e. `ibc/<ibcHash>`
- therefore, the `token-metadata` package will need to support multiple `ibc` metadata's per symbol `key` in the `tokens.ts` file. This PR is an initiative to accomplish this

## Engineering decisions
-  refactoring `.ibc` properties on token meta in `tokens.ts` to be `.ibcs`, each with a different `source`.  If they come from a cosmos chain, it'd be `source: TokenSource.Cosmos`, for example. The implementation is similar to how we abstracted `cw20` to  `cw20s`, so now there can be multiple ibc subdenoms from different sources.
- we use getTokenInfo to grab the correct ibc object from a token's `.ibcs` array, using the `TokenSource`, and the products will be returned a `Token` with a final `.ibc` property

## Testing Complete
- hooked up `token-metadata` and `sdk-ui-ts` to `helix` and no issues
- hooked up `token-metadata` and `sdk-ui-ts` to `explorer` and no issues. checked a bunch of `ibc` tokens on `assets` page to see decimals are ok. also checked balance of a cosmos wallet holding some cosmos tokens, and decimals were ok
- hooked up to `hub` and some light refactors were needed to the hub based off this refactor but nbd. then, I checked `wallets` page and decimals looked good for ibc tokens. I transferred some ibc tokens bi-directionally, and token decimals/balances looked good. Also, tsx history token decimals were legit

## Note
This PR should not be merged until the issue described in this [notion](https://www.notion.so/injective/Token-Meta-By-Symbol-Inquiry-a02bcf4493ee4643b4e4211f7e277524) has been resolved