### PR TITLE
feat: add v2 exchange message

### DIFF
--- a/packages/sdk-ts/src/core/modules/exchange/index.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/index.ts
@@ -28,6 +28,32 @@ import MsgBatchCancelBinaryOptionsOrders from './msgs/MsgBatchCancelBinaryOption
 import MsgCreateBinaryOptionsMarketOrder from './msgs/MsgCreateBinaryOptionsMarketOrder.js'
 import MsgSetDelegationTransferReceivers from './msgs/MsgSetDelegationTransferReceivers.js'
 import MsgInstantBinaryOptionsMarketLaunch from './msgs/MsgInstantBinaryOptionsMarketLaunch.js'
+import MsgDepositV2 from './msgs/MsgDepositV2.js'
+import MsgSignDataV2 from './msgs/MsgSignDataV2.js'
+import MsgWithdrawV2 from './msgs/MsgWithdrawV2.js'
+import MsgRewardsOptOutV2 from './msgs/MsgRewardsOptOutV2.js'
+import MsgCancelSpotOrderV2 from './msgs/MsgCancelSpotOrderV2.js'
+import MsgExternalTransferV2 from './msgs/MsgExternalTransferV2.js'
+import MsgBatchUpdateOrdersV2 from './msgs/MsgBatchUpdateOrdersV2.js'
+import MsgLiquidatePositionV2 from './msgs/MsgLiquidatePositionV2.js'
+import MsgReclaimLockedFundsV2 from './msgs/MsgReclaimLockedFundsV2.js'
+import MsgAuthorizeStakeGrantsV2 from './msgs/MsgAuthorizeStakeGrantsV2.js'
+import MsgCancelDerivativeOrderV2 from './msgs/MsgCancelDerivativeOrderV2.js'
+import MsgBatchCancelSpotOrdersV2 from './msgs/MsgBatchCancelSpotOrdersV2.js'
+import MsgCreateSpotLimitOrderV2 from './msgs/MsgCreateSpotLimitOrderV2.js'
+import MsgCreateSpotMarketOrderV2 from './msgs/MsgCreateSpotMarketOrderV2.js'
+import MsgIncreasePositionMarginV2 from './msgs/MsgIncreasePositionMarginV2.js'
+import MsgDecreasePositionMarginV2 from './msgs/MsgDecreasePositionMarginV2.js'
+import MsgInstantSpotMarketLaunchV2 from './msgs/MsgInstantSpotMarketLaunchV2.js'
+import MsgCancelBinaryOptionsOrderV2 from './msgs/MsgCancelBinaryOptionsOrderV2.js'
+import MsgCreateDerivativeLimitOrderV2 from './msgs/MsgCreateDerivativeLimitOrderV2.js'
+import MsgBatchCancelDerivativeOrdersV2 from './msgs/MsgBatchCancelDerivativeOrdersV2.js'
+import MsgCreateDerivativeMarketOrderV2 from './msgs/MsgCreateDerivativeMarketOrderV2.js'
+import MsgCreateBinaryOptionsLimitOrderV2 from './msgs/MsgCreateBinaryOptionsLimitOrderV2.js'
+import MsgAdminUpdateBinaryOptionsMarketV2 from './msgs/MsgAdminUpdateBinaryOptionsMarketV2.js'
+import MsgBatchCancelBinaryOptionsOrdersV2 from './msgs/MsgBatchCancelBinaryOptionsOrdersV2.js'
+import MsgCreateBinaryOptionsMarketOrderV2 from './msgs/MsgCreateBinaryOptionsMarketOrderV2.js'
+import MsgInstantBinaryOptionsMarketLaunchV2 from './msgs/MsgInstantBinaryOptionsMarketLaunchV2.js'
 
 export {
   MsgDeposit,
@@ -60,6 +86,32 @@ export {
   MsgBatchCancelBinaryOptionsOrders,
   MsgSetDelegationTransferReceivers,
   MsgInstantBinaryOptionsMarketLaunch,
+  MsgDepositV2,
+  MsgSignDataV2,
+  MsgWithdrawV2,
+  MsgRewardsOptOutV2,
+  MsgCancelSpotOrderV2,
+  MsgExternalTransferV2,
+  MsgBatchUpdateOrdersV2,
+  MsgLiquidatePositionV2,
+  MsgReclaimLockedFundsV2,
+  MsgAuthorizeStakeGrantsV2,
+  MsgCancelDerivativeOrderV2,
+  MsgBatchCancelSpotOrdersV2,
+  MsgCreateSpotLimitOrderV2,
+  MsgCreateSpotMarketOrderV2,
+  MsgIncreasePositionMarginV2,
+  MsgDecreasePositionMarginV2,
+  MsgInstantSpotMarketLaunchV2,
+  MsgCancelBinaryOptionsOrderV2,
+  MsgCreateDerivativeLimitOrderV2,
+  MsgBatchCancelDerivativeOrdersV2,
+  MsgCreateDerivativeMarketOrderV2,
+  MsgCreateBinaryOptionsLimitOrderV2,
+  MsgAdminUpdateBinaryOptionsMarketV2,
+  MsgBatchCancelBinaryOptionsOrdersV2,
+  MsgCreateBinaryOptionsMarketOrderV2,
+  MsgInstantBinaryOptionsMarketLaunchV2,
 }
 
 export * from './utils/index.js'

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.spec.ts
@@ -1,0 +1,53 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgAdminUpdateBinaryOptionsMarketV2 from './MsgAdminUpdateBinaryOptionsMarketV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgAdminUpdateBinaryOptionsMarketV2['params'] = {
+  sender: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  settlementPrice: '1000000000000000000',
+  expirationTimestamp: '1662648237',
+  settlementTimestamp: '1662648237',
+  status: 4, // expired
+}
+
+const message = MsgAdminUpdateBinaryOptionsMarketV2.fromJSON(params)
+
+describe('MsgAdminUpdateBinaryOptionsMarketV2', () => {
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it.skip('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.ts
@@ -1,0 +1,141 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgAdminUpdateBinaryOptionsMarketV2 {
+  export interface Params {
+    sender: string
+    marketId: string
+    settlementPrice: string
+    expirationTimestamp: string
+    settlementTimestamp: string
+    status: InjectiveExchangeV2MarketPb.MarketStatus
+  }
+
+  export type Proto =
+    InjectiveExchangeV2TxPb.MsgAdminUpdateBinaryOptionsMarket
+}
+
+const createMessage = (
+  params: MsgAdminUpdateBinaryOptionsMarketV2.Params,
+) => {
+  const message =
+    InjectiveExchangeV2TxPb.MsgAdminUpdateBinaryOptionsMarket.create({
+      sender: params.sender,
+      marketId: params.marketId,
+      settlementPrice: params.settlementPrice,
+      expirationTimestamp: BigInt(params.expirationTimestamp),
+      settlementTimestamp: BigInt(params.settlementTimestamp),
+      status: params.status,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgAdminUpdateBinaryOptionsMarketV2 extends MsgBase<
+  MsgAdminUpdateBinaryOptionsMarketV2.Params,
+  MsgAdminUpdateBinaryOptionsMarketV2.Proto
+> {
+  static fromJSON(
+    params: MsgAdminUpdateBinaryOptionsMarketV2.Params,
+  ): MsgAdminUpdateBinaryOptionsMarketV2 {
+    return new MsgAdminUpdateBinaryOptionsMarketV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      settlementPrice: toChainFormat(
+        initialParams.settlementPrice,
+      ).toFixed(),
+    } as MsgAdminUpdateBinaryOptionsMarketV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgAdminUpdateBinaryOptionsMarket',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.sender,
+      market_id: params.marketId,
+      settlement_price: params.settlementPrice,
+      expiration_timestamp: params.expirationTimestamp,
+      settlement_timestamp: params.settlementTimestamp,
+      status: params.status,
+    }
+
+    return {
+      type: 'exchange/MsgAdminUpdateBinaryOptionsMarket',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgAdminUpdateBinaryOptionsMarket',
+      ...value,
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { type, value } = amino
+
+    const messageAdjusted = {
+      ...value,
+      settlement_price: toChainFormat(value.settlement_price).toFixed(),
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    const messageAdjusted = {
+      ...web3gw,
+      settlement_price: numberToCosmosSdkDecString(params.settlementPrice),
+      status: InjectiveExchangeV2MarketPb.MarketStatus[params.status],
+    }
+
+    return messageAdjusted
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgAdminUpdateBinaryOptionsMarket',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgAdminUpdateBinaryOptionsMarket.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAuthorizeStakeGrantsV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAuthorizeStakeGrantsV2.spec.ts
@@ -1,0 +1,91 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgAuthorizeStakeGrantsV2 from './MsgAuthorizeStakeGrantsV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgAuthorizeStakeGrantsV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  grantee: mockFactory.injectiveAddress2,
+  amount: '1000000000000000000',
+}
+
+const protoType = '/injective.exchange.v2.MsgAuthorizeStakeGrants'
+const protoTypeShort = 'exchange/MsgAuthorizeStakeGrants'
+const protoParams = {
+  sender: params.injectiveAddress,
+  grants: [{ grantee: params.grantee, amount: params.amount }],
+}
+const message = MsgAuthorizeStakeGrantsV2.fromJSON(params)
+
+describe('MsgAuthorizeStakeGrantsV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: { sender: protoParams.sender, grants: protoParams.grants },
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      sender: protoParams.sender,
+      grants: protoParams.grants,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAuthorizeStakeGrantsV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgAuthorizeStakeGrantsV2.ts
@@ -1,0 +1,89 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgAuthorizeStakeGrantsV2 {
+  export interface Params {
+    grantee: string
+    injectiveAddress: string
+    amount: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgAuthorizeStakeGrants
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgAuthorizeStakeGrantsV2 extends MsgBase<
+  MsgAuthorizeStakeGrantsV2.Params,
+  MsgAuthorizeStakeGrantsV2.Proto
+> {
+  static fromJSON(
+    params: MsgAuthorizeStakeGrantsV2.Params,
+  ): MsgAuthorizeStakeGrantsV2 {
+    return new MsgAuthorizeStakeGrantsV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgAuthorizeStakeGrants.create({
+      sender: params.injectiveAddress,
+      grants: [
+        {
+          grantee: params.grantee,
+          amount: params.amount,
+        },
+      ],
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgAuthorizeStakeGrants',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      grants: proto.grants,
+    }
+
+    return {
+      type: 'exchange/MsgAuthorizeStakeGrants',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgAuthorizeStakeGrants',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgAuthorizeStakeGrants',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgAuthorizeStakeGrants.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.spec.ts
@@ -1,0 +1,88 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgBatchCancelBinaryOptionsOrdersV2 from './MsgBatchCancelBinaryOptionsOrdersV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgBatchCancelBinaryOptionsOrdersV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      subaccountId: mockFactory.subaccountId,
+      orderHash: mockFactory.orderHash,
+      cid: 'order-1',
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v2.MsgBatchCancelBinaryOptionsOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelBinaryOptionsOrders'
+const message = MsgBatchCancelBinaryOptionsOrdersV2.fromJSON(params)
+
+describe('MsgBatchCancelBinaryOptionsOrdersV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto.sender).toStrictEqual(params.injectiveAddress)
+    expect(proto.data).toHaveLength(1)
+    expect(proto.data[0].marketId).toStrictEqual(params.orders[0].marketId)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data['@type']).toStrictEqual(protoType)
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino.type).toStrictEqual(protoTypeShort)
+    expect(amino.value.sender).toStrictEqual(params.injectiveAddress)
+    expect(amino.value.data[0].market_id).toStrictEqual(
+      params.orders[0].marketId,
+    )
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3['@type']).toStrictEqual(protoType)
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.ts
@@ -1,0 +1,107 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgBatchCancelBinaryOptionsOrdersV2 {
+  export interface Params {
+    injectiveAddress: string
+    orders: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      orderMask?: InjectiveExchangeV2OrderPb.OrderMask
+      cid?: string
+    }[]
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgBatchCancelBinaryOptionsOrders
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgBatchCancelBinaryOptionsOrdersV2 extends MsgBase<
+  MsgBatchCancelBinaryOptionsOrdersV2.Params,
+  MsgBatchCancelBinaryOptionsOrdersV2.Proto
+> {
+  static fromJSON(
+    params: MsgBatchCancelBinaryOptionsOrdersV2.Params,
+  ): MsgBatchCancelBinaryOptionsOrdersV2 {
+    return new MsgBatchCancelBinaryOptionsOrdersV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const orderDataList = params.orders.map((order) => {
+      return InjectiveExchangeV2TxPb.OrderData.create({
+        marketId: order.marketId,
+        subaccountId: order.subaccountId,
+        orderHash: order.orderHash || '',
+        orderMask: InjectiveExchangeV2OrderPb.OrderMask.ANY,
+        cid: order.cid || '',
+      })
+    })
+
+    const message =
+      InjectiveExchangeV2TxPb.MsgBatchCancelBinaryOptionsOrders.create({
+        sender: params.injectiveAddress,
+        data: orderDataList,
+      })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelBinaryOptionsOrders',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      data: params.orders.map((order) => ({
+        market_id: order.marketId,
+        subaccount_id: order.subaccountId,
+        order_hash: order.orderHash,
+        order_mask: order.orderMask,
+        cid: order.cid,
+      })),
+    }
+
+    return {
+      type: 'exchange/MsgBatchCancelBinaryOptionsOrders',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelBinaryOptionsOrders',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgBatchCancelBinaryOptionsOrders',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgBatchCancelBinaryOptionsOrders.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrdersV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrdersV2.spec.ts
@@ -1,0 +1,88 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgBatchCancelDerivativeOrdersV2 from './MsgBatchCancelDerivativeOrdersV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgBatchCancelDerivativeOrdersV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      subaccountId: mockFactory.subaccountId,
+      orderHash: mockFactory.orderHash,
+      cid: 'order-1',
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v2.MsgBatchCancelDerivativeOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelDerivativeOrders'
+const message = MsgBatchCancelDerivativeOrdersV2.fromJSON(params)
+
+describe('MsgBatchCancelDerivativeOrdersV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto.sender).toStrictEqual(params.injectiveAddress)
+    expect(proto.data).toHaveLength(1)
+    expect(proto.data[0].marketId).toStrictEqual(params.orders[0].marketId)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data['@type']).toStrictEqual(protoType)
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino.type).toStrictEqual(protoTypeShort)
+    expect(amino.value.sender).toStrictEqual(params.injectiveAddress)
+    expect(amino.value.data[0].market_id).toStrictEqual(
+      params.orders[0].marketId,
+    )
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3['@type']).toStrictEqual(protoType)
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrdersV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelDerivativeOrdersV2.ts
@@ -1,0 +1,110 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgBatchCancelDerivativeOrdersV2 {
+  export interface Params {
+    injectiveAddress: string
+    orders: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      orderMask?: InjectiveExchangeV2OrderPb.OrderMask
+      cid?: string
+    }[]
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgBatchCancelDerivativeOrders
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgBatchCancelDerivativeOrdersV2 extends MsgBase<
+  MsgBatchCancelDerivativeOrdersV2.Params,
+  MsgBatchCancelDerivativeOrdersV2.Proto
+> {
+  static fromJSON(
+    params: MsgBatchCancelDerivativeOrdersV2.Params,
+  ): MsgBatchCancelDerivativeOrdersV2 {
+    return new MsgBatchCancelDerivativeOrdersV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const orderDataList = params.orders.map((order) => {
+      const orderData = InjectiveExchangeV2TxPb.OrderData.create({
+        marketId: order.marketId,
+        subaccountId: order.subaccountId,
+        orderHash: order.orderHash || '',
+        orderMask:
+          order.orderMask || InjectiveExchangeV2OrderPb.OrderMask.ANY,
+        cid: order.cid || '',
+      })
+
+      return orderData
+    })
+
+    const message =
+      InjectiveExchangeV2TxPb.MsgBatchCancelDerivativeOrders.create({
+        sender: params.injectiveAddress,
+        data: orderDataList,
+      })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelDerivativeOrders',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      data: proto.data.map((orderData) => ({
+        market_id: orderData.marketId,
+        subaccount_id: orderData.subaccountId,
+        order_hash: orderData.orderHash,
+        order_mask: orderData.orderMask,
+        cid: orderData.cid,
+      })),
+    }
+
+    return {
+      type: 'exchange/MsgBatchCancelDerivativeOrders',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelDerivativeOrders',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgBatchCancelDerivativeOrders',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgBatchCancelDerivativeOrders.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrdersV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrdersV2.spec.ts
@@ -1,0 +1,88 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgBatchCancelSpotOrdersV2 from './MsgBatchCancelSpotOrdersV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgBatchCancelSpotOrdersV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  orders: [
+    {
+      marketId: mockFactory.injUsdtSpotMarket.marketId,
+      subaccountId: mockFactory.subaccountId,
+      orderHash: mockFactory.orderHash,
+      cid: 'order-1',
+    },
+  ],
+}
+
+const protoType = '/injective.exchange.v2.MsgBatchCancelSpotOrders'
+const protoTypeShort = 'exchange/MsgBatchCancelSpotOrders'
+const message = MsgBatchCancelSpotOrdersV2.fromJSON(params)
+
+describe('MsgBatchCancelSpotOrdersV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto.sender).toStrictEqual(params.injectiveAddress)
+    expect(proto.data).toHaveLength(1)
+    expect(proto.data[0].marketId).toStrictEqual(params.orders[0].marketId)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data['@type']).toStrictEqual(protoType)
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino.type).toStrictEqual(protoTypeShort)
+    expect(amino.value.sender).toStrictEqual(params.injectiveAddress)
+    expect(amino.value.data[0].market_id).toStrictEqual(
+      params.orders[0].marketId,
+    )
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3['@type']).toStrictEqual(protoType)
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrdersV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchCancelSpotOrdersV2.ts
@@ -1,0 +1,109 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgBatchCancelSpotOrdersV2 {
+  export interface Params {
+    injectiveAddress: string
+    orders: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      orderMask?: InjectiveExchangeV2OrderPb.OrderMask
+      cid?: string
+    }[]
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgBatchCancelSpotOrders
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgBatchCancelSpotOrdersV2 extends MsgBase<
+  MsgBatchCancelSpotOrdersV2.Params,
+  MsgBatchCancelSpotOrdersV2.Proto
+> {
+  static fromJSON(
+    params: MsgBatchCancelSpotOrdersV2.Params,
+  ): MsgBatchCancelSpotOrdersV2 {
+    return new MsgBatchCancelSpotOrdersV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const orderDataList = params.orders.map((order) => {
+      const orderData = InjectiveExchangeV2TxPb.OrderData.create({
+        marketId: order.marketId,
+        subaccountId: order.subaccountId,
+        orderHash: order.orderHash || '',
+        orderMask:
+          order.orderMask || InjectiveExchangeV2OrderPb.OrderMask.ANY,
+        cid: order.cid || '',
+      })
+
+      return orderData
+    })
+
+    const message = InjectiveExchangeV2TxPb.MsgBatchCancelSpotOrders.create({
+      sender: params.injectiveAddress,
+      data: orderDataList,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelSpotOrders',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      data: proto.data.map((orderData) => ({
+        market_id: orderData.marketId,
+        subaccount_id: orderData.subaccountId,
+        order_hash: orderData.orderHash,
+        order_mask: orderData.orderMask,
+        cid: orderData.cid,
+      })),
+    }
+
+    return {
+      type: 'exchange/MsgBatchCancelSpotOrders',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchCancelSpotOrders',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgBatchCancelSpotOrders',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgBatchCancelSpotOrders.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchUpdateOrdersV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchUpdateOrdersV2.spec.ts
@@ -1,0 +1,59 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgBatchUpdateOrdersV2 from './MsgBatchUpdateOrdersV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgBatchUpdateOrdersV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  subaccountId: mockFactory.subaccountId,
+  spotOrdersToCreate: [
+    {
+      orderType: 1,
+      marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+      feeRecipient: mockFactory.injectiveAddress2,
+      price: '1500000',
+      quantity: '100',
+      cid: 'test-cid',
+    },
+  ],
+}
+
+const message = MsgBatchUpdateOrdersV2.fromJSON(params)
+
+describe('MsgBatchUpdateOrdersV2', () => {
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchUpdateOrdersV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgBatchUpdateOrdersV2.ts
@@ -1,0 +1,575 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+type SnakeCaseKeys<T extends Record<string, any> | readonly any[]> = T
+
+interface SpotOrderToCreate {
+  orderType: InjectiveExchangeV2OrderPb.OrderType
+  triggerPrice?: string
+  marketId: string
+  feeRecipient: string
+  price: string
+  quantity: string
+  cid?: string
+}
+
+interface DerivativeOrderToCreate {
+  orderType: InjectiveExchangeV2OrderPb.OrderType
+  triggerPrice?: string
+  feeRecipient: string
+  marketId: string
+  price: string
+  margin: string
+  quantity: string
+  cid?: string
+}
+
+interface BinaryOptionOrderToCreate {
+  orderType: InjectiveExchangeV2OrderPb.OrderType
+  triggerPrice?: string
+  feeRecipient: string
+  marketId: string
+  price: string
+  margin: string
+  quantity: string
+  cid?: string
+}
+
+export declare namespace MsgBatchUpdateOrdersV2 {
+  export interface Params {
+    subaccountId: string
+    spotMarketIdsToCancelAll?: string[]
+    derivativeMarketIdsToCancelAll?: string[]
+    binaryOptionsMarketIdsToCancelAll?: string[]
+    spotOrdersToCancel?: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      cid?: string
+    }[]
+    derivativeOrdersToCancel?: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      cid?: string
+    }[]
+    binaryOptionsOrdersToCancel?: {
+      marketId: string
+      subaccountId: string
+      orderHash?: string
+      cid?: string
+    }[]
+    spotOrdersToCreate?: SpotOrderToCreate[]
+    derivativeOrdersToCreate?: DerivativeOrderToCreate[]
+    binaryOptionsOrdersToCreate?: BinaryOptionOrderToCreate[]
+    spotMarketOrdersToCreate?: SpotOrderToCreate[]
+    derivativeMarketOrdersToCreate?: DerivativeOrderToCreate[]
+    binaryOptionsMarketOrdersToCreate?: BinaryOptionOrderToCreate[]
+    injectiveAddress: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgBatchUpdateOrders
+}
+
+const createSpotOrder = (
+  args: SpotOrderToCreate & { subaccountId: string },
+) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: args.subaccountId,
+    feeRecipient: args.feeRecipient,
+    price: args.price,
+    quantity: args.quantity,
+    cid: args.cid,
+  })
+
+  const order = InjectiveExchangeV2OrderPb.SpotOrder.create({
+    marketId: args.marketId,
+    orderType: args.orderType,
+    orderInfo: orderInfo,
+    triggerPrice: args.triggerPrice,
+  })
+
+  return order
+}
+
+const createDerivativeOrder = (
+  args: DerivativeOrderToCreate & { subaccountId: string },
+) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: args.subaccountId,
+    feeRecipient: args.feeRecipient,
+    price: args.price,
+    quantity: args.quantity,
+    cid: args.cid,
+  })
+
+  const order = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: args.marketId,
+    orderType: args.orderType,
+    orderInfo: orderInfo,
+    margin: args.margin,
+    triggerPrice: args.triggerPrice,
+  })
+
+  return order
+}
+
+const createBinaryOptionOrder = (
+  args: BinaryOptionOrderToCreate & { subaccountId: string },
+) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: args.subaccountId,
+    feeRecipient: args.feeRecipient,
+    price: args.price,
+    quantity: args.quantity,
+    cid: args.cid,
+  })
+
+  const order = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: args.marketId,
+    orderType: args.orderType,
+    orderInfo: orderInfo,
+    margin: args.margin,
+    triggerPrice: args.triggerPrice,
+  })
+
+  return order
+}
+
+const createMsgAndCancelOrders = (params: MsgBatchUpdateOrdersV2.Params) => {
+  const hasCancelAll =
+    (params.spotMarketIdsToCancelAll &&
+      params.spotMarketIdsToCancelAll.length > 0) ||
+    (params.derivativeMarketIdsToCancelAll &&
+      params.derivativeMarketIdsToCancelAll.length > 0) ||
+    (params.binaryOptionsMarketIdsToCancelAll &&
+      params.binaryOptionsMarketIdsToCancelAll.length > 0)
+
+  const message = InjectiveExchangeV2TxPb.MsgBatchUpdateOrders.create({
+    sender: params.injectiveAddress,
+    ...(hasCancelAll && { subaccountId: params.subaccountId }),
+  })
+
+  if (
+    params.spotMarketIdsToCancelAll &&
+    params.spotMarketIdsToCancelAll.length > 0
+  ) {
+    message.spotMarketIdsToCancelAll = params.spotMarketIdsToCancelAll
+  }
+
+  if (
+    params.derivativeMarketIdsToCancelAll &&
+    params.derivativeMarketIdsToCancelAll.length > 0
+  ) {
+    message.derivativeMarketIdsToCancelAll =
+      params.derivativeMarketIdsToCancelAll
+  }
+
+  if (
+    params.binaryOptionsMarketIdsToCancelAll &&
+    params.binaryOptionsMarketIdsToCancelAll.length > 0
+  ) {
+    message.binaryOptionsMarketIdsToCancelAll =
+      params.binaryOptionsMarketIdsToCancelAll
+  }
+
+  if (params.spotOrdersToCancel) {
+    message.spotOrdersToCancel = params.spotOrdersToCancel.map(
+      ({ marketId, subaccountId, orderHash, cid }) => {
+        return InjectiveExchangeV2TxPb.OrderData.create({
+          marketId,
+          subaccountId,
+          orderHash,
+          cid,
+        })
+      },
+    )
+  }
+
+  if (params.derivativeOrdersToCancel) {
+    message.derivativeOrdersToCancel = params.derivativeOrdersToCancel.map(
+      ({ marketId, subaccountId, orderHash, cid }) => {
+        return InjectiveExchangeV2TxPb.OrderData.create({
+          marketId,
+          subaccountId,
+          orderHash,
+          cid,
+        })
+      },
+    )
+  }
+
+  if (params.binaryOptionsOrdersToCancel) {
+    message.binaryOptionsOrdersToCancel =
+      params.binaryOptionsOrdersToCancel.map(
+        ({ marketId, subaccountId, orderHash, cid }) => {
+          return InjectiveExchangeV2TxPb.OrderData.create({
+            marketId,
+            subaccountId,
+            orderHash,
+            cid,
+          })
+        },
+      )
+  }
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgBatchUpdateOrdersV2 extends MsgBase<
+  MsgBatchUpdateOrdersV2.Params,
+  MsgBatchUpdateOrdersV2.Proto
+> {
+  static fromJSON(
+    params: MsgBatchUpdateOrdersV2.Params,
+  ): MsgBatchUpdateOrdersV2 {
+    return new MsgBatchUpdateOrdersV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = createMsgAndCancelOrders(params)
+
+    if (params.spotOrdersToCreate) {
+      message.spotOrdersToCreate = params.spotOrdersToCreate.map((args) => {
+        const paramsFromArgs = {
+          ...args,
+          price: toChainFormat(args.price).toFixed(),
+          triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+          quantity: toChainFormat(args.quantity).toFixed(),
+        }
+
+        return createSpotOrder({
+          ...args,
+          ...paramsFromArgs,
+          subaccountId: params.subaccountId,
+        })
+      })
+    }
+
+    if (params.derivativeOrdersToCreate) {
+      message.derivativeOrdersToCreate = params.derivativeOrdersToCreate.map(
+        (args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: toChainFormat(args.price).toFixed(),
+            margin: toChainFormat(args.margin).toFixed(),
+            triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+            quantity: toChainFormat(args.quantity).toFixed(),
+          }
+
+          return createDerivativeOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        },
+      )
+    }
+
+    if (params.binaryOptionsOrdersToCreate) {
+      message.binaryOptionsOrdersToCreate =
+        params.binaryOptionsOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: toChainFormat(args.price).toFixed(),
+            margin: toChainFormat(args.margin).toFixed(),
+            triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+            quantity: toChainFormat(args.quantity).toFixed(),
+          }
+
+          return createBinaryOptionOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    if (params.spotMarketOrdersToCreate) {
+      message.spotMarketOrdersToCreate = params.spotMarketOrdersToCreate.map(
+        (args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: toChainFormat(args.price).toFixed(),
+            triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+            quantity: toChainFormat(args.quantity).toFixed(),
+          }
+
+          return createSpotOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        },
+      )
+    }
+
+    if (params.derivativeMarketOrdersToCreate) {
+      message.derivativeMarketOrdersToCreate =
+        params.derivativeMarketOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: toChainFormat(args.price).toFixed(),
+            margin: toChainFormat(args.margin).toFixed(),
+            triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+            quantity: toChainFormat(args.quantity).toFixed(),
+          }
+
+          return createDerivativeOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    if (params.binaryOptionsMarketOrdersToCreate) {
+      message.binaryOptionsMarketOrdersToCreate =
+        params.binaryOptionsMarketOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: toChainFormat(args.price).toFixed(),
+            margin: toChainFormat(args.margin).toFixed(),
+            triggerPrice: toChainFormat(args.triggerPrice || 0).toFixed(),
+            quantity: toChainFormat(args.quantity).toFixed(),
+          }
+
+          return createBinaryOptionOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchUpdateOrders',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+
+    const message = createMsgAndCancelOrders(params)
+
+    if (params.spotOrdersToCreate) {
+      message.spotOrdersToCreate = params.spotOrdersToCreate.map((args) => {
+        const paramsFromArgs = {
+          ...args,
+          price: args.price,
+          triggerPrice: args.triggerPrice || '0',
+          quantity: args.quantity,
+        }
+
+        return createSpotOrder({
+          ...args,
+          ...paramsFromArgs,
+          subaccountId: params.subaccountId,
+        })
+      })
+    }
+
+    if (params.derivativeOrdersToCreate) {
+      message.derivativeOrdersToCreate = params.derivativeOrdersToCreate.map(
+        (args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: args.price,
+            margin: args.margin,
+            triggerPrice: args.triggerPrice || '0',
+            quantity: args.quantity,
+          }
+
+          return createDerivativeOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        },
+      )
+    }
+
+    if (params.binaryOptionsOrdersToCreate) {
+      message.binaryOptionsOrdersToCreate =
+        params.binaryOptionsOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: args.price,
+            margin: args.margin,
+            triggerPrice: args.triggerPrice || '0',
+            quantity: args.quantity,
+          }
+
+          return createBinaryOptionOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    if (params.spotMarketOrdersToCreate) {
+      message.spotMarketOrdersToCreate = params.spotMarketOrdersToCreate.map(
+        (args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: args.price,
+            triggerPrice: args.triggerPrice || '0',
+            quantity: args.quantity,
+          }
+
+          return createSpotOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        },
+      )
+    }
+
+    if (params.derivativeMarketOrdersToCreate) {
+      message.derivativeMarketOrdersToCreate =
+        params.derivativeMarketOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: args.price,
+            margin: args.margin,
+            triggerPrice: args.triggerPrice || '0',
+            quantity: args.quantity,
+          }
+
+          return createDerivativeOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    if (params.binaryOptionsMarketOrdersToCreate) {
+      message.binaryOptionsMarketOrdersToCreate =
+        params.binaryOptionsMarketOrdersToCreate.map((args) => {
+          const paramsFromArgs = {
+            ...args,
+            price: args.price,
+            margin: args.margin,
+            triggerPrice: args.triggerPrice || '0',
+            quantity: args.quantity,
+          }
+
+          return createBinaryOptionOrder({
+            ...args,
+            ...paramsFromArgs,
+            subaccountId: params.subaccountId,
+          })
+        })
+    }
+
+    const orderInfoToSnakeCase = (orderInfo: any) => ({
+      subaccount_id: orderInfo.subaccountId,
+      fee_recipient: orderInfo.feeRecipient,
+      price: orderInfo.price,
+      quantity: orderInfo.quantity,
+      cid: orderInfo.cid,
+    })
+
+    const spotOrderToSnakeCase = (order: any) => ({
+      market_id: order.marketId,
+      order_type: order.orderType,
+      order_info: orderInfoToSnakeCase(order.orderInfo),
+      trigger_price: order.triggerPrice,
+    })
+
+    const derivativeOrderToSnakeCase = (order: any) => ({
+      market_id: order.marketId,
+      order_type: order.orderType,
+      order_info: orderInfoToSnakeCase(order.orderInfo),
+      margin: order.margin,
+      trigger_price: order.triggerPrice,
+    })
+
+    const orderDataToSnakeCase = (orderData: any) => ({
+      market_id: orderData.marketId,
+      subaccount_id: orderData.subaccountId,
+      order_hash: orderData.orderHash,
+      cid: orderData.cid,
+    })
+
+    const msg = {
+      sender: message.sender,
+      subaccount_id: message.subaccountId,
+      spot_market_ids_to_cancel_all: message.spotMarketIdsToCancelAll,
+      derivative_market_ids_to_cancel_all:
+        message.derivativeMarketIdsToCancelAll,
+      binary_options_market_ids_to_cancel_all:
+        message.binaryOptionsMarketIdsToCancelAll,
+      spot_orders_to_cancel:
+        message.spotOrdersToCancel.map(orderDataToSnakeCase),
+      derivative_orders_to_cancel:
+        message.derivativeOrdersToCancel.map(orderDataToSnakeCase),
+      binary_options_orders_to_cancel:
+        message.binaryOptionsOrdersToCancel.map(orderDataToSnakeCase),
+      spot_orders_to_create:
+        message.spotOrdersToCreate.map(spotOrderToSnakeCase),
+      derivative_orders_to_create: message.derivativeOrdersToCreate.map(
+        derivativeOrderToSnakeCase,
+      ),
+      binary_options_orders_to_create: message.binaryOptionsOrdersToCreate.map(
+        derivativeOrderToSnakeCase,
+      ),
+      spot_market_orders_to_create:
+        message.spotMarketOrdersToCreate.map(spotOrderToSnakeCase),
+      derivative_market_orders_to_create:
+        message.derivativeMarketOrdersToCreate.map(derivativeOrderToSnakeCase),
+      binary_options_market_orders_to_create:
+        message.binaryOptionsMarketOrdersToCreate.map(
+          derivativeOrderToSnakeCase,
+        ),
+    }
+
+    return {
+      type: 'exchange/MsgBatchUpdateOrders',
+      value:
+        msg as unknown as SnakeCaseKeys<InjectiveExchangeV2TxPb.MsgBatchUpdateOrders>,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgBatchUpdateOrders',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgBatchUpdateOrders',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgBatchUpdateOrders.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrderV2.spec.ts
@@ -1,0 +1,97 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCancelBinaryOptionsOrderV2 from './MsgCancelBinaryOptionsOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCancelBinaryOptionsOrderV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderHash: mockFactory.orderHash,
+  subaccountId: mockFactory.subaccountId,
+  cid: 'order-123',
+}
+
+const protoType = '/injective.exchange.v2.MsgCancelBinaryOptionsOrder'
+const protoTypeShort = 'exchange/MsgCancelBinaryOptionsOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  marketId: params.marketId,
+  orderHash: params.orderHash,
+  subaccountId: params.subaccountId,
+  orderMask: 15,
+  cid: params.cid,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCancelBinaryOptionsOrderV2.fromJSON(params)
+
+describe('MsgCancelBinaryOptionsOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelBinaryOptionsOrderV2.ts
@@ -1,0 +1,97 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgCancelBinaryOptionsOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderHash?: string
+    orderMask?: InjectiveExchangeV2OrderPb.OrderMask
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCancelBinaryOptionsOrder
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCancelBinaryOptionsOrderV2 extends MsgBase<
+  MsgCancelBinaryOptionsOrderV2.Params,
+  MsgCancelBinaryOptionsOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCancelBinaryOptionsOrderV2.Params,
+  ): MsgCancelBinaryOptionsOrderV2 {
+    return new MsgCancelBinaryOptionsOrderV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message =
+      InjectiveExchangeV2TxPb.MsgCancelBinaryOptionsOrder.create({
+        sender: params.injectiveAddress,
+        marketId: params.marketId,
+        subaccountId: params.subaccountId,
+        orderHash: params.orderHash || '',
+        orderMask: InjectiveExchangeV2OrderPb.OrderMask.ANY,
+        cid: params.cid || '',
+      })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelBinaryOptionsOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      market_id: proto.marketId,
+      subaccount_id: proto.subaccountId,
+      order_hash: proto.orderHash,
+      order_mask: proto.orderMask,
+      cid: proto.cid,
+    }
+
+    return {
+      type: 'exchange/MsgCancelBinaryOptionsOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelBinaryOptionsOrder',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCancelBinaryOptionsOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCancelBinaryOptionsOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrderV2.spec.ts
@@ -1,0 +1,97 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCancelDerivativeOrderV2 from './MsgCancelDerivativeOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCancelDerivativeOrderV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderHash: mockFactory.orderHash,
+  subaccountId: mockFactory.subaccountId,
+  cid: 'order-123',
+}
+
+const protoType = '/injective.exchange.v2.MsgCancelDerivativeOrder'
+const protoTypeShort = 'exchange/MsgCancelDerivativeOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  marketId: params.marketId,
+  orderHash: params.orderHash,
+  subaccountId: params.subaccountId,
+  orderMask: 15,
+  cid: params.cid,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCancelDerivativeOrderV2.fromJSON(params)
+
+describe('MsgCancelDerivativeOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelDerivativeOrderV2.ts
@@ -1,0 +1,97 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgCancelDerivativeOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderHash?: string
+    orderMask?: InjectiveExchangeV2OrderPb.OrderMask
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCancelDerivativeOrder
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCancelDerivativeOrderV2 extends MsgBase<
+  MsgCancelDerivativeOrderV2.Params,
+  MsgCancelDerivativeOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCancelDerivativeOrderV2.Params,
+  ): MsgCancelDerivativeOrderV2 {
+    return new MsgCancelDerivativeOrderV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgCancelDerivativeOrder.create({
+      sender: params.injectiveAddress,
+      marketId: params.marketId,
+      subaccountId: params.subaccountId,
+      orderHash: params.orderHash || '',
+      orderMask:
+        params.orderMask || InjectiveExchangeV2OrderPb.OrderMask.ANY,
+      cid: params.cid || '',
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelDerivativeOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      market_id: proto.marketId,
+      subaccount_id: proto.subaccountId,
+      order_hash: proto.orderHash,
+      order_mask: proto.orderMask,
+      cid: proto.cid,
+    }
+
+    return {
+      type: 'exchange/MsgCancelDerivativeOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelDerivativeOrder',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCancelDerivativeOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCancelDerivativeOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrderV2.spec.ts
@@ -1,0 +1,96 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCancelSpotOrderV2 from './MsgCancelSpotOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCancelSpotOrderV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtSpotMarket.marketId,
+  orderHash: mockFactory.orderHash,
+  subaccountId: mockFactory.subaccountId,
+  cid: 'order-123',
+}
+
+const protoType = '/injective.exchange.v2.MsgCancelSpotOrder'
+const protoTypeShort = 'exchange/MsgCancelSpotOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  marketId: params.marketId,
+  orderHash: params.orderHash,
+  subaccountId: params.subaccountId,
+  cid: params.cid,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCancelSpotOrderV2.fromJSON(params)
+
+describe('MsgCancelSpotOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCancelSpotOrderV2.ts
@@ -1,0 +1,88 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgCancelSpotOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderHash?: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCancelSpotOrder
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCancelSpotOrderV2 extends MsgBase<
+  MsgCancelSpotOrderV2.Params,
+  MsgCancelSpotOrderV2.Proto
+> {
+  static fromJSON(params: MsgCancelSpotOrderV2.Params): MsgCancelSpotOrderV2 {
+    return new MsgCancelSpotOrderV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgCancelSpotOrder.create({
+      sender: params.injectiveAddress,
+      marketId: params.marketId,
+      subaccountId: params.subaccountId,
+      orderHash: params.orderHash || '',
+      cid: params.cid || '',
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelSpotOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      market_id: proto.marketId,
+      subaccount_id: proto.subaccountId,
+      order_hash: proto.orderHash,
+      cid: proto.cid,
+    }
+
+    return {
+      type: 'exchange/MsgCancelSpotOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCancelSpotOrder',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCancelSpotOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCancelSpotOrder.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.spec.ts
@@ -1,0 +1,122 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateBinaryOptionsLimitOrderV2 from './MsgCreateBinaryOptionsLimitOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateBinaryOptionsLimitOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  margin: '75000000',
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateBinaryOptionsLimitOrder'
+const protoTypeShort = 'exchange/MsgCreateBinaryOptionsLimitOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    margin: '75000000000000000000000000',
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateBinaryOptionsLimitOrderV2.fromJSON(params)
+
+describe('MsgCreateBinaryOptionsLimitOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.ts
@@ -1,0 +1,184 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateBinaryOptionsLimitOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    margin: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsLimitOrder
+}
+
+const createLimitOrder = (
+  params: MsgCreateBinaryOptionsLimitOrderV2.Params,
+) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const derivativeOrder = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message =
+    InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsLimitOrder.create({
+      sender: params.injectiveAddress,
+      order: derivativeOrder,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateBinaryOptionsLimitOrderV2 extends MsgBase<
+  MsgCreateBinaryOptionsLimitOrderV2.Params,
+  MsgCreateBinaryOptionsLimitOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateBinaryOptionsLimitOrderV2.Params,
+  ): MsgCreateBinaryOptionsLimitOrderV2 {
+    return new MsgCreateBinaryOptionsLimitOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      margin: toChainFormat(initialParams.margin).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateBinaryOptionsLimitOrderV2.Params
+
+    return createLimitOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateBinaryOptionsLimitOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        margin: params.margin,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateBinaryOptionsLimitOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateBinaryOptionsLimitOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        margin: numberToCosmosSdkDecString(params.margin),
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        margin: toChainFormat(params.margin).toFixed(),
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateBinaryOptionsLimitOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsLimitOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.spec.ts
@@ -1,0 +1,122 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateBinaryOptionsMarketOrderV2 from './MsgCreateBinaryOptionsMarketOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateBinaryOptionsMarketOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  margin: '75000000',
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateBinaryOptionsMarketOrder'
+const protoTypeShort = 'exchange/MsgCreateBinaryOptionsMarketOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    margin: '75000000000000000000000000',
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateBinaryOptionsMarketOrderV2.fromJSON(params)
+
+describe('MsgCreateBinaryOptionsMarketOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.ts
@@ -1,0 +1,184 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateBinaryOptionsMarketOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    margin: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsMarketOrder
+}
+
+const createMarketOrder = (
+  params: MsgCreateBinaryOptionsMarketOrderV2.Params,
+) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const derivativeOrder = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message =
+    InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsMarketOrder.create({
+      sender: params.injectiveAddress,
+      order: derivativeOrder,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateBinaryOptionsMarketOrderV2 extends MsgBase<
+  MsgCreateBinaryOptionsMarketOrderV2.Params,
+  MsgCreateBinaryOptionsMarketOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateBinaryOptionsMarketOrderV2.Params,
+  ): MsgCreateBinaryOptionsMarketOrderV2 {
+    return new MsgCreateBinaryOptionsMarketOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      margin: toChainFormat(initialParams.margin).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateBinaryOptionsMarketOrderV2.Params
+
+    return createMarketOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateBinaryOptionsMarketOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        margin: params.margin,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateBinaryOptionsMarketOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateBinaryOptionsMarketOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        margin: numberToCosmosSdkDecString(params.margin),
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        margin: toChainFormat(params.margin).toFixed(),
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateBinaryOptionsMarketOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateBinaryOptionsMarketOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeLimitOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeLimitOrderV2.spec.ts
@@ -1,0 +1,122 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateDerivativeLimitOrderV2 from './MsgCreateDerivativeLimitOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateDerivativeLimitOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  margin: '75000000',
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateDerivativeLimitOrder'
+const protoTypeShort = 'exchange/MsgCreateDerivativeLimitOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    margin: '75000000000000000000000000',
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateDerivativeLimitOrderV2.fromJSON(params)
+
+describe('MsgCreateDerivativeLimitOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeLimitOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeLimitOrderV2.ts
@@ -1,0 +1,183 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateDerivativeLimitOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    margin: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateDerivativeLimitOrder
+}
+
+const createLimitOrder = (params: MsgCreateDerivativeLimitOrderV2.Params) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const derivativeOrder = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message =
+    InjectiveExchangeV2TxPb.MsgCreateDerivativeLimitOrder.create({
+      sender: params.injectiveAddress,
+      order: derivativeOrder,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateDerivativeLimitOrderV2 extends MsgBase<
+  MsgCreateDerivativeLimitOrderV2.Params,
+  MsgCreateDerivativeLimitOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateDerivativeLimitOrderV2.Params,
+  ): MsgCreateDerivativeLimitOrderV2 {
+    return new MsgCreateDerivativeLimitOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      margin: toChainFormat(initialParams.margin).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateDerivativeLimitOrderV2.Params
+
+    return createLimitOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateDerivativeLimitOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        margin: params.margin,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateDerivativeLimitOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateDerivativeLimitOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        margin: numberToCosmosSdkDecString(params.margin),
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        margin: toChainFormat(params.margin).toFixed(),
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateDerivativeLimitOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateDerivativeLimitOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeMarketOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeMarketOrderV2.spec.ts
@@ -1,0 +1,122 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateDerivativeMarketOrderV2 from './MsgCreateDerivativeMarketOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateDerivativeMarketOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  margin: '75000000',
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateDerivativeMarketOrder'
+const protoTypeShort = 'exchange/MsgCreateDerivativeMarketOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    margin: '75000000000000000000000000',
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateDerivativeMarketOrderV2.fromJSON(params)
+
+describe('MsgCreateDerivativeMarketOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeMarketOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateDerivativeMarketOrderV2.ts
@@ -1,0 +1,182 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateDerivativeMarketOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    margin: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateDerivativeMarketOrder
+}
+
+const createMarketOrder = (params: MsgCreateDerivativeMarketOrderV2.Params) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const derivativeOrder = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    margin: params.margin,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message =
+    InjectiveExchangeV2TxPb.MsgCreateDerivativeMarketOrder.create({
+      sender: params.injectiveAddress,
+      order: derivativeOrder,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateDerivativeMarketOrderV2 extends MsgBase<
+  MsgCreateDerivativeMarketOrderV2.Params,
+  MsgCreateDerivativeMarketOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateDerivativeMarketOrderV2.Params,
+  ): MsgCreateDerivativeMarketOrderV2 {
+    return new MsgCreateDerivativeMarketOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      margin: toChainFormat(initialParams.margin).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateDerivativeMarketOrderV2.Params
+
+    return createMarketOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateDerivativeMarketOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        margin: params.margin,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateDerivativeMarketOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateDerivativeMarketOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        margin: numberToCosmosSdkDecString(params.margin),
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        margin: toChainFormat(params.margin).toFixed(),
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateDerivativeMarketOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateDerivativeMarketOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotLimitOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotLimitOrderV2.spec.ts
@@ -1,0 +1,119 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateSpotLimitOrderV2 from './MsgCreateSpotLimitOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateSpotLimitOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateSpotLimitOrder'
+const protoTypeShort = 'exchange/MsgCreateSpotLimitOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateSpotLimitOrderV2.fromJSON(params)
+
+describe('MsgCreateSpotLimitOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotLimitOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotLimitOrderV2.ts
@@ -1,0 +1,176 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateSpotLimitOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateSpotLimitOrder
+}
+
+const createLimitOrder = (params: MsgCreateSpotLimitOrderV2.Params) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const spotOrder = InjectiveExchangeV2OrderPb.SpotOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message = InjectiveExchangeV2TxPb.MsgCreateSpotLimitOrder.create({
+    sender: params.injectiveAddress,
+    order: spotOrder,
+  })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateSpotLimitOrderV2 extends MsgBase<
+  MsgCreateSpotLimitOrderV2.Params,
+  MsgCreateSpotLimitOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateSpotLimitOrderV2.Params,
+  ): MsgCreateSpotLimitOrderV2 {
+    return new MsgCreateSpotLimitOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateSpotLimitOrderV2.Params
+
+    return createLimitOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateSpotLimitOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateSpotLimitOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateSpotLimitOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateSpotLimitOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateSpotLimitOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotMarketOrderV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotMarketOrderV2.spec.ts
@@ -1,0 +1,119 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgCreateSpotMarketOrderV2 from './MsgCreateSpotMarketOrderV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgCreateSpotMarketOrderV2['params'] = {
+  feeRecipient: mockFactory.injectiveAddress2,
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  orderType: 1,
+  price: '1500000',
+  quantity: '100',
+  subaccountId: mockFactory.subaccountId,
+  cid: 'test-cid',
+  triggerPrice: '0',
+}
+
+const protoType = '/injective.exchange.v2.MsgCreateSpotMarketOrder'
+const protoTypeShort = 'exchange/MsgCreateSpotMarketOrder'
+const protoParams = {
+  sender: params.injectiveAddress,
+  order: {
+    marketId: params.marketId,
+    orderInfo: {
+      feeRecipient: params.feeRecipient,
+      price: params.price,
+      quantity: params.quantity,
+      subaccountId: params.subaccountId,
+      cid: params.cid,
+    },
+    orderType: params.orderType,
+    triggerPrice: params.triggerPrice,
+  },
+}
+const formattedProtoParams = {
+  ...protoParams,
+  order: {
+    ...protoParams.order,
+    orderInfo: {
+      ...protoParams.order.orderInfo,
+      price: '1500000000000000000000000',
+      quantity: '100000000000000000000',
+    },
+  },
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgCreateSpotMarketOrderV2.fromJSON(params)
+
+describe('MsgCreateSpotMarketOrderV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotMarketOrderV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgCreateSpotMarketOrderV2.ts
@@ -1,0 +1,175 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgCreateSpotMarketOrderV2 {
+  export interface Params {
+    marketId: string
+    subaccountId: string
+    injectiveAddress: string
+    orderType: InjectiveExchangeV2OrderPb.OrderType
+    triggerPrice?: string
+    feeRecipient: string
+    price: string
+    quantity: string
+    cid?: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgCreateSpotMarketOrder
+}
+
+const createMarketOrder = (params: MsgCreateSpotMarketOrderV2.Params) => {
+  const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+    subaccountId: params.subaccountId,
+    feeRecipient: params.feeRecipient,
+    price: params.price,
+    quantity: params.quantity,
+    cid: params.cid || '',
+  })
+
+  const spotOrder = InjectiveExchangeV2OrderPb.SpotOrder.create({
+    marketId: params.marketId,
+    orderInfo: orderInfo,
+    orderType: params.orderType,
+    triggerPrice: params.triggerPrice || '0',
+  })
+
+  const message = InjectiveExchangeV2TxPb.MsgCreateSpotMarketOrder.create({
+    sender: params.injectiveAddress,
+    order: spotOrder,
+  })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgCreateSpotMarketOrderV2 extends MsgBase<
+  MsgCreateSpotMarketOrderV2.Params,
+  MsgCreateSpotMarketOrderV2.Proto
+> {
+  static fromJSON(
+    params: MsgCreateSpotMarketOrderV2.Params,
+  ): MsgCreateSpotMarketOrderV2 {
+    return new MsgCreateSpotMarketOrderV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+    const params = {
+      ...initialParams,
+      price: toChainFormat(initialParams.price).toFixed(),
+      triggerPrice: toChainFormat(initialParams.triggerPrice || 0).toFixed(),
+      quantity: toChainFormat(initialParams.quantity).toFixed(),
+    } as MsgCreateSpotMarketOrderV2.Params
+
+    return createMarketOrder(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateSpotMarketOrder',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      order: {
+        market_id: params.marketId,
+        order_info: {
+          subaccount_id: params.subaccountId,
+          fee_recipient: params.feeRecipient,
+          price: params.price,
+          quantity: params.quantity,
+          cid: params.cid || '',
+        },
+        order_type: params.orderType,
+        trigger_price: params.triggerPrice || '0',
+      },
+    }
+
+    return {
+      type: 'exchange/MsgCreateSpotMarketOrder',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgCreateSpotMarketOrder',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: {
+        ...order,
+        order_info: {
+          ...order.order_info,
+          price: numberToCosmosSdkDecString(params.price),
+          quantity: numberToCosmosSdkDecString(params.quantity),
+        },
+        trigger_price: numberToCosmosSdkDecString(params.triggerPrice || '0'),
+        order_type: InjectiveExchangeV2OrderPb.OrderType[params.orderType],
+      },
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+
+    const messageAdjusted = {
+      ...value,
+      order: {
+        ...value.order,
+        order_info: {
+          ...value.order?.order_info,
+          price: toChainFormat(params.price).toFixed(),
+          quantity: toChainFormat(params.quantity).toFixed(),
+        },
+        trigger_price: toChainFormat(params.triggerPrice || '0').toFixed(),
+      },
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgCreateSpotMarketOrder',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgCreateSpotMarketOrder.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDecreasePositionMarginV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDecreasePositionMarginV2.spec.ts
@@ -1,0 +1,100 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgDecreasePositionMarginV2 from './MsgDecreasePositionMarginV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgDecreasePositionMarginV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  srcSubaccountId: mockFactory.subaccountId,
+  dstSubaccountId: mockFactory.subaccountId,
+  amount: '100',
+}
+
+const protoType = '/injective.exchange.v2.MsgDecreasePositionMargin'
+const protoTypeShort = 'exchange/MsgDecreasePositionMargin'
+const protoParams = {
+  sender: params.injectiveAddress,
+  sourceSubaccountId: params.srcSubaccountId,
+  destinationSubaccountId: params.dstSubaccountId,
+  marketId: params.marketId,
+  amount: params.amount,
+}
+const formattedProtoParams = {
+  ...protoParams,
+  amount: '100000000000000000000',
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgDecreasePositionMarginV2.fromJSON(params)
+
+describe('MsgDecreasePositionMarginV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDecreasePositionMarginV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDecreasePositionMarginV2.ts
@@ -1,0 +1,130 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgDecreasePositionMarginV2 {
+  export interface Params {
+    marketId: string
+    injectiveAddress: string
+    srcSubaccountId: string
+    dstSubaccountId: string
+    amount: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgDecreasePositionMargin
+}
+
+const createMessage = (params: MsgDecreasePositionMarginV2.Params) => {
+  const message = InjectiveExchangeV2TxPb.MsgDecreasePositionMargin.create({
+    sender: params.injectiveAddress,
+    sourceSubaccountId: params.srcSubaccountId,
+    destinationSubaccountId: params.dstSubaccountId,
+    marketId: params.marketId,
+    amount: params.amount,
+  })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgDecreasePositionMarginV2 extends MsgBase<
+  MsgDecreasePositionMarginV2.Params,
+  MsgDecreasePositionMarginV2.Proto
+> {
+  static fromJSON(
+    params: MsgDecreasePositionMarginV2.Params,
+  ): MsgDecreasePositionMarginV2 {
+    return new MsgDecreasePositionMarginV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      amount: toChainFormat(initialParams.amount).toFixed(),
+    } as MsgDecreasePositionMarginV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgDecreasePositionMargin',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      source_subaccount_id: params.srcSubaccountId,
+      destination_subaccount_id: params.dstSubaccountId,
+      market_id: params.marketId,
+      amount: params.amount,
+    }
+
+    return {
+      type: 'exchange/MsgDecreasePositionMargin',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgDecreasePositionMargin',
+      ...value,
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { type, value } = amino
+
+    const messageAdjusted = {
+      ...value,
+      amount: toChainFormat(value.amount).toFixed(),
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    const messageAdjusted = {
+      ...web3gw,
+      amount: numberToCosmosSdkDecString(params.amount),
+    }
+
+    return messageAdjusted
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgDecreasePositionMargin',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgDecreasePositionMargin.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDepositV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDepositV2.spec.ts
@@ -1,0 +1,95 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgDepositV2 from './MsgDepositV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgDepositV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  subaccountId: mockFactory.subaccountId,
+  amount: {
+    amount: '1000000',
+    denom: 'inj',
+  },
+}
+
+const protoType = '/injective.exchange.v2.MsgDeposit'
+const protoTypeShort = 'exchange/MsgDeposit'
+const protoParams = {
+  sender: params.injectiveAddress,
+  subaccountId: params.subaccountId,
+  amount: params.amount,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgDepositV2.fromJSON(params)
+
+describe('MsgDepositV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDepositV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgDepositV2.ts
@@ -1,0 +1,91 @@
+import * as CosmosBaseV1Beta1CoinPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/base/v1beta1/coin_pb'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgDepositV2 {
+  export interface Params {
+    subaccountId: string
+    injectiveAddress: string
+    amount: {
+      amount: string
+      denom: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgDeposit
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgDepositV2 extends MsgBase<
+  MsgDepositV2.Params,
+  MsgDepositV2.Proto
+> {
+  static fromJSON(params: MsgDepositV2.Params): MsgDepositV2 {
+    return new MsgDepositV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const amountCoin = CosmosBaseV1Beta1CoinPb.Coin.create({
+      denom: params.amount.denom,
+      amount: params.amount.amount,
+    })
+
+    const message = InjectiveExchangeV2TxPb.MsgDeposit.create({
+      sender: params.injectiveAddress,
+      subaccountId: params.subaccountId,
+      amount: amountCoin,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgDeposit',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      subaccount_id: proto.subaccountId,
+      amount: proto.amount,
+    }
+
+    return {
+      type: 'exchange/MsgDeposit',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgDeposit',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgDeposit',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgDeposit.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgExternalTransferV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgExternalTransferV2.spec.ts
@@ -1,0 +1,97 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgExternalTransferV2 from './MsgExternalTransferV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgExternalTransferV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  srcSubaccountId: mockFactory.subaccountId,
+  dstSubaccountId: mockFactory.subaccountId,
+  amount: {
+    amount: '1000000',
+    denom: 'inj',
+  },
+}
+
+const protoType = '/injective.exchange.v2.MsgExternalTransfer'
+const protoTypeShort = 'exchange/MsgExternalTransfer'
+const protoParams = {
+  sender: params.injectiveAddress,
+  sourceSubaccountId: params.srcSubaccountId,
+  destinationSubaccountId: params.dstSubaccountId,
+  amount: params.amount,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgExternalTransferV2.fromJSON(params)
+
+describe('MsgExternalTransferV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgExternalTransferV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgExternalTransferV2.ts
@@ -1,0 +1,94 @@
+import * as CosmosBaseV1Beta1CoinPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/base/v1beta1/coin_pb'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgExternalTransferV2 {
+  export interface Params {
+    srcSubaccountId: string
+    dstSubaccountId: string
+    injectiveAddress: string
+    amount: {
+      amount: string
+      denom: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgExternalTransfer
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgExternalTransferV2 extends MsgBase<
+  MsgExternalTransferV2.Params,
+  MsgExternalTransferV2.Proto
+> {
+  static fromJSON(params: MsgExternalTransferV2.Params): MsgExternalTransferV2 {
+    return new MsgExternalTransferV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const amountCoin = CosmosBaseV1Beta1CoinPb.Coin.create({
+      denom: params.amount.denom,
+      amount: params.amount.amount,
+    })
+
+    const message = InjectiveExchangeV2TxPb.MsgExternalTransfer.create({
+      sender: params.injectiveAddress,
+      sourceSubaccountId: params.srcSubaccountId,
+      destinationSubaccountId: params.dstSubaccountId,
+      amount: amountCoin,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgExternalTransfer',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      source_subaccount_id: proto.sourceSubaccountId,
+      destination_subaccount_id: proto.destinationSubaccountId,
+      amount: proto.amount,
+    }
+
+    return {
+      type: 'exchange/MsgExternalTransfer',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgExternalTransfer',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgExternalTransfer',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgExternalTransfer.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgIncreasePositionMarginV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgIncreasePositionMarginV2.spec.ts
@@ -1,0 +1,100 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgIncreasePositionMarginV2 from './MsgIncreasePositionMarginV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgIncreasePositionMarginV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  srcSubaccountId: mockFactory.subaccountId,
+  dstSubaccountId: mockFactory.subaccountId,
+  amount: '100',
+}
+
+const protoType = '/injective.exchange.v2.MsgIncreasePositionMargin'
+const protoTypeShort = 'exchange/MsgIncreasePositionMargin'
+const protoParams = {
+  sender: params.injectiveAddress,
+  sourceSubaccountId: params.srcSubaccountId,
+  destinationSubaccountId: params.dstSubaccountId,
+  marketId: params.marketId,
+  amount: params.amount,
+}
+const formattedProtoParams = {
+  ...protoParams,
+  amount: '100000000000000000000',
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgIncreasePositionMarginV2.fromJSON(params)
+
+describe('MsgIncreasePositionMarginV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(formattedProtoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...formattedProtoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgIncreasePositionMarginV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgIncreasePositionMarginV2.ts
@@ -1,0 +1,130 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgIncreasePositionMarginV2 {
+  export interface Params {
+    marketId: string
+    injectiveAddress: string
+    srcSubaccountId: string
+    dstSubaccountId: string
+    amount: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgIncreasePositionMargin
+}
+
+const createMessage = (params: MsgIncreasePositionMarginV2.Params) => {
+  const message = InjectiveExchangeV2TxPb.MsgIncreasePositionMargin.create({
+    sender: params.injectiveAddress,
+    sourceSubaccountId: params.srcSubaccountId,
+    destinationSubaccountId: params.dstSubaccountId,
+    marketId: params.marketId,
+    amount: params.amount,
+  })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgIncreasePositionMarginV2 extends MsgBase<
+  MsgIncreasePositionMarginV2.Params,
+  MsgIncreasePositionMarginV2.Proto
+> {
+  static fromJSON(
+    params: MsgIncreasePositionMarginV2.Params,
+  ): MsgIncreasePositionMarginV2 {
+    return new MsgIncreasePositionMarginV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      amount: toChainFormat(initialParams.amount).toFixed(),
+    } as MsgIncreasePositionMarginV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgIncreasePositionMargin',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.injectiveAddress,
+      source_subaccount_id: params.srcSubaccountId,
+      destination_subaccount_id: params.dstSubaccountId,
+      market_id: params.marketId,
+      amount: params.amount,
+    }
+
+    return {
+      type: 'exchange/MsgIncreasePositionMargin',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgIncreasePositionMargin',
+      ...value,
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { type, value } = amino
+
+    const messageAdjusted = {
+      ...value,
+      amount: toChainFormat(value.amount).toFixed(),
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    const messageAdjusted = {
+      ...web3gw,
+      amount: numberToCosmosSdkDecString(params.amount),
+    }
+
+    return messageAdjusted
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgIncreasePositionMargin',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgIncreasePositionMargin.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.spec.ts
@@ -1,0 +1,64 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgInstantBinaryOptionsMarketLaunchV2 from './MsgInstantBinaryOptionsMarketLaunchV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgInstantBinaryOptionsMarketLaunchV2['params'] = {
+  proposer: mockFactory.injectiveAddress,
+  market: {
+    ticker: 'INJ/USDT',
+    admin: mockFactory.injectiveAddress,
+    oracleSymbol: 'INJ/USDT',
+    oracleProvider: 'provider',
+    oracleScaleFactor: 6,
+    quoteDenom: 'peggy0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+    minPriceTickSize: '0.000000000000001',
+    minQuantityTickSize: '1000000000000000',
+    makerFeeRate: '-0.00005',
+    takerFeeRate: '0.0005',
+    minNotional: '1000000',
+    oracleType: 7,
+    expirationTimestamp: 1713177600,
+    settlementTimestamp: 1713177600,
+  },
+}
+
+const message = MsgInstantBinaryOptionsMarketLaunchV2.fromJSON(params)
+
+describe('MsgInstantBinaryOptionsMarketLaunchV2', () => {
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it.skip('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.ts
@@ -1,0 +1,198 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveOracleV1Beta1OraclePb from '@injectivelabs/core-proto-ts-v2/generated/injective/oracle/v1beta1/oracle_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgInstantBinaryOptionsMarketLaunchV2 {
+  export interface Params {
+    proposer: string
+    market: {
+      ticker: string
+      admin: string
+      oracleSymbol: string
+      oracleProvider: string
+      oracleScaleFactor: number
+      oracleType: InjectiveOracleV1Beta1OraclePb.OracleType
+      quoteDenom: string
+      makerFeeRate: string
+      takerFeeRate: string
+      expirationTimestamp: number
+      settlementTimestamp: number
+      minPriceTickSize: string
+      minQuantityTickSize: string
+      minNotional: string
+    }
+  }
+
+  export type Proto =
+    InjectiveExchangeV2TxPb.MsgInstantBinaryOptionsMarketLaunch
+}
+
+const createMessage = (
+  params: MsgInstantBinaryOptionsMarketLaunchV2.Params,
+) => {
+  const message =
+    InjectiveExchangeV2TxPb.MsgInstantBinaryOptionsMarketLaunch.create({
+      sender: params.proposer,
+      ticker: params.market.ticker,
+      oracleSymbol: params.market.oracleSymbol,
+      oracleProvider: params.market.oracleProvider,
+      oracleType: params.market.oracleType,
+      oracleScaleFactor: params.market.oracleScaleFactor,
+      makerFeeRate: params.market.makerFeeRate,
+      takerFeeRate: params.market.takerFeeRate,
+      expirationTimestamp: BigInt(params.market.expirationTimestamp),
+      settlementTimestamp: BigInt(params.market.settlementTimestamp),
+      admin: params.market.admin,
+      quoteDenom: params.market.quoteDenom,
+      minPriceTickSize: params.market.minPriceTickSize,
+      minQuantityTickSize: params.market.minQuantityTickSize,
+      minNotional: params.market.minNotional,
+    })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgInstantBinaryOptionsMarketLaunchV2 extends MsgBase<
+  MsgInstantBinaryOptionsMarketLaunchV2.Params,
+  MsgInstantBinaryOptionsMarketLaunchV2.Proto
+> {
+  static fromJSON(
+    params: MsgInstantBinaryOptionsMarketLaunchV2.Params,
+  ): MsgInstantBinaryOptionsMarketLaunchV2 {
+    return new MsgInstantBinaryOptionsMarketLaunchV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      market: {
+        ...initialParams.market,
+        minPriceTickSize: toChainFormat(
+          initialParams.market.minPriceTickSize,
+        ).toFixed(),
+        makerFeeRate: toChainFormat(
+          initialParams.market.makerFeeRate,
+        ).toFixed(),
+        takerFeeRate: toChainFormat(
+          initialParams.market.takerFeeRate,
+        ).toFixed(),
+        minQuantityTickSize: toChainFormat(
+          initialParams.market.minQuantityTickSize,
+        ).toFixed(),
+        minNotional: toChainFormat(initialParams.market.minNotional).toFixed(),
+      },
+    } as MsgInstantBinaryOptionsMarketLaunchV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgInstantBinaryOptionsMarketLaunch',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.proposer,
+      ticker: params.market.ticker,
+      oracle_symbol: params.market.oracleSymbol,
+      oracle_provider: params.market.oracleProvider,
+      oracle_type: params.market.oracleType,
+      oracle_scale_factor: params.market.oracleScaleFactor,
+      maker_fee_rate: params.market.makerFeeRate,
+      taker_fee_rate: params.market.takerFeeRate,
+      expiration_timestamp: params.market.expirationTimestamp.toString(),
+      settlement_timestamp: params.market.settlementTimestamp.toString(),
+      admin: params.market.admin,
+      quote_denom: params.market.quoteDenom,
+      min_price_tick_size: params.market.minPriceTickSize,
+      min_quantity_tick_size: params.market.minQuantityTickSize,
+      min_notional: params.market.minNotional,
+    }
+
+    return {
+      type: 'exchange/MsgInstantBinaryOptionsMarketLaunch',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgInstantBinaryOptionsMarketLaunch',
+      ...value,
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { type, value } = amino
+
+    const messageAdjusted = {
+      ...value,
+      min_price_tick_size: toChainFormat(value.min_price_tick_size).toFixed(),
+      min_quantity_tick_size: toChainFormat(
+        value.min_quantity_tick_size,
+      ).toFixed(),
+      min_notional: toChainFormat(value.min_notional).toFixed(),
+      taker_fee_rate: toChainFormat(value.taker_fee_rate).toFixed(),
+      maker_fee_rate: toChainFormat(value.maker_fee_rate).toFixed(),
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    const messageAdjusted = {
+      ...web3gw,
+      min_price_tick_size: numberToCosmosSdkDecString(
+        params.market.minPriceTickSize,
+      ),
+      min_quantity_tick_size: numberToCosmosSdkDecString(
+        params.market.minQuantityTickSize,
+      ),
+      min_notional: numberToCosmosSdkDecString(params.market.minNotional),
+      taker_fee_rate: numberToCosmosSdkDecString(params.market.takerFeeRate),
+      maker_fee_rate: numberToCosmosSdkDecString(params.market.makerFeeRate),
+      oracle_type:
+        InjectiveOracleV1Beta1OraclePb.OracleType[params.market.oracleType],
+    }
+
+    return messageAdjusted
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgInstantBinaryOptionsMarketLaunch',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgInstantBinaryOptionsMarketLaunch.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.spec.ts
@@ -1,0 +1,61 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgInstantSpotMarketLaunchV2 from './MsgInstantSpotMarketLaunchV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const market = mockFactory.injUsdtSpotMarket
+
+const params: MsgInstantSpotMarketLaunchV2['params'] = {
+  proposer: mockFactory.injectiveAddress,
+  market: {
+    minNotional: '1',
+    sender: mockFactory.injectiveAddress,
+    ticker: market.ticker,
+    baseDenom: market.baseDenom,
+    quoteDenom: market.quoteDenom,
+    baseDecimals: market.baseToken.decimals,
+    quoteDecimals: market.quoteToken.decimals,
+    minPriceTickSize: market.minPriceTickSize,
+    minQuantityTickSize: market.minQuantityTickSize,
+  },
+}
+
+const message = MsgInstantSpotMarketLaunchV2.fromJSON(params)
+
+describe('MsgInstantSpotMarketLaunchV2', () => {
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it.skip('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.ts
@@ -1,0 +1,164 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgInstantSpotMarketLaunchV2 {
+  export interface Params {
+    proposer: string
+    market: {
+      sender: string
+      ticker: string
+      baseDenom: string
+      quoteDenom: string
+      minNotional: string
+      baseDecimals: number
+      quoteDecimals: number
+      minPriceTickSize: string
+      minQuantityTickSize: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgInstantSpotMarketLaunch
+}
+
+const createMessage = (params: MsgInstantSpotMarketLaunchV2.Params) => {
+  const message = InjectiveExchangeV2TxPb.MsgInstantSpotMarketLaunch.create({
+    sender: params.proposer,
+    ticker: params.market.ticker,
+    baseDenom: params.market.baseDenom,
+    quoteDenom: params.market.quoteDenom,
+    minPriceTickSize: params.market.minPriceTickSize,
+    minQuantityTickSize: params.market.minQuantityTickSize,
+    minNotional: params.market.minNotional,
+    baseDecimals: Number(params.market.baseDecimals),
+    quoteDecimals: Number(params.market.quoteDecimals),
+  })
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgInstantSpotMarketLaunchV2 extends MsgBase<
+  MsgInstantSpotMarketLaunchV2.Params,
+  MsgInstantSpotMarketLaunchV2.Proto
+> {
+  static fromJSON(
+    params: MsgInstantSpotMarketLaunchV2.Params,
+  ): MsgInstantSpotMarketLaunchV2 {
+    return new MsgInstantSpotMarketLaunchV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      market: {
+        ...initialParams.market,
+        minPriceTickSize: toChainFormat(
+          initialParams.market.minPriceTickSize,
+        ).toFixed(),
+        minQuantityTickSize: toChainFormat(
+          initialParams.market.minQuantityTickSize,
+        ).toFixed(),
+        minNotional: toChainFormat(initialParams.market.minNotional).toFixed(),
+      },
+    } as MsgInstantSpotMarketLaunchV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgInstantSpotMarketLaunch',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const { params } = this
+    const message = {
+      sender: params.proposer,
+      ticker: params.market.ticker,
+      base_denom: params.market.baseDenom,
+      quote_denom: params.market.quoteDenom,
+      min_price_tick_size: params.market.minPriceTickSize,
+      min_quantity_tick_size: params.market.minQuantityTickSize,
+      min_notional: params.market.minNotional,
+      base_decimals: params.market.baseDecimals,
+      quote_decimals: params.market.quoteDecimals,
+    }
+
+    return {
+      type: 'exchange/MsgInstantSpotMarketLaunch',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgInstantSpotMarketLaunch',
+      ...value,
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { type, value } = amino
+
+    const messageAdjusted = {
+      ...value,
+      min_price_tick_size: toChainFormat(value.min_price_tick_size).toFixed(),
+      min_quantity_tick_size: toChainFormat(
+        value.min_quantity_tick_size,
+      ).toFixed(),
+      min_notional: toChainFormat(value.min_notional).toFixed(),
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    const messageAdjusted = {
+      ...web3gw,
+      min_price_tick_size: numberToCosmosSdkDecString(
+        params.market.minPriceTickSize,
+      ),
+      min_quantity_tick_size: numberToCosmosSdkDecString(
+        params.market.minQuantityTickSize,
+      ),
+      min_notional: numberToCosmosSdkDecString(params.market.minNotional),
+    }
+
+    return messageAdjusted
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgInstantSpotMarketLaunch',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgInstantSpotMarketLaunch.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidatePositionV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidatePositionV2.spec.ts
@@ -1,0 +1,93 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgLiquidatePositionV2 from './MsgLiquidatePositionV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgLiquidatePositionV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  subaccountId: mockFactory.subaccountId,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+}
+
+const protoType = '/injective.exchange.v2.MsgLiquidatePosition'
+const protoTypeShort = 'exchange/MsgLiquidatePosition'
+const protoParams = {
+  sender: params.injectiveAddress,
+  subaccountId: params.subaccountId,
+  marketId: params.marketId,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgLiquidatePositionV2.fromJSON(params)
+
+describe('MsgLiquidatePositionV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: { ...protoParamsAmino, order: undefined },
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+      order: undefined,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidatePositionV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidatePositionV2.ts
@@ -1,0 +1,213 @@
+import { toChainFormat } from '@injectivelabs/utils'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2OrderPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/order_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+
+export declare namespace MsgLiquidatePositionV2 {
+  export interface Params {
+    subaccountId: string
+    injectiveAddress: string
+    marketId: string
+
+    /** optional order to provide for liquidation */
+    order?: {
+      marketId: string
+      subaccountId: string
+      orderType: InjectiveExchangeV2OrderPb.OrderType
+      triggerPrice?: string
+      feeRecipient: string
+      price: string
+      margin: string
+      quantity: string
+      cid?: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgLiquidatePosition
+}
+
+const createMessage = (params: MsgLiquidatePositionV2.Params) => {
+  const message = InjectiveExchangeV2TxPb.MsgLiquidatePosition.create({
+    sender: params.injectiveAddress,
+    subaccountId: params.subaccountId,
+    marketId: params.marketId,
+  })
+
+  if (params.order) {
+    const orderInfo = InjectiveExchangeV2OrderPb.OrderInfo.create({
+      subaccountId: params.order.subaccountId,
+      feeRecipient: params.order.feeRecipient,
+      price: params.order.price,
+      quantity: params.order.quantity,
+      cid: params.order.cid || '',
+    })
+
+    const order = InjectiveExchangeV2OrderPb.DerivativeOrder.create({
+      marketId: params.order.marketId,
+      margin: params.order.margin,
+      orderInfo: orderInfo,
+      orderType: params.order.orderType,
+      triggerPrice: params.order.triggerPrice || '0',
+    })
+
+    message.order = order
+  }
+
+  return message
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgLiquidatePositionV2 extends MsgBase<
+  MsgLiquidatePositionV2.Params,
+  MsgLiquidatePositionV2.Proto
+> {
+  static fromJSON(
+    params: MsgLiquidatePositionV2.Params,
+  ): MsgLiquidatePositionV2 {
+    return new MsgLiquidatePositionV2(params)
+  }
+
+  public toProto() {
+    const { params: initialParams } = this
+
+    const params = {
+      ...initialParams,
+      order: initialParams.order
+        ? {
+            ...initialParams.order,
+            price: toChainFormat(initialParams.order.price).toFixed(),
+            margin: toChainFormat(initialParams.order.margin).toFixed(),
+            triggerPrice: toChainFormat(
+              initialParams.order.triggerPrice || 0,
+            ).toFixed(),
+            quantity: toChainFormat(initialParams.order.quantity).toFixed(),
+          }
+        : undefined,
+    } as MsgLiquidatePositionV2.Params
+
+    return createMessage(params)
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgLiquidatePosition',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      subaccount_id: proto.subaccountId,
+      market_id: proto.marketId,
+      order: proto.order
+        ? {
+            market_id: proto.order.marketId,
+            order_info: {
+              subaccount_id: proto.order.orderInfo?.subaccountId,
+              fee_recipient: proto.order.orderInfo?.feeRecipient,
+              price: proto.order.orderInfo?.price,
+              quantity: proto.order.orderInfo?.quantity,
+              cid: proto.order.orderInfo?.cid,
+            },
+            order_type: proto.order.orderType,
+            margin: proto.order.margin,
+            trigger_price: proto.order.triggerPrice,
+          }
+        : undefined,
+    }
+
+    return {
+      type: 'exchange/MsgLiquidatePosition',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgLiquidatePosition',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const web3gw = this.toWeb3Gw()
+    const order = web3gw.order as any
+
+    const messageAdjusted = {
+      ...web3gw,
+      order: order
+        ? {
+            ...order,
+            order_info: {
+              ...order?.order_info,
+              price: numberToCosmosSdkDecString(order.order_info.price),
+              quantity: numberToCosmosSdkDecString(order.order_info.quantity),
+            },
+            margin: numberToCosmosSdkDecString(order.margin),
+            trigger_price: numberToCosmosSdkDecString(
+              order.trigger_price || '0',
+            ),
+            order_type:
+              InjectiveExchangeV2OrderPb.OrderType[order.order_type],
+          }
+        : undefined,
+    }
+
+    return messageAdjusted
+  }
+
+  public toEip712() {
+    const { params } = this
+    const amino = this.toAmino()
+    const { value, type } = amino
+    const order = value.order as any
+
+    const messageAdjusted = {
+      ...value,
+      order: params.order
+        ? {
+            ...order,
+            order_info: {
+              ...order?.order_info,
+              price: toChainFormat(order?.order_info?.price || '0').toFixed(),
+              quantity: toChainFormat(
+                order?.order_info?.quantity || '0',
+              ).toFixed(),
+            },
+            margin: toChainFormat(order.margin).toFixed(),
+            trigger_price: toChainFormat(order.trigger_price || '0').toFixed(),
+          }
+        : undefined,
+    }
+
+    return {
+      type,
+      value: messageAdjusted,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgLiquidatePosition',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgLiquidatePosition.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.spec.ts
@@ -1,0 +1,34 @@
+import { mockFactory } from '@injectivelabs/utils/test-utils'
+import MsgReclaimLockedFundsV2 from './MsgReclaimLockedFundsV2.js'
+
+const params: MsgReclaimLockedFundsV2['params'] = {
+  sender: mockFactory.injectiveAddress,
+  lockedAccountPubKey: 'dGVzdC1wdWJrZXk=',
+  signature: new Uint8Array([1, 2, 3]),
+}
+
+const protoType = '/injective.exchange.v2.MsgReclaimLockedFunds'
+const protoTypeShort = 'exchange/MsgReclaimLockedFunds'
+const message = MsgReclaimLockedFundsV2.fromJSON(params)
+
+describe('MsgReclaimLockedFundsV2', () => {
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data['@type']).toStrictEqual(protoType)
+    expect(data.sender).toStrictEqual(params.sender)
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino.type).toStrictEqual(protoTypeShort)
+    expect(amino.value.sender).toStrictEqual(params.sender)
+  })
+
+  it('throws for EIP712', () => {
+    expect(() => message.toWeb3Gw()).toThrow()
+    expect(() => message.toEip712()).toThrow()
+    expect(() => message.toEip712V2()).toThrow()
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.ts
@@ -1,0 +1,100 @@
+import { GeneralException } from '@injectivelabs/exceptions'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import {
+  base64ToUint8Array,
+  uint8ArrayToBase64,
+} from '../../../../utils/encoding.js'
+
+export declare namespace MsgReclaimLockedFundsV2 {
+  export interface Params {
+    sender: string
+    lockedAccountPubKey: string
+    signature: Uint8Array
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgReclaimLockedFunds
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgReclaimLockedFundsV2 extends MsgBase<
+  MsgReclaimLockedFundsV2.Params,
+  MsgReclaimLockedFundsV2.Proto
+> {
+  static fromJSON(
+    params: MsgReclaimLockedFundsV2.Params,
+  ): MsgReclaimLockedFundsV2 {
+    return new MsgReclaimLockedFundsV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgReclaimLockedFunds.create({
+      sender: params.sender,
+      lockedAccountPubKey: base64ToUint8Array(params.lockedAccountPubKey),
+      signature: params.signature,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgReclaimLockedFunds',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    const message = {
+      sender: proto.sender,
+      lockedAccountPubKey: uint8ArrayToBase64(proto.lockedAccountPubKey),
+      signature: uint8ArrayToBase64(proto.signature),
+    }
+
+    return {
+      type: 'exchange/MsgReclaimLockedFunds',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw(): never {
+    throw new GeneralException(
+      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
+    )
+  }
+
+  public toEip712(): never {
+    throw new GeneralException(
+      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
+    )
+  }
+
+  public toEip712V2(): never {
+    throw new GeneralException(
+      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
+    )
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgReclaimLockedFunds',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgReclaimLockedFunds.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgRewardsOptOutV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgRewardsOptOutV2.spec.ts
@@ -1,0 +1,88 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgRewardsOptOutV2 from './MsgRewardsOptOutV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgRewardsOptOutV2['params'] = {
+  sender: mockFactory.injectiveAddress,
+}
+
+const protoType = '/injective.exchange.v2.MsgRewardsOptOut'
+const protoTypeShort = 'exchange/MsgRewardsOptOut'
+const protoParams = {
+  sender: params.sender,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgRewardsOptOutV2.fromJSON(params)
+
+describe('MsgRewardsOptOutV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgRewardsOptOutV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgRewardsOptOutV2.ts
@@ -1,0 +1,76 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgRewardsOptOutV2 {
+  export interface Params {
+    sender: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgRewardsOptOut
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgRewardsOptOutV2 extends MsgBase<
+  MsgRewardsOptOutV2.Params,
+  MsgRewardsOptOutV2.Proto
+> {
+  static fromJSON(params: MsgRewardsOptOutV2.Params): MsgRewardsOptOutV2 {
+    return new MsgRewardsOptOutV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgRewardsOptOut.create({
+      sender: params.sender,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgRewardsOptOut',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+    }
+
+    return {
+      type: 'exchange/MsgRewardsOptOut',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgRewardsOptOut',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgRewardsOptOut',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgRewardsOptOut.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSignDataV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSignDataV2.spec.ts
@@ -1,0 +1,49 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgSignDataV2 from './MsgSignDataV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgSignDataV2['params'] = {
+  sender: mockFactory.injectiveAddress,
+  data: 'test-data',
+}
+
+const message = MsgSignDataV2.fromJSON(params)
+
+describe('MsgSignDataV2', () => {
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSignDataV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSignDataV2.ts
@@ -1,0 +1,85 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import { toUtf8, getEthereumAddress } from '../../../../utils/index.js'
+import {
+  hexToUint8Array,
+  uint8ArrayToHex,
+  stringToUint8Array,
+} from '../../../../utils/encoding.js'
+
+export declare namespace MsgSignDataV2 {
+  export interface Params {
+    sender: string
+    data: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgSignData
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgSignDataV2 extends MsgBase<
+  MsgSignDataV2.Params,
+  MsgSignDataV2.Proto
+> {
+  static fromJSON(params: MsgSignDataV2.Params): MsgSignDataV2 {
+    return new MsgSignDataV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const message = InjectiveExchangeV2TxPb.MsgSignData.create({
+      signer: hexToUint8Array(getEthereumAddress(params.sender)),
+      data: stringToUint8Array(toUtf8(params.data)),
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgSignData',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      signer: uint8ArrayToHex(proto.signer),
+      data: toUtf8(proto.data),
+    }
+
+    return {
+      type: 'sign/MsgSignData',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgSignData',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgSignData',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgSignData.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgWithdrawV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgWithdrawV2.spec.ts
@@ -1,0 +1,95 @@
+import snakecaseKeys from 'snakecase-keys'
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import MsgWithdrawV2 from './MsgWithdrawV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgWithdrawV2['params'] = {
+  injectiveAddress: mockFactory.injectiveAddress,
+  subaccountId: mockFactory.subaccountId,
+  amount: {
+    amount: '1000000',
+    denom: 'inj',
+  },
+}
+
+const protoType = '/injective.exchange.v2.MsgWithdraw'
+const protoTypeShort = 'exchange/MsgWithdraw'
+const protoParams = {
+  sender: params.injectiveAddress,
+  subaccountId: params.subaccountId,
+  amount: params.amount,
+}
+const protoParamsAmino = snakecaseKeys(protoParams)
+const message = MsgWithdrawV2.fromJSON(params)
+
+describe('MsgWithdrawV2', () => {
+  it('generates proper proto', () => {
+    const proto = message.toProto()
+
+    expect(proto).toStrictEqual(protoParams)
+  })
+
+  it('generates proper data', () => {
+    const data = message.toData()
+
+    expect(data).toStrictEqual({
+      '@type': protoType,
+      ...protoParams,
+    })
+  })
+
+  it('generates proper amino', () => {
+    const amino = message.toAmino()
+
+    expect(amino).toStrictEqual({
+      type: protoTypeShort,
+      value: protoParamsAmino,
+    })
+  })
+
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      ...protoParamsAmino,
+    })
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgWithdrawV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgWithdrawV2.ts
@@ -1,0 +1,91 @@
+import * as CosmosBaseV1Beta1CoinPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/base/v1beta1/coin_pb'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgWithdrawV2 {
+  export interface Params {
+    subaccountId: string
+    injectiveAddress: string
+    amount: {
+      amount: string
+      denom: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgWithdraw
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgWithdrawV2 extends MsgBase<
+  MsgWithdrawV2.Params,
+  MsgWithdrawV2.Proto
+> {
+  static fromJSON(params: MsgWithdrawV2.Params): MsgWithdrawV2 {
+    return new MsgWithdrawV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    const amountCoin = CosmosBaseV1Beta1CoinPb.Coin.create({
+      denom: params.amount.denom,
+      amount: params.amount.amount,
+    })
+
+    const message = InjectiveExchangeV2TxPb.MsgWithdraw.create({
+      sender: params.injectiveAddress,
+      subaccountId: params.subaccountId,
+      amount: amountCoin,
+    })
+
+    return message
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgWithdraw',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+    const message = {
+      sender: proto.sender,
+      subaccount_id: proto.subaccountId,
+      amount: proto.amount,
+    }
+
+    return {
+      type: 'exchange/MsgWithdraw',
+      value: message,
+    }
+  }
+
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgWithdraw',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgWithdraw',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgWithdraw.toBinary(this.toProto())
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **26 new V2 message classes** covering the full exchange module in `@injectivelabs/sdk-ts`, each paired with a `.spec.ts` test file
- Each class mirrors its v1 counterpart but uses proto types from `@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/{tx,order,market}_pb`
- All existing v1 classes are untouched — this is purely additive

## What changed

### Proto type differences from v1

| Concern | v1 | v2 |
|---|---|---|
| Proto FQN | `/injective.exchange.v1beta1.MsgX` | `/injective.exchange.v2.MsgX` |
| `OrderType`, `SpotOrder`, `DerivativeOrder`, `OrderInfo` | `exchange_pb` | `order_pb` |
| `MarketStatus` | `exchange_pb` | `market_pb` |
| `MsgInstantSpotMarketLaunch` | no decimals fields | adds `baseDecimals`, `quoteDecimals` |
| `MsgBatchUpdateOrders` | limit orders only | adds `spotMarketOrdersToCreate`, `derivativeMarketOrdersToCreate`, `binaryOptionsMarketOrdersToCreate` |

### API

Each class implements the same 8-method public API as v1: `toProto`, `toData`, `toAmino`, `toWeb3Gw`, `toEip712`, `toEip712V2`, `toDirectSign`, `toBinary`.

`toChainFormat` (×10¹⁸) is still applied for Dec fields in `toProto` and `toEip712`, consistent with existing v2 message classes (`MsgUpdateSpotMarketV2`, `MsgUpdateDerivativeMarketV2`).

### New exports from `exchange/index.ts`

`MsgDepositV2`, `MsgWithdrawV2`, `MsgExternalTransferV2`, `MsgSignDataV2`, `MsgRewardsOptOutV2`, `MsgReclaimLockedFundsV2`, `MsgAuthorizeStakeGrantsV2`, `MsgCancelSpotOrderV2`, `MsgCancelDerivativeOrderV2`, `MsgCancelBinaryOptionsOrderV2`, `MsgBatchCancelSpotOrdersV2`, `MsgBatchCancelDerivativeOrdersV2`, `MsgBatchCancelBinaryOptionsOrdersV2`, `MsgIncreasePositionMarginV2`, `MsgDecreasePositionMarginV2`, `MsgLiquidatePositionV2`, `MsgCreateSpotLimitOrderV2`, `MsgCreateSpotMarketOrderV2`, `MsgCreateDerivativeLimitOrderV2`, `MsgCreateDerivativeMarketOrderV2`, `MsgCreateBinaryOptionsLimitOrderV2`, `MsgCreateBinaryOptionsMarketOrderV2`, `MsgInstantSpotMarketLaunchV2`, `MsgInstantBinaryOptionsMarketLaunchV2`, `MsgAdminUpdateBinaryOptionsMarketV2`, `MsgBatchUpdateOrdersV2`

## Test plan

- [ ] Each message class has a matching `.spec.ts` with proto, data, amino, and web3Gw assertions (where applicable) plus EIP712 v1/v2 chain comparison tests
- [ ] TypeScript compiles with no new errors (pre-existing OLP module errors unrelated to this PR are present on master)
- [ ] `MsgSetDelegationTransferReceivers` intentionally skipped — no v2 proto equivalent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added comprehensive support for Injective Exchange V2 message types, including deposit/withdrawal operations, order creation and cancellation for spot, derivative, and binary options markets, position margin adjustments, and market launch functionality.
  * Enabled EIP-712 signing support across all new message types for enhanced transaction security and compatibility.

* **Tests**
  * Added extensive test coverage for all new Exchange V2 message implementations, including serialization, encoding format compatibility, and EIP-712 validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->