### PR TITLE
Restored path parameter for PrivateKey.fromMnemonic

### DIFF
--- a/packages/sdk-ts/src/core/accounts/PrivateKey.ts
+++ b/packages/sdk-ts/src/core/accounts/PrivateKey.ts
@@ -1,12 +1,15 @@
 import { generateMnemonic } from 'bip39'
-import { Wallet } from 'ethers'
+import { Wallet, HDNodeWallet } from 'ethers'
 import secp256k1 from 'secp256k1'
 import keccak256 from 'keccak256'
 import { PublicKey } from './PublicKey'
 import { Address } from './Address'
 import * as BytesUtils from '@ethersproject/bytes'
 import { signTypedData, SignTypedDataVersion } from '@metamask/eth-sig-util'
-import { recoverTypedSignaturePubKey } from '../../utils'
+import {
+  DEFAULT_DERIVATION_PATH,
+  recoverTypedSignaturePubKey,
+} from '../../utils'
 import {
   CosmosTxV1Beta1Tx,
   InjectiveTypesV1Beta1TxExt,
@@ -49,8 +52,12 @@ export class PrivateKey {
    * @param {string|undefined} path the HD path that follows the BIP32 standard (optional)
    * @returns {PrivateKey} Initialized PrivateKey object
    */
-  static fromMnemonic(words: string): PrivateKey {
-    return new PrivateKey(new Wallet(Wallet.fromPhrase(words).signingKey))
+  static fromMnemonic(
+    words: string,
+    path: string | undefined = DEFAULT_DERIVATION_PATH,
+  ): PrivateKey {
+    const hdNodeWallet = HDNodeWallet.fromPhrase(words, undefined, path)
+    return new PrivateKey(new Wallet(hdNodeWallet.privateKey))
   }
 
   /**


### PR DESCRIPTION
Hi, I noticed the path parameter for `PrivateKey.fromMnemonic` was removed in the last few releases. This PR restores this parameter so we can create `PrivateKey` instances with different HD derivation paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `fromMnemonic` method to support an optional path parameter for improved key generation from HD wallets.
- **Bug Fixes**
	- Reorganized import statements for better clarity and structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->