### PR TITLE
fix: update rpcUrl handling in Eip1193Provider and TurnkeyWalletStrategy

### DIFF
--- a/packages/wallets/wallet-base/src/types/strategy.ts
+++ b/packages/wallets/wallet-base/src/types/strategy.ts
@@ -51,7 +51,7 @@ export type WalletConnectMetadata = {
 export interface WalletStrategyEvmOptions {
   evmChainId: EvmChainId
   rpcUrl?: string
-  rpcUrls?: Partial<Record<EvmChainId, string>>
+  rpcUrls?: Partial<Record<number, string>>
 }
 
 export interface SendTransactionOptions {

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
@@ -6,15 +6,35 @@ import {
 import type { Hash, LocalAccount } from 'viem'
 import type { Eip1193Provider } from '@injectivelabs/wallet-base'
 
+type RpcUrls = Partial<Record<number, string>>
+
+const parseChainId = (chainId: number | string) => {
+  if (typeof chainId === 'number') {
+    return chainId
+  }
+
+  if (chainId.startsWith('0x')) {
+    return parseInt(chainId.replace('0x', ''), 16)
+  }
+
+  return parseInt(chainId, 10)
+}
+
 export const getEip1193ProviderForTurnkey = async (
   account: LocalAccount,
-  chainId: string,
+  chainId: number | string,
+  params: {
+    rpcUrl?: string
+    rpcUrls?: RpcUrls
+  } = {},
 ): Promise<Eip1193Provider> => {
   const provider = new CustomEip1193Provider({
-    chainId: parseInt(chainId, 16),
+    chainId: parseChainId(chainId),
     signTypedData: account.signTypedData.bind(account),
     signMessage: account.signMessage.bind(account),
     signTransaction: account.signTransaction.bind(account),
+    rpcUrl: params.rpcUrl,
+    rpcUrls: params.rpcUrls,
     account,
     address: account.address,
   })
@@ -27,6 +47,8 @@ class CustomEip1193Provider implements Eip1193Provider {
   signTypedData: (...args: any[]) => Promise<any>
   signMessage: (...args: any[]) => Promise<any>
   signTransaction: (...args: any[]) => Promise<any>
+  private readonly rpcUrl?: string
+  private readonly rpcUrls?: RpcUrls
   account: LocalAccount
   address: string
 
@@ -35,6 +57,8 @@ class CustomEip1193Provider implements Eip1193Provider {
     signTypedData: (...args: any[]) => Promise<any>
     signMessage: (...args: any[]) => Promise<any>
     signTransaction: (...args: any[]) => Promise<any>
+    rpcUrl?: string
+    rpcUrls?: RpcUrls
     account: LocalAccount
     address: string
   }) {
@@ -43,7 +67,13 @@ class CustomEip1193Provider implements Eip1193Provider {
     this.signMessage = args.signMessage
     this.account = args.account
     this.address = args.address
+    this.rpcUrl = args.rpcUrl
+    this.rpcUrls = args.rpcUrls
     this.signTransaction = args.signTransaction
+  }
+
+  private getRpcUrl() {
+    return this.rpcUrls?.[this.chainId] || this.rpcUrl
   }
 
   async requestAccounts() {
@@ -54,6 +84,7 @@ class CustomEip1193Provider implements Eip1193Provider {
     return getViemWalletClient({
       chainId: this.chainId,
       account: this.account as any,
+      rpcUrl: this.getRpcUrl(),
     })
   }
 
@@ -91,7 +122,7 @@ class CustomEip1193Provider implements Eip1193Provider {
     }
 
     if (args.method === 'eth_chainId') {
-      return this.chainId
+      return `0x${this.chainId.toString(16)}`
     }
 
     if (args.method === 'wallet_switchEthereumChain') {
@@ -99,9 +130,7 @@ class CustomEip1193Provider implements Eip1193Provider {
         throw new Error('params is required')
       }
 
-      const chainId = String(args.params[0].chainId).replace('0x', '')
-
-      this.chainId = parseInt(chainId, 16)
+      this.chainId = parseChainId(args.params[0].chainId)
 
       return true
     }
@@ -114,6 +143,7 @@ class CustomEip1193Provider implements Eip1193Provider {
       const accountClient = getViemWalletClient({
         chainId: this.chainId,
         account: this.account as any,
+        rpcUrl: this.getRpcUrl(),
       })
 
       const client = this.getClient()
@@ -165,7 +195,7 @@ class CustomEip1193Provider implements Eip1193Provider {
         throw new Error('params is required')
       }
 
-      const client = getViemPublicClient(this.chainId)
+      const client = getViemPublicClient(this.chainId, this.getRpcUrl())
 
       const count = await client.getTransactionCount({
         address: this.address as Hash,

--- a/packages/wallets/wallet-turnkey/src/strategy/strategy.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/strategy.ts
@@ -170,7 +170,7 @@ export class TurnkeyWalletStrategy
       const turnkeyWallet = await this.getTurnkeyWallet()
 
       const chainId = args.evmChainId || options.evmChainId
-      const url = options.rpcUrl || options.rpcUrls?.[args.evmChainId]
+      const url = options.rpcUrls?.[chainId] || options.rpcUrl
 
       if (!url) {
         throw new WalletException(
@@ -377,7 +377,7 @@ export class TurnkeyWalletStrategy
     const options = this.evmOptions
 
     const chainId = evmChainId || options.evmChainId
-    const url = options.rpcUrl || options.rpcUrls?.[chainId]
+    const url = options.rpcUrls?.[chainId] || options.rpcUrl
 
     if (!url) {
       throw new WalletException(
@@ -458,6 +458,10 @@ export class TurnkeyWalletStrategy
     const eip1193Provider = await getEip1193ProviderForTurnkey(
       account,
       String(this.evmOptions.evmChainId),
+      {
+        rpcUrl: this.evmOptions.rpcUrl,
+        rpcUrls: this.evmOptions.rpcUrls,
+      },
     )
 
     return eip1193Provider


### PR DESCRIPTION
This pull request improves the flexibility and correctness of how RPC URLs are handled for EVM chains in the wallet packages. The main changes standardize the use of chain IDs as numbers (instead of enums) for RPC URL mapping, add utility functions for parsing chain IDs, and ensure that the correct RPC URL is selected based on the current chain context. These updates make it easier to support multiple networks and improve compatibility with various chain ID formats.

**EVM Chain ID and RPC URL Handling Improvements:**

* Changed the type of `rpcUrls` in `WalletStrategyEvmOptions` and related code to use `Partial<Record<number, string>>`, ensuring chain IDs are consistently treated as numbers, which improves flexibility for multi-chain support.
* Added a `parseChainId` utility to handle both string (including hex) and number chain ID formats, ensuring robust parsing throughout the codebase. [[1]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR9-R37) [[2]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eL94-R133)
* Updated the `CustomEip1193Provider` and its instantiation to accept and correctly prioritize `rpcUrl` and `rpcUrls` parameters, allowing dynamic selection of the appropriate RPC URL for the active chain. [[1]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR9-R37) [[2]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR50-R51) [[3]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR60-R61) [[4]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR70-R78) [[5]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR87) [[6]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR146) [[7]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eL168-R198) [[8]](diffhunk://#diff-ddf60a84a4b5de8f1970b6f29c80f51634657bcdb181f782ae031a647cba57cfR461-R464)

**Strategy Logic Updates:**

* Modified logic in `TurnkeyWalletStrategy` to always prioritize `rpcUrls[chainId]` over `rpcUrl` for selecting the RPC endpoint, ensuring the correct URL is used for each chain. [[1]](diffhunk://#diff-ddf60a84a4b5de8f1970b6f29c80f51634657bcdb181f782ae031a647cba57cfL173-R173) [[2]](diffhunk://#diff-ddf60a84a4b5de8f1970b6f29c80f51634657bcdb181f782ae031a647cba57cfL380-R380)

**EIP-1193 Compliance and Consistency:**

* Ensured that the provider returns the chain ID in hexadecimal format for the `eth_chainId` method, as required by the EIP-1193 specification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced RPC URL configuration with support for per-chain endpoints, enabling more granular control over network connections
  * Expanded chain ID compatibility to accept both numeric and string formats for increased flexibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-ts/pull/670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->