### PR TITLE
chore: fix fallthrough by adding missing rpc methods

### DIFF
--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
@@ -1,0 +1,87 @@
+import { vi } from 'vitest'
+import { LedgerEip1193Provider } from './Eip1193Provider.js'
+import type LedgerHW from './hw/index.js'
+
+vi.mock('@injectivelabs/wallet-base', () => ({
+  getEvmChainConfig: vi.fn(),
+  getViemPublicClient: vi.fn(),
+  getViemWalletClient: vi.fn(() => ({
+    request: vi.fn(() => {
+      throw new Error('Unexpected RPC fallback')
+    }),
+  })),
+}))
+
+describe('Ledger EIP-1193 provider', () => {
+  const address = '0x0000000000000000000000000000000000000001'
+  const typedData = {
+    domain: { name: 'Injective', version: '1', chainId: 1 },
+    types: {
+      Message: [{ name: 'contents', type: 'string' }],
+    },
+    primaryType: 'Message',
+    message: {
+      contents: 'hello',
+    },
+  }
+
+  const getProvider = () => {
+    const ledger = {
+      getInstance: vi.fn().mockResolvedValue({
+        getAddress: vi.fn().mockResolvedValue({ address }),
+      }),
+    } as unknown as LedgerHW
+
+    return new LedgerEip1193Provider(ledger, {
+      rpcUrl: 'http://127.0.0.1:1',
+    })
+  }
+
+  it.each(['eth_requestAccounts', 'eth_accounts'])(
+    'resolves %s from the Ledger account',
+    async (method) => {
+      const provider = getProvider()
+
+      await expect(provider.request({ method, params: [] })).resolves.toEqual([
+        address,
+      ])
+    },
+  )
+
+  it.each(['eth_sign', 'personal_sign'])(
+    'routes %s through the Ledger message signer',
+    async (method) => {
+      const provider = getProvider()
+      const signMessage = vi
+        .spyOn(provider, 'signMessage')
+        .mockResolvedValue('0xsigned')
+
+      const params =
+        method === 'eth_sign' ? [address, '0x68656c6c6f'] : ['hello', address]
+
+      await expect(provider.request({ method, params })).resolves.toBe(
+        '0xsigned',
+      )
+      expect(signMessage).toHaveBeenCalledWith('68656c6c6f')
+    },
+  )
+
+  it.each([
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ])('routes %s through the Ledger typed data signer', async (method) => {
+    const provider = getProvider()
+    const signTypedData = vi
+      .spyOn(provider, 'signTypedData')
+      .mockResolvedValue('0xtyped')
+
+    const params =
+      method === 'eth_signTypedData'
+        ? [typedData]
+        : [address, JSON.stringify(typedData)]
+
+    await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
+    expect(signTypedData).toHaveBeenCalledWith(JSON.stringify(typedData))
+  })
+})

--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
@@ -66,6 +66,17 @@ describe('Ledger EIP-1193 provider', () => {
     },
   )
 
+  it.each(['eth_sign', 'personal_sign'])(
+    'rejects %s without a message payload',
+    async (method) => {
+      const provider = getProvider()
+
+      await expect(
+        provider.request({ method, params: [address] }),
+      ).rejects.toThrow(`Missing message parameter for ${method}`)
+    },
+  )
+
   it.each([
     'eth_signTypedData',
     'eth_signTypedData_v3',
@@ -83,5 +94,13 @@ describe('Ledger EIP-1193 provider', () => {
 
     await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
     expect(signTypedData).toHaveBeenCalledWith(JSON.stringify(typedData))
+  })
+
+  it('rejects typed data signing without a typed-data payload', async () => {
+    const provider = getProvider()
+
+    await expect(
+      provider.request({ method: 'eth_signTypedData_v4', params: [address] }),
+    ).rejects.toThrow('Missing typed data parameter for eth_signTypedData_v4')
   })
 })

--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
@@ -23,19 +23,34 @@ const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
 const isEthAddress = (value: unknown) =>
   typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
 
