### PR TITLE
chore: remove wallet restriction on getCosmosWallet

### DIFF
--- a/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
+++ b/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
@@ -838,6 +838,9 @@ export class MsgBroadcaster {
     }
 
     const cosmosWallet = walletStrategy.getCosmosWallet(chainId)
+    const canDisableCosmosGasCheck = [Wallet.Keplr, Wallet.OWallet].includes(
+      walletStrategy.wallet,
+    )
     const feePayerPubKey = await this.fetchFeePayerPubKey(
       options.feePayerPubKey,
     )
@@ -888,10 +891,7 @@ export class MsgBroadcaster {
     })
 
     // Temporary remove tx gas check because Keplr doesn't recognize feePayer
-    if (
-      walletStrategy.wallet === Wallet.Keplr &&
-      cosmosWallet.disableGasCheck
-    ) {
+    if (canDisableCosmosGasCheck && cosmosWallet.disableGasCheck) {
       cosmosWallet.disableGasCheck(chainId)
     }
 
@@ -916,7 +916,7 @@ export class MsgBroadcaster {
     })
 
     // Re-enable tx gas check removed above
-    if (walletStrategy.wallet === Wallet.Keplr && cosmosWallet.enableGasCheck) {
+    if (canDisableCosmosGasCheck && cosmosWallet.enableGasCheck) {
       cosmosWallet.enableGasCheck(chainId)
     }
 

--- a/packages/wallets/wallet-core/src/strategy/BaseWalletStrategy.ts
+++ b/packages/wallets/wallet-core/src/strategy/BaseWalletStrategy.ts
@@ -207,12 +207,6 @@ export default class BaseWalletStrategy implements WalletStrategyInterface {
   }
 
   public getCosmosWallet(chainId: ChainId): CosmosWalletAbstraction {
-    if (![Wallet.Keplr, Wallet.Leap].includes(this.getWallet())) {
-      throw new WalletException(
-        new Error(`You can't use this method outside of Keplr/Leap wallet`),
-      )
-    }
-
     const strategy = this.getStrategy()
 
     if (strategy.getCosmosWallet == undefined) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced gas check flexibility for multiple wallet types in the broadcasting process.
	- Simplified access to the `getCosmosWallet` method, allowing use with any supported wallet type.

- **Bug Fixes**
	- Improved error handling in wallet strategy to prevent unnecessary exceptions for unsupported wallet types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->