### PR TITLE
chore: msgBroadcaster pass txTimeout override to fetchTxPoll

### DIFF
--- a/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcAuctionTransformer.ts
+++ b/packages/sdk-ts/src/client/indexer/transformers/IndexerGrpcAuctionTransformer.ts
@@ -63,6 +63,7 @@ export class IndexerGrpcAuctionTransformer {
       basket: grpcAuction.basket.map(
         IndexerGrpcAuctionTransformer.grpcAuctionCoinPricesToAuctionCoinPrices,
       ),
+      contract: grpcAuction.contract,
       winningBidAmount: grpcAuction.winningBidAmount,
       round: parseInt(grpcAuction.round, 10),
       endTimestamp: parseInt(grpcAuction.endTimestamp, 10),

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
@@ -112,7 +112,7 @@ export class TxGrpcApi implements TxConcreteApi {
 
   public async fetchTxPoll(
     txHash: string,
-    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS || 60000,
+    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
   ): Promise<TxResponse> {
     const POLL_INTERVAL = DEFAULT_BLOCK_TIME_IN_SECONDS * 1000
 

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -17,6 +17,12 @@ export const DEFAULT_BRIDGE_FEE_AMOUNT = '200000000000000'
 
 export const DEFAULT_BLOCK_TIMEOUT_HEIGHT = 120
 export const DEFAULT_BLOCK_TIME_IN_SECONDS = 0.7
+
+/**
+ * Default timeout for transaction block inclusion polling.
+ *
+ * Calculation: 120 blocks × 0.7 seconds/block = 84 seconds = 84,000ms
+ */
 export const DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS = Math.floor(
   DEFAULT_BLOCK_TIMEOUT_HEIGHT * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
 )

--- a/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
+++ b/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
@@ -11,6 +11,7 @@ import {
   toBigNumber,
   DEFAULT_GAS_PRICE,
   DEFAULT_BLOCK_TIMEOUT_HEIGHT,
+  DEFAULT_BLOCK_TIME_IN_SECONDS,
 } from '@injectivelabs/utils'
 import {
   WalletException,
@@ -348,7 +349,12 @@ export class MsgBroadcaster {
    * @returns transaction hash
    */
   private async broadcastEip712(tx: MsgBroadcasterTxOptionsWithAddresses) {
-    const { chainId, txTimeout, endpoints, walletStrategy } = this
+    const {
+      chainId,
+      endpoints,
+      walletStrategy,
+      txTimeout: txTimeoutInBlocks,
+    } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
 
     const evmChainId = await this.getEvmChainId()
@@ -360,7 +366,7 @@ export class MsgBroadcaster {
     /** Account Details * */
     const { baseAccount, latestHeight } =
       await this.fetchAccountAndBlockDetails(tx.injectiveAddress)
-    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeout)
+    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeoutInBlocks)
 
     const gas = (tx.gas?.gas || getGasPriceBasedOnMessage(msgs)).toString()
     let stdFee = getStdFee({ ...tx.gas, gas })
@@ -440,13 +446,16 @@ export class MsgBroadcaster {
     const response = await walletStrategy.sendTransaction(txRawEip712, {
       chainId,
       endpoints,
-      txTimeout,
+      txTimeout: txTimeoutInBlocks,
       address: tx.injectiveAddress,
     })
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
 
-    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      response.txHash,
+      txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+    )
   }
 
   /**
@@ -461,7 +470,12 @@ export class MsgBroadcaster {
   private async broadcastEip712V2(
     tx: MsgBroadcasterTxOptionsWithAddresses,
   ): Promise<TxResponse> {
-    const { chainId, endpoints, txTimeout, walletStrategy } = this
+    const {
+      chainId,
+      endpoints,
+      walletStrategy,
+      txTimeout: txTimeoutInBlocks,
+    } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
 
     const evmChainId = await this.getEvmChainId()
@@ -473,7 +487,7 @@ export class MsgBroadcaster {
     /** Account Details * */
     const { baseAccount, latestHeight } =
       await this.fetchAccountAndBlockDetails(tx.injectiveAddress)
-    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeout)
+    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeoutInBlocks)
 
     const gas = (tx.gas?.gas || getGasPriceBasedOnMessage(msgs)).toString()
     let stdFee = getStdFee({ ...tx.gas, gas })
@@ -564,13 +578,16 @@ export class MsgBroadcaster {
     const response = await walletStrategy.sendTransaction(txRawEip712, {
       chainId,
       endpoints,
-      txTimeout,
+      txTimeout: txTimeoutInBlocks,
       address: tx.injectiveAddress,
     })
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
 
-    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      response.txHash,
+      txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+    )
   }
 
   /**
@@ -584,12 +601,12 @@ export class MsgBroadcaster {
     tx: MsgBroadcasterTxOptionsWithAddresses,
   ): Promise<TxResponse> {
     const {
-      txTimeout,
       endpoints,
       simulateTx,
       httpHeaders,
       walletStrategy,
       txTimeoutOnFeeDelegation,
+      txTimeout: txTimeoutInBlocks,
     } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
     const web3Msgs = msgs.map((msg) => msg.toWeb3())
@@ -617,7 +634,9 @@ export class MsgBroadcaster {
 
       const latestHeight = latestBlock!.header!.height
 
-      timeoutHeight = toBigNumber(latestHeight).plus(txTimeout).toNumber()
+      timeoutHeight = toBigNumber(latestHeight)
+        .plus(txTimeoutInBlocks)
+        .toNumber()
     }
 
     walletStrategy.emit(
@@ -662,7 +681,10 @@ export class MsgBroadcaster {
         WalletStrategyEmitterEventType.TransactionBroadcastEnd,
       )
 
-      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+        response.txHash,
+        txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+      )
     } catch (e) {
       const error = e as any
 
@@ -709,7 +731,12 @@ export class MsgBroadcaster {
   private async broadcastDirectSign(
     tx: MsgBroadcasterTxOptionsWithAddresses,
   ): Promise<TxResponse> {
-    const { walletStrategy, txTimeout, endpoints, chainId } = this
+    const {
+      chainId,
+      endpoints,
+      walletStrategy,
+      txTimeout: txTimeoutInBlocks,
+    } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
 
     /**
@@ -731,7 +758,7 @@ export class MsgBroadcaster {
 
     const { baseAccount, latestHeight } =
       await this.fetchAccountAndBlockDetails(tx.injectiveAddress)
-    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeout)
+    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeoutInBlocks)
 
     const signMode = isCosmosAminoOnlyWallet(walletStrategy.wallet)
       ? SIGN_EIP712
@@ -789,15 +816,18 @@ export class MsgBroadcaster {
       const response = await walletStrategy.sendTransaction(txRaw, {
         chainId,
         endpoints,
-        txTimeout,
         address: tx.injectiveAddress,
+        txTimeout: txTimeoutInBlocks,
       })
 
       walletStrategy.emit(
         WalletStrategyEmitterEventType.TransactionBroadcastEnd,
       )
 
-      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+        response.txHash,
+        txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+      )
     }
 
     const directSignResponse = (await walletStrategy.signCosmosTransaction({
@@ -814,13 +844,16 @@ export class MsgBroadcaster {
     const response = await walletStrategy.sendTransaction(directSignResponse, {
       chainId,
       endpoints,
-      txTimeout,
+      txTimeout: txTimeoutInBlocks,
       address: tx.injectiveAddress,
     })
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
 
-    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      response.txHash,
+      txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+    )
   }
 
   /**
@@ -834,11 +867,11 @@ export class MsgBroadcaster {
   ) {
     const {
       chainId,
-      txTimeout,
       endpoints,
       evmChainId,
       simulateTx,
       walletStrategy,
+      txTimeout: txTimeoutInBlocks,
     } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
 
@@ -871,7 +904,7 @@ export class MsgBroadcaster {
 
     const { baseAccount, latestHeight } =
       await this.fetchAccountAndBlockDetails(tx.injectiveAddress)
-    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeout)
+    const timeoutHeight = toBigNumber(latestHeight).plus(txTimeoutInBlocks)
 
     const pubKey = await walletStrategy.getPubKey()
     const gas = (tx.gas?.gas || getGasPriceBasedOnMessage(msgs)).toString()
@@ -942,7 +975,7 @@ export class MsgBroadcaster {
     /** Broadcast the transaction */
     const response = await new TxGrpcApi(endpoints.grpc).broadcast(
       txRawEip712,
-      { txTimeout },
+      { txTimeout: txTimeoutInBlocks },
     )
 
     if (response.code !== 0) {
@@ -969,11 +1002,11 @@ export class MsgBroadcaster {
     const {
       options,
       chainId,
-      txTimeout,
       endpoints,
       httpHeaders,
       walletStrategy,
       txTimeoutOnFeeDelegation,
+      txTimeout: txTimeoutInBlocks,
     } = this
     const msgs = Array.isArray(tx.msgs) ? tx.msgs : [tx.msgs]
 
@@ -1019,7 +1052,9 @@ export class MsgBroadcaster {
     const { baseAccount: feePayerBaseAccount } = feePayerAccountDetails
 
     const timeoutHeight = toBigNumber(latestHeight).plus(
-      txTimeoutOnFeeDelegation ? txTimeout : DEFAULT_BLOCK_TIMEOUT_HEIGHT,
+      txTimeoutOnFeeDelegation
+        ? txTimeoutInBlocks
+        : DEFAULT_BLOCK_TIMEOUT_HEIGHT,
     )
 
     const pubKey = await walletStrategy.getPubKey()
@@ -1101,7 +1136,10 @@ export class MsgBroadcaster {
         cosmosWallet.enableGasCheck(chainId)
       }
 
-      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+      return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+        response.txHash,
+        txTimeoutInBlocks * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+      )
     } catch (e) {
       const error = e as any
 

--- a/packages/wallets/wallet-cosmos/README.md
+++ b/packages/wallets/wallet-cosmos/README.md
@@ -63,7 +63,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-cosmostation/README.md
+++ b/packages/wallets/wallet-cosmostation/README.md
@@ -63,7 +63,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-evm/README.md
+++ b/packages/wallets/wallet-evm/README.md
@@ -66,7 +66,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-ledger/README.md
+++ b/packages/wallets/wallet-ledger/README.md
@@ -66,7 +66,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-magic/README.md
+++ b/packages/wallets/wallet-magic/README.md
@@ -66,7 +66,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-private-key/README.md
+++ b/packages/wallets/wallet-private-key/README.md
@@ -68,7 +68,7 @@ const sendTX = async () => {
       },
     })
 
-    return await msgBroadcaster.broadcast({ msgs: message })
+    return await msgBroadcaster.broadcastV2({ msgs: message })
   }
 
   const result = await sendTX()

