### PR TITLE
Add support CID for fetchOrders/fetchTrades

### DIFF
--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcDerivativesApi.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcDerivativesApi.ts
@@ -203,7 +203,8 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
     orderSide?: OrderSide
     isConditional?: boolean
     subaccountId?: string
-    pagination?: PaginationOption
+    pagination?: PaginationOption,
+    cid?: string
   }) {
     const {
       marketId,
@@ -212,6 +213,7 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
       orderSide,
       isConditional,
       pagination,
+      cid,
     } = params || {}
 
     const request = InjectiveDerivativeExchangeRpc.OrdersRequest.create()
@@ -234,6 +236,10 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
 
     if (isConditional !== undefined) {
       request.isConditional = isConditional ? 'true' : 'false'
+    }
+
+    if (cid) {
+      request.cid = cid
     }
 
     if (pagination) {
@@ -287,6 +293,7 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
     direction?: TradeDirection
     isConditional?: boolean
     state?: OrderState
+    cid?: string,
     pagination?: PaginationOption
   }) {
     const {
@@ -299,6 +306,7 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
       isConditional,
       state,
       pagination,
+      cid,
     } = params || {}
 
     const request = InjectiveDerivativeExchangeRpc.OrdersHistoryRequest.create()
@@ -333,6 +341,10 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
 
     if (state) {
       request.state = state
+    }
+
+    if (cid) {
+      request.cid = cid
     }
 
     if (pagination) {
@@ -546,6 +558,7 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
     pagination?: PaginationOption
     executionSide?: TradeExecutionSide
     executionTypes?: TradeExecutionType[]
+    cid?: string
   }) {
     const {
       endTime,
@@ -559,6 +572,7 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
       executionSide,
       executionTypes,
       accountAddress,
+      cid,
     } = params || {}
 
     const request = InjectiveDerivativeExchangeRpc.TradesRequest.create()
@@ -601,6 +615,10 @@ export class IndexerGrpcDerivativesApi extends BaseGrpcConsumer {
 
     if (endTime) {
       request.endTime = endTime.toString()
+    }
+
+    if (cid) {
+      request.cid = cid
     }
 
     if (pagination) {

--- a/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc/IndexerGrpcSpotApi.ts
@@ -121,8 +121,9 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
     orderSide?: OrderSide
     isConditional?: boolean
     pagination?: PaginationOption
+    cid?: string
   }) {
-    const { marketId, marketIds, subaccountId, orderSide, pagination } =
+    const { marketId, marketIds, subaccountId, orderSide, pagination, cid } =
       params || {}
     const request = InjectiveSpotExchangeRpc.OrdersRequest.create()
 
@@ -140,6 +141,10 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
 
     if (orderSide) {
       request.orderSide = orderSide
+    }
+
+    if (cid) {
+      request.cid = cid
     }
 
     /*
@@ -200,6 +205,7 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
     isConditional?: boolean
     state?: OrderState
     pagination?: PaginationOption
+    cid?: string
   }) {
     const {
       subaccountId,
@@ -210,6 +216,7 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
       direction,
       state,
       pagination,
+      cid,
     } = params || {}
 
     const request = InjectiveSpotExchangeRpc.OrdersHistoryRequest.create()
@@ -240,6 +247,10 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
 
     if (state) {
       request.state = state
+    }
+
+    if (cid) {
+      request.cid = cid
     }
 
     /*
@@ -304,6 +315,7 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
     pagination?: PaginationOption
     executionSide?: TradeExecutionSide
     executionTypes?: TradeExecutionType[]
+    cid?: string
   }) {
     const {
       endTime,
@@ -317,6 +329,7 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
       executionSide,
       executionTypes,
       accountAddress,
+      cid
     } = params || {}
 
     const request = InjectiveSpotExchangeRpc.TradesRequest.create()
@@ -359,6 +372,10 @@ export class IndexerGrpcSpotApi extends BaseGrpcConsumer {
 
     if (endTime) {
       request.endTime = endTime.toString()
+    }
+
+    if (cid) {
+      request.cid = cid;
     }
 
     if (pagination) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced an optional `cid` parameter to enhance request flexibility in several methods, including `fetchOrders`, `fetchOrderHistory`, `fetchTrades`, and more for both the derivatives and spot APIs.
  
- **Bug Fixes**
	- Ensured consistency in parameter lists by modifying the `pagination` parameter in the `fetchOrders` method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->