### PR TITLE
chore: megavault update historical timestamp types

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -128,7 +128,7 @@
     "@injectivelabs/grpc-web": "^0.0.1",
     "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
     "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-    "@injectivelabs/indexer-proto-ts": "1.13.25",
+    "@injectivelabs/indexer-proto-ts": "1.13.26",
     "@injectivelabs/mito-proto-ts": "1.13.2",
     "@injectivelabs/networks": "workspace:*",
     "@injectivelabs/olp-proto-ts": "1.13.4",

--- a/packages/sdk-ts/src/client/indexer/types/mega-vault.ts
+++ b/packages/sdk-ts/src/client/indexer/types/mega-vault.ts
@@ -146,12 +146,12 @@ export interface MegaVaultOperatorRedemptionBucket {
 }
 
 export interface MegaVaultHistoricalTVL {
-  t: number
+  t: string
   v: string
 }
 
 export interface MegaVaultHistoricalPnL {
-  t: number
+  t: string
   v: string
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -211,8 +211,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2(@injectivelabs/grpc-web@0.0.1(google-protobuf@3.21.4))
       '@injectivelabs/indexer-proto-ts':
-        specifier: 1.13.25
-        version: 1.13.25
+        specifier: 1.13.26
+        version: 1.13.26
       '@injectivelabs/mito-proto-ts':
         specifier: 1.13.2
         version: 1.13.2
@@ -2109,10 +2109,10 @@ packages:
     peerDependencies:
       google-protobuf: ^3.14.0
 
-  '@injectivelabs/indexer-proto-ts@1.13.25':
+  '@injectivelabs/indexer-proto-ts@1.13.26':
     resolution:
       {
-        integrity: sha512-QEqcO8KHGoV/OeDKRboNYDrutN5QbIy0KEyVSmUbwyKggxU0vdyhHUBgKbU0F57xKXS+anhaKPzExtWUVbh+5Q==,
+        integrity: sha512-TjdhyppluPUG+x3GM6wHZ14AJX6LWhyhN1aKV8nL+g9q7/rVXUEz+51OJBQeLIGz00JOKpdX2K9xG7pDYt9SQg==,
       }
 
   '@injectivelabs/mito-proto-ts@1.13.2':
@@ -16411,7 +16411,7 @@ snapshots:
       browser-headers: 0.4.1
       google-protobuf: 3.21.4
 
-  '@injectivelabs/indexer-proto-ts@1.13.25':
+  '@injectivelabs/indexer-proto-ts@1.13.26':
     dependencies:
       '@injectivelabs/grpc-web': 0.0.1(google-protobuf@3.21.4)
       google-protobuf: 3.21.4


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated indexer protocol dependency to version 1.13.26
  * Modified timestamp representation in historical vault data structures from numeric to string format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->