### PR TITLE
Fix Eip712TypedDataV2 for date-type

### DIFF
--- a/packages/sdk-ts/src/core/modules/tx/eip712/eip712.ts
+++ b/packages/sdk-ts/src/core/modules/tx/eip712/eip712.ts
@@ -51,6 +51,13 @@ export const getEip712TypedData = ({
   }
 }
 
+const Eip712TypedDataV2Replacer =  function (this: Record<string, any>, key: string, value: any) {
+  if (this[key] instanceof Date) {
+      return this[key].toJSON().slice(0, -5) + 'Z';
+  }
+  return value;
+}
+
 export const getEip712TypedDataV2 = ({
   msgs,
   tx,
@@ -72,7 +79,7 @@ export const getEip712TypedDataV2 = ({
     primaryType: 'Tx',
     ...getEip712DomainV2(ethereumChainId),
     message: {
-      context: JSON.stringify(getEipTxContext({ ...tx, fee })),
+      context: JSON.stringify(getEipTxContext({ ...tx, fee }), Eip712TypedDataV2Replacer),
       msgs: JSON.stringify(eip712Msgs),
     },
   }


### PR DESCRIPTION
Hi, the **getEip712TypedDataV2** method doesn't work correctly for a Date. As a consequence, a transaction that has Messages with Date type fields cannot be correctly signed. For example for a message of type MsgGrant method generate:

![Screenshot 2024-04-30 at 15 39 52](https://github.com/InjectiveLabs/injective-ts/assets/1541637/ef36695b-1075-4022-9712-c72d31dc53e9)


Blockchain expected:

![Screenshot 2024-04-30 at 15 41 24](https://github.com/InjectiveLabs/injective-ts/assets/1541637/f0965dfc-04d9-43ea-b56b-ab2d9e5d9261)


I'm not sure if this patch is good and won't break other Messages that use the Date type.  It may also be better to make this modification on the blockchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced handling of Date objects in transaction data processing to improve accuracy and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->