### PR TITLE
chore: enable wallet after setting

### DIFF
--- a/packages/sdk-ui-ts/src/utils/alchemy.ts
+++ b/packages/sdk-ui-ts/src/utils/alchemy.ts
@@ -3,7 +3,7 @@ import { TokenType, TokenVerification } from '@injectivelabs/token-metadata'
 import { TokenMetadataResponse } from 'alchemy-sdk'
 
 export const getKeyFromRpcUrl = (rpcUrl: string) => {
-  if (!rpcUrl.includes('alchemyapi.io')) {
+  if (!rpcUrl.includes('alchemyapi.io') && !rpcUrl.includes('alchemy.com')) {
     return rpcUrl
   }
 

--- a/packages/token-metadata/src/tokens/tokens/testnet-tokens.ts
+++ b/packages/token-metadata/src/tokens/tokens/testnet-tokens.ts
@@ -54,7 +54,7 @@ export const testnetTokens = () =>
       ...tokens.INJ,
       erc20: {
         ...tokens.INJ.erc20,
-        address: '0xAD1794307245443B3Cb55d88e79EEE4d8a548C03',
+        address: '0x5512c04B6FF813f3571bDF64A1d74c98B5257332',
       },
     },
 

--- a/packages/wallet-ts/src/strategies/wallet-strategy/WalletStrategy.ts
+++ b/packages/wallet-ts/src/strategies/wallet-strategy/WalletStrategy.ts
@@ -141,6 +141,7 @@ export default class WalletStrategy {
   public setWallet(wallet: Wallet) {
     this.disconnect()
     this.wallet = wallet
+    this.enable()
   }
 
   public getStrategy(): ConcreteWalletStrategy {

--- a/packages/wallet-ts/src/utils/alchemy.ts
+++ b/packages/wallet-ts/src/utils/alchemy.ts
@@ -1,5 +1,5 @@
 export const getKeyFromRpcUrl = (rpcUrl: string) => {
-  if (!rpcUrl.includes('alchemyapi.io')) {
+  if (!rpcUrl.includes('alchemyapi.io') && !rpcUrl.includes('alchemy.com')) {
     return rpcUrl
   }
 


### PR DESCRIPTION
## Changes
- after `wallet-ts`'s `setWallet` disconnects and sets the wallet, we add a step to enable the wallet, which finds the wallet provider and gets their account

## Testing Complete
- linked `wallet-ts` to new bridge and tried a SOL migration using Phantom
- tried connecting to keplr/leap/ledger without issue
- tried ibc tranfer with keplr

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved wallet connection process within the app.
- **Bug Fixes**
	- Updated the address of an ERC20 token within the testnet tokens.
- **Documentation**
	- Enhanced error handling and messaging for improved user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->