### PR TITLE
fix(eslint): preserve enum export and values in fixer

### DIFF
--- a/scripts/eslint-rules/no-enum.js
+++ b/scripts/eslint-rules/no-enum.js
@@ -30,14 +30,14 @@ export default {
         const parentNode = node.parent
         const isExported =
           parentNode && parentNode.type === 'ExportNamedDeclaration'
-        const exportKeyword = isExported ? '' : 'export '
+        const exportKeyword = isExported ? 'export ' : ''
 
         // Get the enum members
         const members = node.members.map((member) => {
           const key = member.id.name
           const value = member.initializer
             ? sourceCode.getText(member.initializer)
-            : `'${key.toLowerCase()}'`
+            : `'${key}'`
           return { key, value }
         })
 

--- a/scripts/eslint-rules/no-enum.js
+++ b/scripts/eslint-rules/no-enum.js
@@ -58,7 +58,7 @@ ${constMembers},
           messageId: 'preferTypeConst',
           data: { enumName },
           fix(fixer) {
-            return fixer.replaceText(node, suggestedCode)
+            return fixer.replaceText(isExported ? parentNode : node, suggestedCode)
           },
         })
       },


### PR DESCRIPTION
avoid exporting non-exported enums and preserve original member values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Enum conversion now preserves export keywords so exported and non-exported enums are handled correctly.
  * Generated enum member values retain their original name casing rather than being lowercased.
  * Conversion now targets the correct declaration form for exported enums, ensuring replacements apply to the intended code region.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->