### PR TITLE
fix: ensure expiration seconds is always used

### DIFF
--- a/packages/wallets/wallet-turnkey/src/strategy/turnkey/oauth.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/turnkey/oauth.ts
@@ -7,7 +7,10 @@ import { sha256 } from '@injectivelabs/sdk-ts'
 import type { TurnkeyOauthLoginResponse } from '../types.js'
 import type { TurnkeyIframeClient } from '@turnkey/sdk-browser'
 import { type HttpRestClient } from '@injectivelabs/utils'
-import { TURNKEY_OAUTH_PATH } from '../consts.js'
+import {
+  DEFAULT_TURNKEY_REFRESH_SECONDS,
+  TURNKEY_OAUTH_PATH,
+} from '../consts.js'
 
 export class TurnkeyOauthWallet {
   static async generateOAuthNonce(iframeClient: TurnkeyIframeClient) {
@@ -34,13 +37,13 @@ export class TurnkeyOauthWallet {
     oidcToken: string
     client: HttpRestClient
     oauthLoginPath?: string
-    expirationSeconds?: number
     providerName: 'google' | 'apple'
     iframeClient: TurnkeyIframeClient
+    expirationSeconds?: number
   }): Promise<
     { organizationId: string; credentialBundle: string } | undefined
   > {
-    const { client, iframeClient } = args
+    const { client, iframeClient, expirationSeconds } = args
 
     const path = args.oauthLoginPath || TURNKEY_OAUTH_PATH
 
@@ -57,6 +60,9 @@ export class TurnkeyOauthWallet {
         targetPublicKey,
         oidcToken: args.oidcToken,
         providerName: args.providerName,
+        expirationSeconds: (
+          expirationSeconds || DEFAULT_TURNKEY_REFRESH_SECONDS
+        )?.toString(),
       })
 
       return response.data

--- a/packages/wallets/wallet-turnkey/src/strategy/turnkey/otp.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/turnkey/otp.ts
@@ -9,7 +9,11 @@ import {
   type TurnkeyOTPCredentialsResponse,
 } from './../types.js'
 import { type HttpRestClient } from '@injectivelabs/utils'
-import { TURNKEY_OTP_INIT_PATH, TURNKEY_OTP_VERIFY_PATH } from '../consts.js'
+import {
+  DEFAULT_TURNKEY_REFRESH_SECONDS,
+  TURNKEY_OTP_INIT_PATH,
+  TURNKEY_OTP_VERIFY_PATH,
+} from '../consts.js'
 
 export class TurnkeyOtpWallet {
   static async initEmailOTP(args: {
@@ -56,8 +60,9 @@ export class TurnkeyOtpWallet {
     organizationId: string
     iframeClient: TurnkeyIframeClient
     otpVerifyPath?: string
+    expirationSeconds?: number
   }) {
-    const { client, iframeClient } = args
+    const { client, iframeClient, expirationSeconds } = args
 
     try {
       const organizationId = args.organizationId
@@ -84,6 +89,9 @@ export class TurnkeyOtpWallet {
         otpId: emailOTPId,
         otpCode: args.otpCode,
         suborgID: organizationId,
+        expirationSeconds: (
+          expirationSeconds || DEFAULT_TURNKEY_REFRESH_SECONDS
+        )?.toString(),
       })
 
       return response?.data


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for specifying a custom session expiration time during OAuth login and email OTP confirmation. If not provided, a default expiration time is used.

- **Bug Fixes**
  - Improved consistency in session retrieval and expiration handling after credential injection and session refresh, with clearer error handling if a session cannot be obtained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->