### PR TITLE
feat: dynamic import es or cjs module when build wallet-ts

### DIFF
--- a/packages/wallet-ts/package.json
+++ b/packages/wallet-ts/package.json
@@ -19,7 +19,9 @@
   },
   "scripts": {
     "postinstall": "link-module-alias",
-    "build": "tsc --build tsconfig.build.json && tsc --build tsconfig.build.esm.json && yarn build:post && link-module-alias",
+    "build:cjs": "BUILD_TYPE=CJS node ./transfromPath.js && tsc --build tsconfig.build.json",
+    "build:esm": "BUILD_TYPE=ESM node ./transfromPath.js && tsc --build tsconfig.build.esm.json",
+    "build": "yarn build:esm && yarn build:cjs && yarn build:post && link-module-alias",
     "build:watch": "tsc --build -w tsconfig.build.json && tsc -w --build tsconfig.build.esm.json && yarn build:post && link-module-alias",
     "build:post": "shx cp ../../etc/stub/package.json.stub dist/cjs/package.json && shx cp ../../etc/stub/package.esm.json.stub dist/esm/package.json",
     "clean": "tsc --build tsconfig.build.json --clean && tsc --build tsconfig.build.esm.json --clean && shx rm -rf coverage *.log junit.xml dist && jest --clearCache && shx mkdir -p dist",

--- a/packages/wallet-ts/transfromPath.js
+++ b/packages/wallet-ts/transfromPath.js
@@ -1,0 +1,31 @@
+const fs = require('fs');
+const path = require('path');
+
+const buildType = process.env.BUILD_TYPE;
+
+const cjsModule = "@ledgerhq/hw-app-eth/lib/services/ledger";
+
+const esmModule = "@ledgerhq/hw-app-eth/lib-es/services/ledger";
+
+const searchString = (buildType === "ESM") ? cjsModule : esmModule;
+const replaceString = (buildType === "ESM") ? esmModule : cjsModule;
+
+const filePath = './src/strategies/wallet-strategy/strategies/Ledger/Base.ts';
+
+fs.readFile(filePath, 'utf8', (err, data) => {
+    if (err) {
+        console.error("Error reading file:", err);
+        return;
+    }
+
+    const updatedData = data.replace(new RegExp(searchString, 'g'), replaceString);
+
+    fs.writeFile(filePath, updatedData, 'utf8', (err) => {
+        if (err) {
+            console.error("Error writing file:", err);
+            return;
+        }
+
+        console.log(`Replaced in ${filePath}`);
+    });
+});


### PR DESCRIPTION
### Summary

- **Bug Fix**

- Fixed importing cjs module when build wallet-ts into esm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refactored build scripts to separate CommonJS (CJS) and ECMAScript Module (ESM) builds into distinct commands.
  - Introduced a new build script to orchestrate both ESM and CJS builds along with other necessary steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->