### PR TITLE
chore: token holders api

### DIFF
--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcPortfolioApi.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcPortfolioApi.spec.ts
@@ -1,4 +1,5 @@
 import { getNetworkEndpoints, Network } from '@injectivelabs/networks'
+import { INJ_DENOM } from '@injectivelabs/utils'
 import { mockFactory } from '@injectivelabs/test-utils'
 import { IndexerGrpcAccountPortfolioTransformer } from '../transformers'
 import { IndexerGrpcAccountPortfolioApi } from './IndexerGrpcPortfolioApi'
@@ -31,4 +32,27 @@ describe('IndexerGrpcAccountPortfolioApi', () => {
       )
     }
   })
+})
+
+test('fetchAccountPortfolioTokenHolders', async () => {
+  try {
+    const response =
+      await indexerGrpcPortfolioApi.fetchAccountPortfolioTokenHolders({
+        denom: INJ_DENOM,
+      })
+
+    expect(response).toBeDefined()
+    expect(response).toEqual(
+      expect.objectContaining<
+        ReturnType<
+          typeof IndexerGrpcAccountPortfolioTransformer.tokenHoldersResponseToTokenHolders
+        >
+      >(response),
+    )
+  } catch (e) {
+    console.error(
+      'IndexerGrpcAccountPortfolioApi.fetchAccountPortfolioTokenHolders => ' +
+        (e as any).message,
+    )
+  }
 })

--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcPortfolioApi.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcPortfolioApi.ts
@@ -104,4 +104,51 @@ export class IndexerGrpcAccountPortfolioApi extends BaseGrpcConsumer {
       })
     }
   }
+
+  async fetchAccountPortfolioTokenHolders({
+    denom,
+    cursor,
+    limit,
+  }: {
+    denom: string
+    cursor?: string
+    limit?: number
+  }) {
+    const request = InjectivePortfolioRpc.TokenHoldersRequest.create()
+
+    request.denom = denom
+
+    if (cursor) {
+      request.cursor = cursor
+    }
+
+    if (limit) {
+      request.limit = limit
+    }
+
+    try {
+      const response =
+        await this.retry<InjectivePortfolioRpc.TokenHoldersResponse>(() =>
+          this.client.TokenHolders(request),
+        )
+
+      return IndexerGrpcAccountPortfolioTransformer.tokenHoldersResponseToTokenHolders(
+        response,
+      )
+    } catch (e: unknown) {
+      if (e instanceof InjectivePortfolioRpc.GrpcWebError) {
+        throw new GrpcUnaryRequestException(new Error(e.toString()), {
+          code: e.code,
+          context: 'TokenHolders',
+          contextModule: this.module,
+        })
+      }
+
+      throw new GrpcUnaryRequestException(e as Error, {
+        code: UnspecifiedErrorCode,
+        context: 'TokenHolders',
+        contextModule: this.module,
+      })
+    }
+  }
 }

--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerAccountPortfolioTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerAccountPortfolioTransformer.ts
@@ -1,6 +1,7 @@
 import { Coin } from '@injectivelabs/ts-types'
 import { GrpcCoin } from '../../../types'
 import {
+  TokenHolders,
   PositionsWithUPNL,
   AccountPortfolioV2,
   SubaccountDepositV2,
@@ -87,9 +88,7 @@ export class IndexerGrpcAccountPortfolioTransformer {
 
     return {
       position: grpcPosition
-        ? IndexerGrpcDerivativeTransformer.grpcPositionToPosition(
-            grpcPosition,
-          )
+        ? IndexerGrpcDerivativeTransformer.grpcPositionToPosition(grpcPosition)
         : undefined,
       unrealizedPnl: positionsWithUPNL.unrealizedPnl,
     }
@@ -117,6 +116,18 @@ export class IndexerGrpcAccountPortfolioTransformer {
             deposit,
           )
         : undefined,
+    }
+  }
+
+  static tokenHoldersResponseToTokenHolders(
+    response: InjectivePortfolioRpc.TokenHoldersResponse,
+  ): TokenHolders {
+    return {
+      holders: response.holders.map((holder) => ({
+        accountAddress: holder.accountAddress,
+        balance: holder.balance,
+      })),
+      nextCursors: response.nextCursors,
     }
   }
 }

--- a/packages/sdk-ts/src/client/indexer/types/account-portfolio.ts
+++ b/packages/sdk-ts/src/client/indexer/types/account-portfolio.ts
@@ -31,9 +31,20 @@ export interface AccountPortfolioBalances {
   subaccountsList: PortfolioSubaccountBalanceV2[]
 }
 
+export interface Holder {
+  accountAddress: string
+  balance: string
+}
+
+export interface TokenHolders {
+  holders: Holder[]
+  nextCursors: string[]
+}
+
 export type GrpcPositionV2 = InjectivePortfolioRpc.DerivativePosition
 export type GrpcAccountPortfolioV2 = InjectivePortfolioRpc.Portfolio
 export type GrpcSubaccountDepositV2 = InjectivePortfolioRpc.SubaccountDeposit
 export type GrpcPositionsWithUPNL = InjectivePortfolioRpc.PositionsWithUPNL
 export type GrpcPortfolioSubaccountBalanceV2 =
   InjectivePortfolioRpc.SubaccountBalanceV2
+export type GrpcTokenHolders = InjectivePortfolioRpc.TokenHoldersResponse


### PR DESCRIPTION
supports token holders feature on explorer

## Note
- `TokenHolders` api works in testnet. get error from `indexer` in mainnet, but they are working on optimizing the query


Mainnet failure message:
https://sentry.exchange.grpc-web.injective.network/injective_portfolio_rpc.InjectivePortfolioRPC/TokenHolders
```
"Error: failed to list token holders: db: failed to query portfolios documents: (QueryExceededMemoryLimitNoDiskUseAllowed) PlanExecutor error during aggregation :: caused by :: Exceeded memory limit for $group, but didn't allow external sort. Pass allowDiskUse:true to opt in."
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new method to fetch token holders for specified accounts, enhancing the API's capabilities.
	- Added a transformation method for structuring token holder data, improving data handling and usability.

- **Bug Fixes**
	- Improved error handling for API call failures, ensuring better reliability and logging during operation.

- **Documentation**
	- Updated type definitions for token holder data to support new functionalities, facilitating future feature development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->