### PR TITLE
chore/market-rewards-range-update

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -130,7 +130,7 @@
     "@injectivelabs/indexer-proto-ts": "1.13.6",
     "@injectivelabs/mito-proto-ts": "1.13.2",
     "@injectivelabs/networks": "^1.14.41",
-    "@injectivelabs/olp-proto-ts": "1.13.3",
+    "@injectivelabs/olp-proto-ts": "1.13.4",
     "@injectivelabs/test-utils": "^1.14.41",
     "@injectivelabs/ts-types": "^1.14.41",
     "@injectivelabs/utils": "^1.14.41",

--- a/packages/sdk-ts/src/client/olp/grpc/OLPGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/client/olp/grpc/OLPGrpcApi.spec.ts
@@ -200,20 +200,22 @@ describe('OLPGrpcApi', () => {
     }
   })
 
-  test('fetchMinMaxRewards', async () => {
+  test('fetchMarketRewardsRange', async () => {
     try {
-      const response = await dmmGrpcApi.fetchMinMaxRewards({ epochId })
+      const response = await dmmGrpcApi.fetchMarketRewardsRange({ epochId })
 
       expect(response).toBeDefined()
       expect(response).toEqual(
         expect.objectContaining<
           ReturnType<
-            typeof DmmGrpcTransformer.minMaxRewardsResponseToMinMaxRewards
+            typeof DmmGrpcTransformer.marketRewardsRangeResponseToMarketRewardsRange
           >
         >(response),
       )
     } catch (e) {
-      console.error('OLPGrpcApi.fetchMinMaxRewards => ' + (e as any).message)
+      console.error(
+        'OLPGrpcApi.fetchMarketRewardsRange => ' + (e as any).message,
+      )
     }
   })
 })

--- a/packages/sdk-ts/src/client/olp/grpc/OLPGrpcApi.ts
+++ b/packages/sdk-ts/src/client/olp/grpc/OLPGrpcApi.ts
@@ -416,37 +416,39 @@ export class OLPGrpcApi extends BaseGrpcConsumer {
     }
   }
 
-  async fetchMinMaxRewards({
+  async fetchMarketRewardsRange({
     epochId,
     marketId,
   }: {
     epochId: string
     marketId?: string
   }) {
-    const request = InjectiveDmmRpc.GetMarketMinMaxRewardsRequest.create()
+    const request = InjectiveDmmRpc.GetMarketRewardsRangeRequest.create()
 
     request.epochId = epochId
     request.marketId = marketId
 
     try {
       const response =
-        await this.retry<InjectiveDmmRpc.GetMarketMinMaxRewardsResponse>(() =>
-          this.client.GetMarketMinMaxRewards(request),
+        await this.retry<InjectiveDmmRpc.GetMarketRewardsRangeResponse>(() =>
+          this.client.GetMarketRewardRanges(request),
         )
 
-      return DmmGrpcTransformer.minMaxRewardsResponseToMinMaxRewards(response)
+      return DmmGrpcTransformer.marketRewardsRangeResponseToMarketRewardsRange(
+        response,
+      )
     } catch (e: unknown) {
       if (e instanceof InjectiveDmmRpc.GrpcWebError) {
         throw new GrpcUnaryRequestException(new Error(e.toString()), {
           code: e.code,
-          context: 'GetMarketMinMaxRewards',
+          context: 'GetMarketRewardRanges',
           contextModule: this.module,
         })
       }
 
       throw new GrpcUnaryRequestException(e as Error, {
         code: UnspecifiedErrorCode,
-        context: 'GetMarketMinMaxRewards',
+        context: 'GetMarketRewardRanges',
         contextModule: this.module,
       })
     }

--- a/packages/sdk-ts/src/client/olp/grpc/transformers/index.ts
+++ b/packages/sdk-ts/src/client/olp/grpc/transformers/index.ts
@@ -291,18 +291,20 @@ export class DmmGrpcTransformer {
     }
   }
 
-  static minMaxRewardsResponseToMinMaxRewards(
-    response: InjectiveDmmRpc.GetMarketMinMaxRewardsResponse,
+  static marketRewardsRangeResponseToMarketRewardsRange(
+    response: InjectiveDmmRpc.GetMarketRewardsRangeResponse,
   ): MinMaxRewards {
     const formattedMinCurrentEpochRewards: Record<string, string> = {}
+    const formattedMaxCurrentEpochRewards: Record<string, string> = {}
 
-    response.minRewards.forEach((item) => {
-      formattedMinCurrentEpochRewards[item.marketId] = item.minReward
+    response.ranges.forEach((item) => {
+      formattedMinCurrentEpochRewards[item.marketId] = item.min
+      formattedMaxCurrentEpochRewards[item.marketId] = item.max
     })
 
     return {
       minRewards: formattedMinCurrentEpochRewards,
-      maxReward: response.maxReward,
+      maxRewards: formattedMaxCurrentEpochRewards,
     }
   }
 }

--- a/packages/sdk-ts/src/client/olp/grpc/types/index.ts
+++ b/packages/sdk-ts/src/client/olp/grpc/types/index.ts
@@ -208,7 +208,7 @@ export interface AccountVolume {
 
 export interface MinMaxRewards {
   minRewards: Record<string, string>
-  maxReward: string
+  maxRewards: Record<string, string>
 }
 
 export type GrpcEpochsV2 = InjectiveDmmRpc.GetEpochsResponse

--- a/yarn.lock
+++ b/yarn.lock
@@ -2240,10 +2240,10 @@
     protobufjs "^7.0.0"
     rxjs "^7.4.0"
 
-"@injectivelabs/olp-proto-ts@1.13.3":
-  version "1.13.3"
-  resolved "https://registry.yarnpkg.com/@injectivelabs/olp-proto-ts/-/olp-proto-ts-1.13.3.tgz#8c3c013ff88e63918c494ca255ea54f2ed9192f7"
-  integrity sha512-z2AQOXVYItMlM+qYraPbAzC6uhhJty7qpiI3KVGLCqFfTtICefOh4sa0gzMR/xP5zhS9SoRq0Wu4zuqaDy9UrQ==
+"@injectivelabs/olp-proto-ts@1.13.4":
+  version "1.13.4"
+  resolved "https://registry.yarnpkg.com/@injectivelabs/olp-proto-ts/-/olp-proto-ts-1.13.4.tgz#55201321c01265e5e23d3396d38c5634be00d7b8"
+  integrity sha512-MTltuDrPJ+mu8IonkfwBp11ZJzTw2x+nA3wzrK+T4ZzEs+fBW8SgaCoXKc5COU7IBzg3wB316QwaR1l6MrffXg==
   dependencies:
     "@injectivelabs/grpc-web" "^0.0.1"
     google-protobuf "^3.14.0"


### PR DESCRIPTION
chore: update for injective-trading-ui repo where indexer update for market page rewards range

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated an external dependency to the latest version for improved stability.

- **Refactor**
  - Enhanced the market rewards fetching functionality with clearer naming and a refined response structure.
  - Now returns both minimum rewards and a structured collection of maximum rewards.
  - Revised error messaging for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->