-const getTypedDataParam = (params: any[]) => {
-  const typedData =
-    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+const getTypedDataParam = (method: string, params: any[]) => {
+  const typedData = isEthAddress(params[0]) ? params[1] : params[0]
+
+  if (
+    typedData == null ||
+    (typeof typedData === 'string' && typedData.length === 0)
+  ) {
+    throw new Error(`Missing typed data parameter for ${method}`)
+  }
 
   return typeof typedData === 'string' ? typedData : JSON.stringify(typedData)
 }
 
 const getMessageParam = (method: string, params: any[]) => {
-  if (method === 'eth_sign') {
-    return params[1] || params[0]
+  let message = params[0]
+
+  if (method === 'eth_sign' || isEthAddress(params[0])) {
+    message = params[1]
   }
 
-  return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+  if (
+    !(message instanceof Uint8Array) &&
+    (typeof message !== 'string' || message.length === 0)
+  ) {
+    throw new Error(`Missing message parameter for ${method}`)
+  }
+
+  return message
 }
 
 const getMessageHex = (message: any) => {
@@ -191,7 +206,7 @@ export class LedgerEip1193Provider implements Eip1193Provider {
         throw new Error(`Missing parameter for ${args.method}`)
       }
 
-      return this.signTypedData(getTypedDataParam(args.params))
+      return this.signTypedData(getTypedDataParam(args.method, args.params))
     }
 
     if (args.method === 'eth_chainId') {

--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
@@ -1,4 +1,4 @@
-import { serializeTransaction } from 'viem'
+import { serializeTransaction, toHex } from 'viem'
 import {
   getEvmChainConfig,
   getViemPublicClient,
@@ -11,6 +11,44 @@ import type {
   WalletStrategyEvmOptions,
 } from '@injectivelabs/wallet-base'
 import type LedgerHW from './hw/index.js'
+
+const signTypedDataMethods = new Set([
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+])
+
+const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
+
+const isEthAddress = (value: unknown) =>
+  typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
+
+const getTypedDataParam = (params: any[]) => {
+  const typedData =
+    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+
+  return typeof typedData === 'string' ? typedData : JSON.stringify(typedData)
+}
+
+const getMessageParam = (method: string, params: any[]) => {
+  if (method === 'eth_sign') {
+    return params[1] || params[0]
+  }
+
+  return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+}
+
+const getMessageHex = (message: any) => {
+  if (message instanceof Uint8Array) {
+    return toHex(message).replace(/^0x/, '')
+  }
+
+  if (typeof message === 'string' && message.startsWith('0x')) {
+    return message.replace(/^0x/, '')
+  }
+
+  return toHex(String(message)).replace(/^0x/, '')
+}
 
 export class LedgerEip1193Provider implements Eip1193Provider {
   private readonly ledger: LedgerHW
@@ -121,16 +159,23 @@ export class LedgerEip1193Provider implements Eip1193Provider {
   }
 
   async request(args: { method: string; params: any[] }): Promise<any> {
-    if (args.method === 'eth_requestAccounts') {
+    if (
+      args.method === 'eth_requestAccounts' ||
+      args.method === 'eth_accounts'
+    ) {
       const address = await this.getAddress()
 
       return [address]
     }
 
-    if (args.method === 'eth_sign') {
-      if (!args.params[0]) throw new Error('Missing parameter for eth_sign')
+    if (signMessageMethods.has(args.method)) {
+      if (!args.params[0]) {
+        throw new Error(`Missing parameter for ${args.method}`)
+      }
 
-      return this.signMessage(args.params[0])
+      return this.signMessage(
+        getMessageHex(getMessageParam(args.method, args.params)),
+      )
     }
 
     if (args.method === 'eth_signTransaction') {
@@ -141,12 +186,12 @@ export class LedgerEip1193Provider implements Eip1193Provider {
       return this.signTransaction(args.params[0])
     }
 
-    if (args.method === 'eth_signTypedData') {
+    if (signTypedDataMethods.has(args.method)) {
       if (!args.params[0]) {
-        throw new Error('Missing parameter for eth_signTypedData')
+        throw new Error(`Missing parameter for ${args.method}`)
       }
 
-      return this.signTypedData(args.params[0])
+      return this.signTypedData(getTypedDataParam(args.params))
     }
 
     if (args.method === 'eth_chainId') {

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
@@ -1,0 +1,89 @@
+import { vi } from 'vitest'
+import { TrezorEip1193Provider } from './Eip1193Provider.js'
+import type { BaseTrezorTransport } from './hw/index.js'
+
+vi.mock('@injectivelabs/wallet-base', () => ({
+  getEvmChainConfig: vi.fn(),
+  getViemPublicClient: vi.fn(),
+  getViemWalletClient: vi.fn(() => ({
+    request: vi.fn(() => {
+      throw new Error('Unexpected RPC fallback')
+    }),
+  })),
+}))
+
+describe('Trezor EIP-1193 provider', () => {
+  const address = '0x0000000000000000000000000000000000000001'
+  const typedData = {
+    domain: { name: 'Injective', version: '1', chainId: 1 },
+    types: {
+      Message: [{ name: 'contents', type: 'string' }],
+    },
+    primaryType: 'Message',
+    message: {
+      contents: 'hello',
+    },
+  }
+
+  const getProvider = () => {
+    const trezor = {
+      connect: vi.fn(),
+    } as unknown as BaseTrezorTransport
+
+    return new TrezorEip1193Provider(trezor, {
+      rpcUrl: 'http://127.0.0.1:1',
+    })
+  }
+
+  it.each(['eth_requestAccounts', 'eth_accounts'])(
+    'resolves %s from the Trezor account',
+    async (method) => {
+      const provider = getProvider()
+
+      vi.spyOn(provider, 'getAddress').mockResolvedValue(address)
+
+      await expect(provider.request({ method, params: [] })).resolves.toEqual([
+        address,
+      ])
+    },
+  )
+
+  it.each(['eth_sign', 'personal_sign'])(
+    'routes %s through the Trezor message signer',
+    async (method) => {
+      const provider = getProvider()
+      const signMessage = vi
+        .spyOn(provider, 'signMessage')
+        .mockResolvedValue('0xsigned')
+
+      const params =
+        method === 'eth_sign' ? [address, '0x68656c6c6f'] : ['hello', address]
+
+      await expect(provider.request({ method, params })).resolves.toBe(
+        '0xsigned',
+      )
+      expect(signMessage).toHaveBeenCalledWith(
+        method === 'eth_sign' ? '0x68656c6c6f' : 'hello',
+      )
+    },
+  )
+
+  it.each([
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ])('routes %s through the Trezor typed data signer', async (method) => {
+    const provider = getProvider()
+    const signTypedData = vi
+      .spyOn(provider, 'signTypedData')
+      .mockResolvedValue('0xtyped')
+
+    const params =
+      method === 'eth_signTypedData'
+        ? [typedData]
+        : [address, JSON.stringify(typedData)]
+
+    await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
+    expect(signTypedData).toHaveBeenCalledWith(JSON.stringify(typedData))
+  })
+})

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
@@ -68,6 +68,17 @@ describe('Trezor EIP-1193 provider', () => {
     },
   )
 
+  it.each(['eth_sign', 'personal_sign'])(
+    'rejects %s without a message payload',
+    async (method) => {
+      const provider = getProvider()
+
+      await expect(
+        provider.request({ method, params: [address] }),
+      ).rejects.toThrow(`Missing message parameter for ${method}`)
+    },
+  )
+
   it.each([
     'eth_signTypedData',
     'eth_signTypedData_v3',
@@ -85,5 +96,13 @@ describe('Trezor EIP-1193 provider', () => {
 
     await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
     expect(signTypedData).toHaveBeenCalledWith(JSON.stringify(typedData))
+  })
+
+  it('rejects typed data signing without a typed-data payload', async () => {
+    const provider = getProvider()
+
+    await expect(
+      provider.request({ method: 'eth_signTypedData_v4', params: [address] }),
+    ).rejects.toThrow('Missing typed data parameter for eth_signTypedData_v4')
   })
 })

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
@@ -37,19 +37,31 @@ const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
 const isEthAddress = (value: unknown) =>
   typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
 
-const getTypedDataParam = (params: any[]) => {
-  const typedData =
-    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+const getTypedDataParam = (method: string, params: any[]) => {
+  const typedData = isEthAddress(params[0]) ? params[1] : params[0]
+
+  if (
+    typedData == null ||
+    (typeof typedData === 'string' && typedData.length === 0)
+  ) {
+    throw new Error(`Missing typed data parameter for ${method}`)
+  }
 
   return typeof typedData === 'string' ? typedData : JSON.stringify(typedData)
 }
 
 const getMessageParam = (method: string, params: any[]) => {
-  if (method === 'eth_sign') {
-    return params[1] || params[0]
+  let message = params[0]
+
+  if (method === 'eth_sign' || isEthAddress(params[0])) {
+    message = params[1]
   }
 
-  return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+  if (typeof message !== 'string' || message.length === 0) {
+    throw new Error(`Missing message parameter for ${method}`)
+  }
+
+  return message
 }
 
 export class TrezorEip1193Provider implements Eip1193Provider {
@@ -285,7 +297,7 @@ export class TrezorEip1193Provider implements Eip1193Provider {
         throw new Error(`Missing parameter for ${args.method}`)
       }
 
-      return this.signTypedData(getTypedDataParam(args.params))
+      return this.signTypedData(getTypedDataParam(args.method, args.params))
     }
 
     if (args.method === 'eth_chainId') {

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
@@ -26,6 +26,32 @@ type EthereumTransactionEIP1559 = {
   maxPriorityFeePerGas: string
 }
 
+const signTypedDataMethods = new Set([
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+])
+
+const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
+
+const isEthAddress = (value: unknown) =>
+  typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
+
+const getTypedDataParam = (params: any[]) => {
+  const typedData =
+    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+
+  return typeof typedData === 'string' ? typedData : JSON.stringify(typedData)
+}
+
+const getMessageParam = (method: string, params: any[]) => {
+  if (method === 'eth_sign') {
+    return params[1] || params[0]
+  }
+
+  return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+}
+
 export class TrezorEip1193Provider implements Eip1193Provider {
   private readonly trezor: BaseTrezorTransport
   private readonly derivationPath: string
@@ -229,18 +255,21 @@ export class TrezorEip1193Provider implements Eip1193Provider {
   }
 
   async request(args: { method: string; params: any[] }): Promise<any> {
-    if (args.method === 'eth_requestAccounts') {
+    if (
+      args.method === 'eth_requestAccounts' ||
+      args.method === 'eth_accounts'
+    ) {
       const address = await this.getAddress()
 
       return [address]
     }
 
-    if (args.method === 'eth_sign') {
+    if (signMessageMethods.has(args.method)) {
       if (!args.params[0]) {
-        throw new Error('Missing parameter for eth_sign')
+        throw new Error(`Missing parameter for ${args.method}`)
       }
 
-      return this.signMessage(args.params[0])
+      return this.signMessage(getMessageParam(args.method, args.params))
     }
 
     if (args.method === 'eth_signTransaction') {
@@ -251,12 +280,12 @@ export class TrezorEip1193Provider implements Eip1193Provider {
       return this.signTransaction(args.params[0])
     }
 
-    if (args.method === 'eth_signTypedData') {
+    if (signTypedDataMethods.has(args.method)) {
       if (!args.params[0]) {
-        throw new Error('Missing parameter for eth_signTypedData')
+        throw new Error(`Missing parameter for ${args.method}`)
       }
 
-      return this.signTypedData(args.params[0])
+      return this.signTypedData(getTypedDataParam(args.params))
     }
 
     if (args.method === 'eth_chainId') {

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
@@ -1,0 +1,126 @@
+import { vi } from 'vitest'
+import { getEip1193ProviderForTurnkey } from './Eip1193Provider.js'
+import type { LocalAccount } from 'viem'
+
+vi.mock('@injectivelabs/wallet-base', () => ({
+  getEvmChainConfig: vi.fn(),
+  getViemPublicClient: vi.fn(),
+  getViemWalletClient: vi.fn(() => ({
+    request: vi.fn(() => {
+      throw new Error('Unexpected RPC fallback')
+    }),
+  })),
+}))
+
+describe('Turnkey EIP-1193 provider', () => {
+  const address = '0x0000000000000000000000000000000000000001'
+  const typedData = {
+    domain: {
+      name: 'Injective',
+      version: '1',
+      chainId: 1,
+      verifyingContract: '0x0000000000000000000000000000000000000002',
+    },
+    types: {
+      Message: [{ name: 'contents', type: 'string' }],
+    },
+    primaryType: 'Message',
+    message: {
+      contents: 'hello',
+    },
+  }
+
+  const account = {
+    address,
+    sign: vi.fn(),
+    signTypedData: vi.fn(),
+    signMessage: vi.fn(),
+    signTransaction: vi.fn(),
+  } as unknown as LocalAccount
+
+  it.each(['eth_requestAccounts', 'eth_accounts'])(
+    'resolves %s from the Turnkey account',
+    async (method) => {
+      const provider = await getEip1193ProviderForTurnkey(account, 1, {
+        rpcUrl: 'http://127.0.0.1:1',
+      })
+
+      await expect(provider.request({ method, params: [] })).resolves.toEqual([
+        address,
+      ])
+    },
+  )
+
+  it.each(['eth_sign', 'personal_sign'])(
+    'routes %s through the Turnkey message signer',
+    async (method) => {
+      const signMessage = vi.fn().mockResolvedValue('0xsigned')
+      const provider = await getEip1193ProviderForTurnkey(
+        {
+          ...account,
+          signMessage,
+        } as unknown as LocalAccount,
+        1,
+        {
+          rpcUrl: 'http://127.0.0.1:1',
+        },
+      )
+
+      const params =
+        method === 'eth_sign' ? [address, '0x68656c6c6f'] : ['hello', address]
+
+      await expect(provider.request({ method, params })).resolves.toBe(
+        '0xsigned',
+      )
+      expect(signMessage).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.each([
+    'eth_signTypedData',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ])('routes %s through the Turnkey typed data signer', async (method) => {
+    const sign = vi.fn().mockResolvedValue('0xtyped')
+    const provider = await getEip1193ProviderForTurnkey(
+      {
+        ...account,
+        sign,
+      } as unknown as LocalAccount,
+      1,
+      {
+        rpcUrl: 'http://127.0.0.1:1',
+      },
+    )
+
+    const params =
+      method === 'eth_signTypedData'
+        ? [typedData]
+        : [address, JSON.stringify(typedData)]
+
+    await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
+    expect(sign).toHaveBeenCalledTimes(1)
+  })
+
+  it('routes eth_signTransaction through the Turnkey transaction signer', async () => {
+    const signTransaction = vi.fn().mockResolvedValue('0xsignedtx')
+    const provider = await getEip1193ProviderForTurnkey(
+      {
+        ...account,
+        signTransaction,
+      } as unknown as LocalAccount,
+      1,
+      {
+        rpcUrl: 'http://127.0.0.1:1',
+      },
+    )
+
+    await expect(
+      provider.request({
+        method: 'eth_signTransaction',
+        params: [{ to: address }],
+      }),
+    ).resolves.toBe('0xsignedtx')
+    expect(signTransaction).toHaveBeenCalledWith({ to: address })
+  })
+})

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
@@ -51,7 +51,7 @@ describe('Turnkey EIP-1193 provider', () => {
     },
   )
 
-  it.each(['eth_sign', 'personal_sign'])(
+  it.each(['eth_sign', 'personal_sign', 'eth_signMessage'])(
     'routes %s through the Turnkey message signer',
     async (method) => {
       const signMessage = vi.fn().mockResolvedValue('0xsigned')
@@ -67,12 +67,38 @@ describe('Turnkey EIP-1193 provider', () => {
       )
 
       const params =
-        method === 'eth_sign' ? [address, '0x68656c6c6f'] : ['hello', address]
+        method === 'eth_sign'
+          ? [address, '0x68656c6c6f']
+          : method === 'personal_sign'
+            ? ['hello', address]
+            : ['hello']
 
       await expect(provider.request({ method, params })).resolves.toBe(
         '0xsigned',
       )
       expect(signMessage).toHaveBeenCalledTimes(1)
+    },
+  )
+
+  it.each(['eth_sign', 'personal_sign'])(
+    'rejects %s without a message payload',
+    async (method) => {
+      const signMessage = vi.fn()
+      const provider = await getEip1193ProviderForTurnkey(
+        {
+          ...account,
+          signMessage,
+        } as unknown as LocalAccount,
+        1,
+        {
+          rpcUrl: 'http://127.0.0.1:1',
+        },
+      )
+
+      await expect(
+        provider.request({ method, params: [address] }),
+      ).rejects.toThrow(`Missing message parameter for ${method}`)
+      expect(signMessage).not.toHaveBeenCalled()
     },
   )
 
@@ -100,6 +126,25 @@ describe('Turnkey EIP-1193 provider', () => {
 
     await expect(provider.request({ method, params })).resolves.toBe('0xtyped')
     expect(sign).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects typed data signing without a typed-data payload', async () => {
+    const sign = vi.fn()
+    const provider = await getEip1193ProviderForTurnkey(
+      {
+        ...account,
+        sign,
+      } as unknown as LocalAccount,
+      1,
+      {
+        rpcUrl: 'http://127.0.0.1:1',
+      },
+    )
+
+    await expect(
+      provider.request({ method: 'eth_signTypedData_v4', params: [address] }),
+    ).rejects.toThrow('Missing typed data parameter for eth_signTypedData_v4')
+    expect(sign).not.toHaveBeenCalled()
   })
 
   it('routes eth_signTransaction through the Turnkey transaction signer', async () => {

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
@@ -9,6 +9,18 @@ import type { Eip1193Provider } from '@injectivelabs/wallet-base'
 
 type RpcUrls = Partial<Record<number, string>>
 
+const signTypedDataMethods = new Set([
+  'eth_signTypedData',
+  'eth_signTypedData_v3',
+  'eth_signTypedData_v4',
+])
+
+const signMessageMethods = new Set([
+  'eth_sign',
+  'personal_sign',
+  'eth_signMessage',
+])
+
 const parseChainId = (chainId: number | string) => {
   if (typeof chainId === 'number') {
     return chainId
@@ -19,6 +31,51 @@ const parseChainId = (chainId: number | string) => {
   }
 
   return parseInt(chainId, 10)
+}
+
+const isEthAddress = (value: unknown) =>
+  typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
+
+const getTypedDataParam = (params?: any[]) => {
+  if (!params?.length) {
+    throw new Error('params is required')
+  }
+
+  const typedData =
+    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+
+  return typeof typedData === 'string' ? JSON.parse(typedData) : typedData
+}
+
+const getMessageParam = (method: string, params?: any[]) => {
+  if (!params?.length) {
+    throw new Error('params is required')
+  }
+
+  if (method === 'eth_sign') {
+    return params[1] || params[0]
+  }
+
+  if (method === 'personal_sign') {
+    return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+  }
+
+  return params[0]
+}
+
+const getSignableMessage = (message: any) => {
+  if (message && typeof message === 'object' && 'message' in message) {
+    return message
+  }
+
+  if (
+    message instanceof Uint8Array ||
+    (typeof message === 'string' && message.startsWith('0x'))
+  ) {
+    return { message: { raw: message } }
+  }
+
+  return { message }
 }
 
 export const getEip1193ProviderForTurnkey = async (
@@ -106,19 +163,18 @@ class CustomEip1193Provider implements Eip1193Provider {
   }
 
   async request(args: { method: string; params?: any[] }) {
-    if (args.method === 'eth_requestAccounts') {
+    if (
+      args.method === 'eth_requestAccounts' ||
+      args.method === 'eth_accounts'
+    ) {
       return this.requestAccounts()
     }
 
-    if (args.method === 'eth_signTypedData') {
-      if (!args.params) {
-        throw new Error('params is required')
-      }
-
+    if (signTypedDataMethods.has(args.method)) {
       // ? We need to manually hash the EIP712 data to get the raw hash and sign that via Turnkey due to a breaking change on their end
       // account.sign is available in @turnkey/viem >= 0.12.0; older versions hashed client-side inside
       // signTypedData already, so both paths produce an identical signature.
-      const typedData = args.params[0]
+      const typedData = getTypedDataParam(args.params)
 
       if (this.sign) {
         const typedDataHash = hashTypedData({
@@ -140,12 +196,18 @@ class CustomEip1193Provider implements Eip1193Provider {
       return this.signTypedData(typedData)
     }
 
-    if (args.method === 'eth_signMessage') {
+    if (signMessageMethods.has(args.method)) {
+      const message = getMessageParam(args.method, args.params)
+
+      return this.signMessage(getSignableMessage(message))
+    }
+
+    if (args.method === 'eth_signTransaction') {
       if (!args.params) {
         throw new Error('params is required')
       }
 
-      return this.signMessage(args.params[0])
+      return this.signTransaction(args.params[0])
     }
 
     if (args.method === 'eth_chainId') {

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
@@ -36,15 +36,46 @@ const parseChainId = (chainId: number | string) => {
 const isEthAddress = (value: unknown) =>
   typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
 
-const getTypedDataParam = (params?: any[]) => {
+const getTypedDataParam = (method: string, params?: any[]) => {
   if (!params?.length) {
     throw new Error('params is required')
   }
 
-  const typedData =
-    params.length > 1 && isEthAddress(params[0]) ? params[1] : params[0]
+  const typedData = isEthAddress(params[0]) ? params[1] : params[0]
 
-  return typeof typedData === 'string' ? JSON.parse(typedData) : typedData
+  if (
+    typedData == null ||
+    (typeof typedData === 'string' && typedData.length === 0) ||
+    (typeof typedData !== 'string' && typeof typedData !== 'object')
+  ) {
+    throw new Error(`Missing typed data parameter for ${method}`)
+  }
+
+  const parsedTypedData = (() => {
+    if (typeof typedData !== 'string') {
+      return typedData
+    }
+
+    try {
+      return JSON.parse(typedData)
+    } catch {
+      throw new Error(`Invalid typed data parameter for ${method}`)
+    }
+  })()
+
+  if (
+    !parsedTypedData ||
+    typeof parsedTypedData !== 'object' ||
+    Array.isArray(parsedTypedData) ||
+    !parsedTypedData.domain ||
+    !parsedTypedData.types ||
+    typeof parsedTypedData.primaryType !== 'string' ||
+    !('message' in parsedTypedData)
+  ) {
+    throw new Error(`Invalid typed data parameter for ${method}`)
+  }
+
+  return parsedTypedData
 }
 
 const getMessageParam = (method: string, params?: any[]) => {
@@ -52,15 +83,25 @@ const getMessageParam = (method: string, params?: any[]) => {
     throw new Error('params is required')
   }
 
+  let message = params[0]
+
   if (method === 'eth_sign') {
-    return params[1] || params[0]
+    message = params[1]
   }
 
-  if (method === 'personal_sign') {
-    return isEthAddress(params[0]) && params[1] ? params[1] : params[0]
+  if (method === 'personal_sign' && isEthAddress(params[0])) {
+    message = params[1]
   }
 
-  return params[0]
+  if (
+    !(message instanceof Uint8Array) &&
+    (typeof message !== 'string' || message.length === 0) &&
+    !(message && typeof message === 'object' && 'message' in message)
+  ) {
+    throw new Error(`Missing message parameter for ${method}`)
+  }
+
+  return message
 }
 
 const getSignableMessage = (message: any) => {
@@ -174,7 +215,7 @@ class CustomEip1193Provider implements Eip1193Provider {
       // ? We need to manually hash the EIP712 data to get the raw hash and sign that via Turnkey due to a breaking change on their end
       // account.sign is available in @turnkey/viem >= 0.12.0; older versions hashed client-side inside
       // signTypedData already, so both paths produce an identical signature.
-      const typedData = getTypedDataParam(args.params)
+      const typedData = getTypedDataParam(args.method, args.params)
 
       if (this.sign) {
         const typedDataHash = hashTypedData({


### PR DESCRIPTION
This pull request improves the handling and testing of EIP-1193 provider methods for Ledger, Trezor, and Turnkey wallet strategies. The main focus is on standardizing the routing of signing methods (`eth_sign`, `personal_sign`, `eth_signTypedData`, etc.), supporting additional method variants, and ensuring robust parameter parsing and error handling. Comprehensive tests are added for all three providers.

**EIP-1193 Provider Method Handling Improvements:**

- Standardized the handling of signing methods for Ledger, Trezor, and Turnkey providers by introducing sets for `signMessageMethods` and `signTypedDataMethods`, allowing all relevant method variants (e.g., `eth_signTypedData_v3`, `eth_signTypedData_v4`) to be routed appropriately. [[1]](diffhunk://#diff-217322ac0bcaad12ad670b272695065f79b2c901c9d5dcb77c8b72f0fa00681eR15-R52) [[2]](diffhunk://#diff-d9ff8b13bc8f8d498865f613f3976cc999d541f6373a44c272d499d3cc0017bcR29-R54) [[3]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR12-R23)
- Improved parameter extraction and validation for message and typed data signing, including robust checks for Ethereum addresses and support for various parameter shapes. [[1]](diffhunk://#diff-217322ac0bcaad12ad670b272695065f79b2c901c9d5dcb77c8b72f0fa00681eR15-R52) [[2]](diffhunk://#diff-d9ff8b13bc8f8d498865f613f3976cc999d541f6373a44c272d499d3cc0017bcR29-R54) [[3]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR36-R80)
- Enhanced support for both `eth_requestAccounts` and `eth_accounts` methods in all providers, ensuring consistent account retrieval. [[1]](diffhunk://#diff-217322ac0bcaad12ad670b272695065f79b2c901c9d5dcb77c8b72f0fa00681eL124-R178) [[2]](diffhunk://#diff-d9ff8b13bc8f8d498865f613f3976cc999d541f6373a44c272d499d3cc0017bcL232-R272) [[3]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eL109-R177)

**Test Coverage:**

- Added comprehensive unit tests for Ledger, Trezor, and Turnkey EIP-1193 providers, covering all major signing and account retrieval methods, and verifying correct routing and error handling. [[1]](diffhunk://#diff-fbdf03b9a0d6ecbfdd7cf081295bf9400451948a53a4b4e331c7f4439430158aR1-R87) [[2]](diffhunk://#diff-874c6da86ff353ac5fedfa8480199d483f2bf360ff7f0321d0917710b5988e32R1-R89) [[3]](diffhunk://#diff-e0ac22b60f88d144f4ea744762ca133decaeec6f07d529255c1e4fc327b53709R1-R126)

**Turnkey Provider Enhancements:**

- Added support for the `eth_signMessage` method and improved message formatting for Turnkey by introducing a `getSignableMessage` helper. [[1]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR12-R23) [[2]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR36-R80) [[3]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eL143-R210)
- Improved parsing of typed data parameters to ensure correct handling of both object and JSON string formats. [[1]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eR36-R80) [[2]](diffhunk://#diff-ffe709fabe4bc0695966ea12b346191c09143b931fdd848db2c730c8aef53e8eL109-R177)

**Miscellaneous:**

- Minor import updates to include necessary utilities (e.g., `toHex` from `viem`).

These changes collectively make the EIP-1193 provider implementations more robust, easier to maintain, and better tested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded wallet signing support (broader JSON-RPC signing methods) and normalized message/typed-data parameter handling across Ledger, Trezor, and Turnkey providers.
  * Improved error reporting for missing request parameters.

* **Tests**
  * Added end-to-end tests for account retrieval, message signing, typed-data signing, transaction signing, and rejection cases for all providers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/InjectiveLabs/injective-ts/pull/680?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->