### PR TITLE
chore: get coingeckoId from erc20 address

### DIFF
--- a/packages/token-utils/src/CoinGeckoApi.ts
+++ b/packages/token-utils/src/CoinGeckoApi.ts
@@ -57,6 +57,31 @@ export default class CoinGeckoApi {
     }
   }
 
+  async fetchErc20TokenCoinId(
+    tokenAddress: string,
+    options: Record<string, any> | undefined = {},
+  ) {
+    try {
+      const actualParams = {
+        x_cg_pro_api_key: this.apiKey,
+        ...options,
+      }
+
+      const { data } = (await this.httpClient.get(
+        `/coins/ethereum/contract/${tokenAddress}`,
+        actualParams,
+      )) as CoinGeckoReturnObject<CoinGeckoCoinResponse>
+
+      return data?.id
+    } catch (e: unknown) {
+      if (e instanceof HttpRequestException) {
+        throw e
+      }
+
+      throw new HttpRequestException(new Error((e as any).message))
+    }
+  }
+
   async fetchPrice(
     coinId: string,
     options: Record<string, any> | undefined = {},


### PR DESCRIPTION
## Situation
- on new bridge, we want to be able to withdraw arbitrary erc-20 tokens, so we need their `coingeckoId` in order to estimate withdrawal fee
- this PR enables fetching `coingeckoId` from `CoingeckoApi` at the product level

## Potential Enhancements
 - we could use this new method to enable grabbing `coingeckoId` for erc20 denoms via `DenomClientAsync().getDenomToken` at the step:
 ```
    if (isErc20 && this.web3Client) {
      const contractAddress = denom.startsWith('peggy')
        ? denom.replace('peggy', '')
        : denom

      const response = await this.web3Client.fetchTokenMetaData(contractAddress)

      return getTokenFromAlchemyTokenMetaResponse(denom, response)
    }
```
I didn't see immediate use case for that so figured not worth adding extra api call to this. lmk if think useful to add though

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a method to fetch CoinGecko coin IDs for ERC20 tokens, improving data retrieval capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->