### PR TITLE
fix(utils): add onError callback to awaitForAll to prevent silent err…

### DIFF
--- a/packages/utils/src/helpers.spec.ts
+++ b/packages/utils/src/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { splitArrayToChunks, awaitForAll } from './helpers.js'
+import { awaitForAll , splitArrayToChunks} from './helpers.js'
 
 describe('awaitForAll', () => {
   it('should resolve all items when no errors occur', async () => {

--- a/packages/utils/src/helpers.spec.ts
+++ b/packages/utils/src/helpers.spec.ts
@@ -1,4 +1,57 @@
-import { splitArrayToChunks } from './helpers.js'
+import { splitArrayToChunks, awaitForAll } from './helpers.js'
+
+describe('awaitForAll', () => {
+  it('should resolve all items when no errors occur', async () => {
+    const array = [1, 2, 3]
+    const result = await awaitForAll(array, async (item) => item * 2)
+    expect(result).toEqual([2, 4, 6])
+  })
+
+  it('should skip errored items and return only successful results', async () => {
+    const array = [1, 2, 3, 4, 5]
+    const result = await awaitForAll(array, async (item) => {
+      if (item === 3) {
+        throw new Error('Item 3 failed')
+      }
+      return item * 2
+    })
+    expect(result).toEqual([2, 4, 8, 10])
+  })
+
+  it('should call onError with the correct arguments when an item fails', async () => {
+    const array = ['a', 'b', 'c']
+    const errors: Array<{ error: unknown; item: string; index: number }> = []
+
+    await awaitForAll(
+      array,
+      async (item) => {
+        if (item === 'b') {
+          throw new Error('b failed')
+        }
+        return item.toUpperCase()
+      },
+      (error, item, index) => {
+        errors.push({ error, item, index })
+      },
+    )
+
+    expect(errors).toHaveLength(1)
+    expect(errors[0].item).toBe('b')
+    expect(errors[0].index).toBe(1)
+    expect((errors[0].error as Error).message).toBe('b failed')
+  })
+
+  it('should not throw when onError is not provided and items fail', async () => {
+    const array = [1, 2, 3]
+    const result = await awaitForAll(array, async (item) => {
+      if (item === 2) {
+        throw new Error('fail')
+      }
+      return item
+    })
+    expect(result).toEqual([1, 3])
+  })
+})
 
 describe('helpers', () => {
   it('should split array to chunks', () => {

--- a/packages/utils/src/helpers.ts
+++ b/packages/utils/src/helpers.ts
@@ -30,14 +30,17 @@ export const awaitAll = async <T, S>(
 export const awaitForAll = async <T, S>(
   array: Array<T>,
   callback: (item: T) => Promise<S>,
+  onError?: (error: unknown, item: T, index: number) => void,
 ): Promise<S[]> => {
   const result = [] as S[]
 
   for (let i = 0; i < array.length; i += 1) {
     try {
       result.push(await callback(array[i]))
-    } catch {
-      //
+    } catch (e: unknown) {
+      if (onError) {
+        onError(e, array[i], i)
+      }
     }
   }
 


### PR DESCRIPTION
## Problem 
In `helpers.ts`, The `awaitForAll` function had an empty catch block that silently discarded all errors, making failures invisible to callers. The result array length would silently shrink with no indication that items failed. This can mask real failures in production (failed transactions, failed API calls, etc.) with no indication to the caller.

## Fix

This adds an optional onError callback parameter that is invoked with the error, the failed item, and its index when a promise rejects. This is fully backwards compatible — existing callers without onError behave exactly as before.

Also adds 4 new tests for awaitForAll covering:
- All items succeeding
- Skipping errored items
- onError callback receiving correct arguments
- Backwards compatibility (no throw without onError)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional per-item error callback to the async batch processing utility to report item-level failures without stopping the batch.

* **Tests**
  * Added tests covering successful resolution, skipping errored items, invoking the error callback with error/item/index, and behavior when the callback is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->