--- a/packages/wallets/wallet-private-key/src/strategy/strategy.spec.ts
+++ b/packages/wallets/wallet-private-key/src/strategy/strategy.spec.ts
@@ -48,7 +48,7 @@ describe('MsgBroadcaster', () => {
       },
     })
 
-    const response = await msgBroadcaster.broadcast({
+    const response = await msgBroadcaster.broadcastV2({
       msgs: message,
       injectiveAddress,
     })

--- a/packages/wallets/wallet-trezor/README.md
+++ b/packages/wallets/wallet-trezor/README.md
@@ -66,7 +66,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-turnkey/README.md
+++ b/packages/wallets/wallet-turnkey/README.md
@@ -46,7 +46,8 @@ const strategyArgs: WalletStrategyArguments = {
       },
       metadata: {
         turnkeyAuthIframeContainerId,
-        defaultOrganizationId: import.meta.env.VITE_TURNKEY_DEFAULT_ORGANIZATION_ID,
+        defaultOrganizationId: import.meta.env
+          .VITE_TURNKEY_DEFAULT_ORGANIZATION_ID,
         apiBaseUrl: 'https://api.turnkey.com',
       },
     }),
@@ -74,7 +75,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()

--- a/packages/wallets/wallet-wallet-connect/README.md
+++ b/packages/wallets/wallet-wallet-connect/README.md
@@ -70,7 +70,7 @@ const sendTX = async () => {
     },
   })
 
-  return await msgBroadcaster.broadcast({ msgs: message })
+  return await msgBroadcaster.broadcastV2({ msgs: message })
 }
 
 const result = await sendTX()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Auction data now includes a contract field for improved clarity.
- Improvements
  - Standardized transaction inclusion timeout (~84s) and block-based polling for more predictable broadcasting behavior.
- Documentation
  - Updated wallet examples to use broadcastV2 across Cosmos, Cosmostation, EVM, Ledger, Magic, Private Key, Trezor, Turnkey, and WalletConnect guides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->