### PR TITLE
feat: added modes to check if tx has been included

### DIFF
--- a/packages/sdk-ts/src/core/tx/api/TxEventInclusion.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxEventInclusion.spec.ts
@@ -1,0 +1,140 @@
+import * as CosmosTxV1Beta1TxPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/tx/v1beta1/tx_pb'
+import { TxClient } from '../utils/classes/TxClient.js'
+import {
+  subscribeToTendermintTxEvent,
+  normalizeTendermintWebSocketEndpoint,
+} from './TxEventInclusion.js'
+
+class FakeWebSocket extends EventTarget {
+  public readyState = 0
+  public readonly sent: string[] = []
+
+  constructor(public readonly url: string) {
+    super()
+    queueMicrotask(() => {
+      this.readyState = 1
+      this.dispatchEvent(new Event('open'))
+    })
+  }
+
+  send(data: string) {
+    this.sent.push(data)
+    const request = JSON.parse(data)
+    queueMicrotask(() => {
+      this.dispatchEvent(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            id: request.id,
+            jsonrpc: '2.0',
+            result: {},
+          }),
+        }),
+      )
+    })
+  }
+
+  close() {
+    this.readyState = 3
+    this.dispatchEvent(new Event('close'))
+  }
+
+  emitTx(txHash: string, code = 0) {
+    this.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          jsonrpc: '2.0',
+          params: {
+            result: {
+              data: {
+                events: {
+                  'tx.hash': [txHash],
+                },
+                value: {
+                  TxResult: {
+                    height: '123',
+                    result: {
+                      code,
+                      log: code === 0 ? '' : 'failed',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    )
+  }
+}
+
+const makeTxHash = () => {
+  const txRaw = CosmosTxV1Beta1TxPb.TxRaw.create({
+    bodyBytes: new Uint8Array([1]),
+    authInfoBytes: new Uint8Array([2]),
+    signatures: [new Uint8Array([3])],
+  })
+
+  return TxClient.hash(txRaw)
+}
+
+describe('Tendermint tx event inclusion', () => {
+  it('normalizes Tendermint HTTP endpoints to websocket endpoints', () => {
+    expect(normalizeTendermintWebSocketEndpoint('http://localhost:26657')).toBe(
+      'ws://localhost:26657/websocket',
+    )
+    expect(
+      normalizeTendermintWebSocketEndpoint('https://rpc.injective.network/'),
+    ).toBe('wss://rpc.injective.network/websocket')
+    expect(
+      normalizeTendermintWebSocketEndpoint(
+        'wss://rpc.injective.network/websocket',
+      ),
+    ).toBe('wss://rpc.injective.network/websocket')
+  })
+
+  it('waits for the subscribed tx event', async () => {
+    const txHash = makeTxHash()
+    let socket: FakeWebSocket | undefined
+
+    const subscription = await subscribeToTendermintTxEvent({
+      txHash,
+      timeout: 1000,
+      endpoint: 'http://localhost:26657',
+      webSocketFactory: (endpoint) => {
+        socket = new FakeWebSocket(endpoint)
+        return socket as unknown as WebSocket
+      },
+    })
+
+    expect(socket?.url).toBe('ws://localhost:26657/websocket')
+    expect(socket?.sent[0]).toContain(`tx.hash='${txHash}'`)
+
+    socket?.emitTx(txHash)
+
+    await expect(subscription.wait()).resolves.toMatchObject({
+      txHash,
+      height: 123,
+      code: 0,
+    })
+  })
+
+  it('ignores tx events for other hashes', async () => {
+    const txHash = makeTxHash()
+    let socket: FakeWebSocket | undefined
+
+    const subscription = await subscribeToTendermintTxEvent({
+      txHash,
+      timeout: 1000,
+      endpoint: 'http://localhost:26657',
+      webSocketFactory: (endpoint) => {
+        socket = new FakeWebSocket(endpoint)
+        return socket as unknown as WebSocket
+      },
+    })
+
+    socket?.emitTx('OTHER_HASH')
+    socket?.emitTx(txHash)
+
+    await expect(subscription.wait()).resolves.toMatchObject({ txHash })
+  })
+})

--- a/packages/sdk-ts/src/core/tx/api/TxEventInclusion.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxEventInclusion.spec.ts
@@ -38,6 +38,20 @@ class FakeWebSocket extends EventTarget {
     this.dispatchEvent(new Event('close'))
   }
 
+  emitSubscribeError(error: unknown) {
+    const request = JSON.parse(this.sent[0])
+
+    this.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          id: request.id,
+          jsonrpc: '2.0',
+          error,
+        }),
+      }),
+    )
+  }
+
   emitTx(txHash: string, code = 0) {
     this.dispatchEvent(
       new MessageEvent('message', {
@@ -76,6 +90,14 @@ const makeTxHash = () => {
 
   return TxClient.hash(txRaw)
 }
+
+const waitForImmediateResult = <T>(promise: Promise<T>) =>
+  Promise.race([
+    promise,
+    new Promise<'timeout'>((resolve) => {
+      setTimeout(() => resolve('timeout'), 25)
+    }),
+  ])
 
 describe('Tendermint tx event inclusion', () => {
   it('normalizes Tendermint HTTP endpoints to websocket endpoints', () => {
@@ -116,6 +138,47 @@ describe('Tendermint tx event inclusion', () => {
       height: 123,
       code: 0,
     })
+  })
+
+  it('rejects wait immediately when a confirmed subscription receives an error', async () => {
+    const txHash = makeTxHash()
+    let socket: FakeWebSocket | undefined
+
+    const subscription = await subscribeToTendermintTxEvent({
+      txHash,
+      timeout: 1000,
+      endpoint: 'http://localhost:26657',
+      webSocketFactory: (endpoint) => {
+        socket = new FakeWebSocket(endpoint)
+        return socket as unknown as WebSocket
+      },
+    })
+
+    const waitResult = subscription.wait().then(
+      () => 'resolved',
+      (error: Error) => error.message,
+    )
+
+    socket?.emitSubscribeError({ code: -32000, message: 'subscription failed' })
+
+    await expect(waitForImmediateResult(waitResult)).resolves.toContain(
+      'Tendermint subscribe failed',
+    )
+  })
+
+  it('rejects invalid tx hashes before building a Tendermint query', async () => {
+    const webSocketFactory = vi.fn()
+
+    await expect(
+      subscribeToTendermintTxEvent({
+        txHash: "ABC' OR tm.event='NewBlock",
+        timeout: 1000,
+        endpoint: 'http://localhost:26657',
+        webSocketFactory,
+      }),
+    ).rejects.toThrow('Invalid Tendermint tx hash')
+
+    expect(webSocketFactory).not.toHaveBeenCalled()
   })
 
   it('ignores tx events for other hashes', async () => {

--- a/packages/sdk-ts/src/core/tx/api/TxEventInclusion.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxEventInclusion.ts
@@ -1,0 +1,301 @@
+import type {
+  TxEventWebSocketFactory,
+  TxClientBroadcastResponse,
+} from '../types/tx.js'
+
+export interface TendermintTxEventSubscription {
+  close: () => void
+  wait: () => Promise<TxClientBroadcastResponse>
+}
+
+interface SubscribeToTendermintTxEventArgs {
+  endpoint: string
+  timeout: number
+  txHash: string
+  webSocketFactory?: TxEventWebSocketFactory
+}
+
+export function normalizeTendermintWebSocketEndpoint(endpoint: string): string {
+  let normalized = endpoint
+
+  if (normalized.startsWith('http://')) {
+    normalized = `ws://${normalized.slice('http://'.length)}`
+  } else if (normalized.startsWith('https://')) {
+    normalized = `wss://${normalized.slice('https://'.length)}`
+  }
+
+  return normalized.endsWith('/websocket')
+    ? normalized
+    : `${normalized.replace(/\/$/, '')}/websocket`
+}
+
+export async function subscribeToTendermintTxEvent({
+  endpoint,
+  timeout,
+  txHash,
+  webSocketFactory,
+}: SubscribeToTendermintTxEventArgs): Promise<TendermintTxEventSubscription> {
+  const websocketEndpoint = normalizeTendermintWebSocketEndpoint(endpoint)
+  const socket = createTendermintSocket(websocketEndpoint, webSocketFactory)
+  const query = `tm.event='Tx' AND tx.hash='${txHash}'`
+  const requestId = `tx-event-${Date.now()}-${Math.random()}`
+
+  return new Promise((resolve, reject) => {
+    let ready = false
+    let closedIntentionally = false
+    let waitSettled = false
+    let timeoutId: ReturnType<typeof setTimeout>
+    let waitResolve: (response: TxClientBroadcastResponse) => void
+    let waitReject: (error: Error) => void
+
+    const waitPromise = new Promise<TxClientBroadcastResponse>(
+      (resolveWait, rejectWait) => {
+        waitResolve = resolveWait
+        waitReject = rejectWait
+      },
+    )
+
+    const resolveSubscription = () => {
+      if (ready) {
+        return
+      }
+
+      ready = true
+      resolve({
+        close: cleanup,
+        wait: () => waitPromise,
+      })
+    }
+
+    const cleanup = () => {
+      closedIntentionally = true
+      clearTimeout(timeoutId)
+      socket.removeEventListener('open', onOpen)
+      socket.removeEventListener('message', onMessage)
+      socket.removeEventListener('error', onError)
+      socket.removeEventListener('close', onClose)
+
+      if (socket.readyState === 1 || socket.readyState === 0) {
+        socket.close()
+      }
+    }
+
+    const rejectWait = (error: Error) => {
+      if (waitSettled) {
+        return
+      }
+
+      waitSettled = true
+      waitReject(error)
+      cleanup()
+    }
+
+    timeoutId = setTimeout(() => {
+      const error = new Error(
+        `Timed out waiting for Tendermint tx event after ${timeout}ms`,
+      )
+
+      if (ready) {
+        rejectWait(error)
+        return
+      }
+
+      cleanup()
+      reject(error)
+    }, timeout)
+
+    const resolveWait = (response: TxClientBroadcastResponse) => {
+      if (waitSettled) {
+        return
+      }
+
+      waitSettled = true
+      waitResolve(response)
+      cleanup()
+    }
+
+    const rejectForMessageError = (error: Error) => {
+      if (ready) {
+        rejectWait(error)
+        return
+      }
+
+      cleanup()
+      reject(error)
+    }
+
+    const onOpen = () => {
+      socket.send(
+        JSON.stringify({
+          id: requestId,
+          jsonrpc: '2.0',
+          method: 'subscribe',
+          params: { query },
+        }),
+      )
+    }
+
+    const onMessage = (event: MessageEvent) => {
+      void readMessageEventData(event)
+        .then((messageData) => {
+          const message = JSON.parse(messageData)
+          const eventResponse = parseTxEventResponse(message, txHash)
+
+          if (eventResponse) {
+            resolveSubscription()
+            resolveWait(eventResponse)
+            return
+          }
+
+          if (message.id !== requestId) {
+            return
+          }
+
+          if (message.error) {
+            cleanup()
+            reject(
+              new Error(
+                `Tendermint subscribe failed: ${JSON.stringify(message.error)}`,
+              ),
+            )
+            return
+          }
+
+          resolveSubscription()
+        })
+        .catch((error: unknown) => {
+          rejectForMessageError(
+            error instanceof Error
+              ? error
+              : new Error(
+                  `Invalid Tendermint WebSocket JSON: ${String(error)}`,
+                ),
+          )
+        })
+    }
+
+    const onError = () => {
+      const error = new Error('Tendermint WebSocket error')
+
+      if (ready) {
+        rejectWait(error)
+        return
+      }
+
+      cleanup()
+      reject(error)
+    }
+
+    const onClose = () => {
+      if (closedIntentionally) {
+        return
+      }
+
+      const error = new Error('Tendermint WebSocket closed')
+
+      if (ready) {
+        rejectWait(error)
+        return
+      }
+
+      cleanup()
+      reject(error)
+    }
+
+    socket.addEventListener('open', onOpen)
+    socket.addEventListener('message', onMessage)
+    socket.addEventListener('error', onError)
+    socket.addEventListener('close', onClose)
+  })
+}
+
+function createTendermintSocket(
+  endpoint: string,
+  webSocketFactory?: TxEventWebSocketFactory,
+) {
+  if (webSocketFactory) {
+    return webSocketFactory(endpoint)
+  }
+
+  if (!globalThis.WebSocket) {
+    throw new Error('WebSocket is not available in this environment')
+  }
+
+  return new globalThis.WebSocket(endpoint)
+}
+
+async function readMessageEventData(event: MessageEvent): Promise<string> {
+  const { data } = event
+
+  if (typeof data === 'string') {
+    return data
+  }
+
+  if (typeof Blob !== 'undefined' && data instanceof Blob) {
+    return data.text()
+  }
+
+  if (typeof ArrayBuffer !== 'undefined' && data instanceof ArrayBuffer) {
+    return new TextDecoder().decode(data)
+  }
+
+  if (ArrayBuffer.isView(data)) {
+    return new TextDecoder().decode(data)
+  }
+
+  return String(data)
+}
+
+function parseTxEventResponse(
+  message: any,
+  txHash: string,
+): TxClientBroadcastResponse | undefined {
+  const data = message?.params?.result?.data ?? message?.result?.data
+  const eventTxHashes = readTxEventHashes(data)
+
+  if (
+    eventTxHashes.length > 0 &&
+    !eventTxHashes.some(
+      (eventTxHash) => eventTxHash.toUpperCase() === txHash.toUpperCase(),
+    )
+  ) {
+    return undefined
+  }
+
+  const value = data?.value ?? data
+  const txResult = value?.TxResult ?? value?.tx_result ?? value
+  const result = txResult?.result ?? txResult?.Result
+
+  if (!txResult || !result) {
+    return undefined
+  }
+
+  return {
+    txHash,
+    height: Number(txResult.height || value?.height || 0),
+    code: Number(result.code || 0),
+    codespace: result.codespace || '',
+    data: result.data || '',
+    rawLog: result.log || result.raw_log || '',
+    logs: [],
+    info: result.info || '',
+    gasWanted: Number(result.gas_wanted || result.gasWanted || 0),
+    gasUsed: Number(result.gas_used || result.gasUsed || 0),
+    timestamp: '',
+    events: result.events || [],
+  }
+}
+
+function readTxEventHashes(data: any): string[] {
+  const txHashEvent = data?.events?.['tx.hash'] ?? data?.events?.tx_hash
+
+  if (Array.isArray(txHashEvent)) {
+    return txHashEvent.map(String)
+  }
+
+  if (txHashEvent) {
+    return [String(txHashEvent)]
+  }
+
+  return []
+}

--- a/packages/sdk-ts/src/core/tx/api/TxEventInclusion.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxEventInclusion.ts
@@ -2,18 +2,10 @@ import type {
   TxEventWebSocketFactory,
   TxClientBroadcastResponse,
 } from '../types/tx.js'
-
-export interface TendermintTxEventSubscription {
-  close: () => void
-  wait: () => Promise<TxClientBroadcastResponse>
-}
-
-interface SubscribeToTendermintTxEventArgs {
-  endpoint: string
-  timeout: number
-  txHash: string
-  webSocketFactory?: TxEventWebSocketFactory
-}
+import type {
+  TendermintTxEventSubscription,
+  SubscribeToTendermintTxEventArgs,
+} from './types.js'
 
 export function normalizeTendermintWebSocketEndpoint(endpoint: string): string {
   let normalized = endpoint
@@ -30,21 +22,23 @@ export function normalizeTendermintWebSocketEndpoint(endpoint: string): string {
 }
 
 export async function subscribeToTendermintTxEvent({
-  endpoint,
-  timeout,
   txHash,
+  timeout,
+  endpoint,
   webSocketFactory,
 }: SubscribeToTendermintTxEventArgs): Promise<TendermintTxEventSubscription> {
+  const normalizedTxHash = normalizeTendermintTxHash(txHash)
   const websocketEndpoint = normalizeTendermintWebSocketEndpoint(endpoint)
   const socket = createTendermintSocket(websocketEndpoint, webSocketFactory)
-  const query = `tm.event='Tx' AND tx.hash='${txHash}'`
+  const query = `tm.event='Tx' AND tx.hash='${normalizedTxHash}'`
   const requestId = `tx-event-${Date.now()}-${Math.random()}`
 
   return new Promise((resolve, reject) => {
     let ready = false
-    let closedIntentionally = false
     let waitSettled = false
+    let closedIntentionally = false
     let timeoutId: ReturnType<typeof setTimeout>
+
     let waitResolve: (response: TxClientBroadcastResponse) => void
     let waitReject: (error: Error) => void
 
@@ -139,7 +133,7 @@ export async function subscribeToTendermintTxEvent({
       void readMessageEventData(event)
         .then((messageData) => {
           const message = JSON.parse(messageData)
-          const eventResponse = parseTxEventResponse(message, txHash)
+          const eventResponse = parseTxEventResponse(message, normalizedTxHash)
 
           if (eventResponse) {
             resolveSubscription()
@@ -152,8 +146,7 @@ export async function subscribeToTendermintTxEvent({
           }
 
           if (message.error) {
-            cleanup()
-            reject(
+            rejectForMessageError(
               new Error(
                 `Tendermint subscribe failed: ${JSON.stringify(message.error)}`,
               ),
@@ -207,6 +200,14 @@ export async function subscribeToTendermintTxEvent({
     socket.addEventListener('error', onError)
     socket.addEventListener('close', onClose)
   })
+}
+
+function normalizeTendermintTxHash(txHash: string): string {
+  if (!/^[0-9a-fA-F]{64}$/.test(txHash)) {
+    throw new Error('Invalid Tendermint tx hash')
+  }
+
+  return txHash.toUpperCase()
 }
 
 function createTendermintSocket(
@@ -272,17 +273,17 @@ function parseTxEventResponse(
 
   return {
     txHash,
-    height: Number(txResult.height || value?.height || 0),
+    logs: [],
+    timestamp: '',
+    data: result.data || '',
+    info: result.info || '',
+    events: result.events || [],
     code: Number(result.code || 0),
     codespace: result.codespace || '',
-    data: result.data || '',
     rawLog: result.log || result.raw_log || '',
-    logs: [],
-    info: result.info || '',
-    gasWanted: Number(result.gas_wanted || result.gasWanted || 0),
+    height: Number(txResult.height || value?.height || 0),
     gasUsed: Number(result.gas_used || result.gasUsed || 0),
-    timestamp: '',
-    events: result.events || [],
+    gasWanted: Number(result.gas_wanted || result.gasWanted || 0),
   }
 }
 

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
@@ -407,12 +407,16 @@ describe('TxGrpcApi.broadcast event ordering', () => {
     const txHash = TxClient.hash(txRaw)
     const socket = new FakeWebSocket()
     const txResponse = makeTxResponse(txHash)
-    const fetchTxPoll = vi.spyOn(txApi, 'fetchTxPoll').mockImplementation(
-      async () =>
-        await new Promise<TxResponse>(() => {
+    let pollAbortSignal: AbortSignal | undefined
+    const fetchTxPoll = vi
+      .spyOn(txApi, 'fetchTxPoll')
+      .mockImplementation(async (_txHash, _timeout, abortSignal) => {
+        pollAbortSignal = abortSignal
+
+        return await new Promise<TxResponse>(() => {
           // Keep polling pending so the event side wins deterministically.
-        }),
-    )
+        })
+      })
     const fetchTx = vi.spyOn(txApi, 'fetchTx').mockResolvedValue(txResponse)
 
     vi.spyOn(txApi as any, 'executeGrpcCall').mockImplementation(
@@ -453,7 +457,12 @@ describe('TxGrpcApi.broadcast event ordering', () => {
 
     expect(result.txHash).toBe(txHash)
     expect(fetchTx).toHaveBeenCalledWith(txHash)
-    expect(fetchTxPoll).toHaveBeenCalledWith(txHash, expect.any(Number))
+    expect(fetchTxPoll).toHaveBeenCalledWith(
+      txHash,
+      expect.any(Number),
+      expect.any(Object),
+    )
+    expect(pollAbortSignal?.aborted).toBe(true)
   })
 
   it('falls back to sync polling when event inclusion has no rpc endpoint', async () => {

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
@@ -201,7 +201,10 @@ describe('TxGrpcApi.fetchTxPoll', () => {
     const txResponse = makeTxResponse('FOUND_FAST')
     vi.spyOn(txApi as any, 'fetchTx').mockResolvedValue(txResponse)
 
-    const result = await txApi.fetchTxPoll('FOUND_FAST', 5000)
+    const result = await txApi.fetchTxPoll({
+      txHash: 'FOUND_FAST',
+      timeout: 5000,
+    })
     expect(result.txHash).toBe('FOUND_FAST')
   })
 
@@ -221,7 +224,10 @@ describe('TxGrpcApi.fetchTxPoll', () => {
       return txResponse
     })
 
-    const result = await txApi.fetchTxPoll('FOUND_SLOW', 10000)
+    const result = await txApi.fetchTxPoll({
+      txHash: 'FOUND_SLOW',
+      timeout: 10000,
+    })
     expect(result.txHash).toBe('FOUND_SLOW')
   })
 
@@ -236,9 +242,9 @@ describe('TxGrpcApi.fetchTxPoll', () => {
 
     const timeout = 1500
     const start = Date.now()
-    await expect(txApi.fetchTxPoll('NEVER_FOUND', timeout)).rejects.toThrow(
-      GrpcUnaryRequestException,
-    )
+    await expect(
+      txApi.fetchTxPoll({ txHash: 'NEVER_FOUND', timeout }),
+    ).rejects.toThrow(GrpcUnaryRequestException)
     const elapsed = Date.now() - start
 
     // Should throw close to the deadline — allow 500 ms tolerance for CI
@@ -254,9 +260,9 @@ describe('TxGrpcApi.fetchTxPoll', () => {
       }),
     )
 
-    await expect(txApi.fetchTxPoll('NEVER_FOUND', 1000)).rejects.toThrow(
-      /1000ms/,
-    )
+    await expect(
+      txApi.fetchTxPoll({ txHash: 'NEVER_FOUND', timeout: 1000 }),
+    ).rejects.toThrow(/1000ms/)
   })
 
   // Bug 2 regression: the polling loop must not overshoot the deadline by a
@@ -275,7 +281,7 @@ describe('TxGrpcApi.fetchTxPoll', () => {
     const timeout = 2000
     const start = Date.now()
 
-    const promise = txApi.fetchTxPoll('HUNG_NODE', timeout)
+    const promise = txApi.fetchTxPoll({ txHash: 'HUNG_NODE', timeout })
     const assertion = expect(promise).rejects.toThrow(GrpcUnaryRequestException)
 
     await vi.advanceTimersByTimeAsync(timeout + 100)
@@ -331,6 +337,44 @@ describe('TxGrpcApi.broadcast event ordering', () => {
     })
 
     expect(events).toEqual(['onBroadcast', 'fetchTxPoll:start'])
+  })
+
+  it('allows polling waiter to be cancelled', async () => {
+    let pollAbortSignal: AbortSignal | undefined
+    const fetchTxPoll = vi
+      .spyOn(txApi, 'fetchTxPoll')
+      .mockImplementation(async ({ abortSignal }) => {
+        if (!abortSignal) {
+          throw new Error('missing abort signal')
+        }
+
+        pollAbortSignal = abortSignal
+
+        return await new Promise<TxResponse>((_resolve, reject) => {
+          abortSignal.addEventListener(
+            'abort',
+            () => {
+              reject(new Error('poll aborted'))
+            },
+            { once: true },
+          )
+        })
+      })
+
+    const waiter = await txApi.prepareTxInclusionWait('POLL_CANCEL', 1000)
+    const waitPromise = waiter.wait()
+
+    expect(fetchTxPoll).toHaveBeenCalledWith({
+      txHash: 'POLL_CANCEL',
+      timeout: 1000,
+      abortSignal: expect.any(Object),
+    })
+    expect(pollAbortSignal?.aborted).toBe(false)
+
+    waiter.close()
+
+    expect(pollAbortSignal?.aborted).toBe(true)
+    await expect(waitPromise).rejects.toThrow('poll aborted')
   })
 
   it('does not fire onBroadcast when SYNC broadcast returns non-zero code', async () => {
@@ -402,6 +446,56 @@ describe('TxGrpcApi.broadcast event ordering', () => {
     expect(fetchTxPoll).not.toHaveBeenCalled()
   })
 
+  it('allows hash-mismatch fallback polling to be cancelled', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const includedTxHash = 'A'.repeat(64)
+    const socket = new FakeWebSocket()
+    let pollAbortSignal: AbortSignal | undefined
+    const fetchTxPoll = vi
+      .spyOn(txApi, 'fetchTxPoll')
+      .mockImplementation(async ({ abortSignal }) => {
+        if (!abortSignal) {
+          throw new Error('missing abort signal')
+        }
+
+        pollAbortSignal = abortSignal
+
+        return await new Promise<TxResponse>((_resolve, reject) => {
+          abortSignal.addEventListener(
+            'abort',
+            () => {
+              reject(new Error('poll aborted'))
+            },
+            { once: true },
+          )
+        })
+      })
+
+    const waiter = await txApi.prepareTxInclusionWait(txHash, 1000, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+      eventInclusion: {
+        rpcEndpoint: 'http://localhost:26657',
+        webSocketFactory: () => socket as unknown as WebSocket,
+      },
+    })
+    const waitPromise = waiter.wait(includedTxHash)
+
+    await Promise.resolve()
+
+    expect(fetchTxPoll).toHaveBeenCalledWith({
+      txHash: includedTxHash,
+      timeout: 1000,
+      abortSignal: expect.any(Object),
+    })
+    expect(pollAbortSignal?.aborted).toBe(false)
+
+    waiter.close()
+
+    expect(pollAbortSignal?.aborted).toBe(true)
+    await expect(waitPromise).rejects.toThrow('poll aborted')
+  })
+
   it('races event and polling when dual inclusion is enabled', async () => {
     const txRaw = makeTxRaw()
     const txHash = TxClient.hash(txRaw)
@@ -410,7 +504,7 @@ describe('TxGrpcApi.broadcast event ordering', () => {
     let pollAbortSignal: AbortSignal | undefined
     const fetchTxPoll = vi
       .spyOn(txApi, 'fetchTxPoll')
-      .mockImplementation(async (_txHash, _timeout, abortSignal) => {
+      .mockImplementation(async ({ abortSignal }) => {
         pollAbortSignal = abortSignal
 
         return await new Promise<TxResponse>(() => {
@@ -457,11 +551,11 @@ describe('TxGrpcApi.broadcast event ordering', () => {
 
     expect(result.txHash).toBe(txHash)
     expect(fetchTx).toHaveBeenCalledWith(txHash)
-    expect(fetchTxPoll).toHaveBeenCalledWith(
+    expect(fetchTxPoll).toHaveBeenCalledWith({
       txHash,
-      expect.any(Number),
-      expect.any(Object),
-    )
+      timeout: expect.any(Number),
+      abortSignal: expect.any(Object),
+    })
     expect(pollAbortSignal?.aborted).toBe(true)
   })
 

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.spec.ts
@@ -2,7 +2,11 @@ import {
   TransactionException,
   GrpcUnaryRequestException,
 } from '@injectivelabs/exceptions'
+import * as CosmosTxV1Beta1TxPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/tx/v1beta1/tx_pb'
+import * as CosmosTxV1Beta1ServicePb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/tx/v1beta1/service_pb'
 import { TxGrpcApi } from './TxGrpcApi.js'
+import { TxInclusionStrategy } from '../types/tx.js'
+import { TxClient } from '../utils/classes/TxClient.js'
 import type { TxResponse } from '../types/tx.js'
 
 // ---------------------------------------------------------------------------
@@ -30,6 +34,74 @@ const makeTxResponse = (txHash = 'ABC123'): TxResponse =>
 
 /** Delays for `ms` milliseconds */
 const delay = (ms: number) => new Promise<void>((res) => setTimeout(res, ms))
+
+class FakeWebSocket extends EventTarget {
+  public readyState = 0
+  public subscriptionReady = false
+
+  constructor() {
+    super()
+    queueMicrotask(() => {
+      this.readyState = 1
+      this.dispatchEvent(new Event('open'))
+    })
+  }
+
+  send(data: string) {
+    const request = JSON.parse(data)
+    queueMicrotask(() => {
+      this.subscriptionReady = true
+      this.dispatchEvent(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            id: request.id,
+            jsonrpc: '2.0',
+            result: {},
+          }),
+        }),
+      )
+    })
+  }
+
+  close() {
+    this.readyState = 3
+  }
+
+  emitTx(txHash: string) {
+    this.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          jsonrpc: '2.0',
+          params: {
+            result: {
+              data: {
+                events: {
+                  'tx.hash': [txHash],
+                },
+                value: {
+                  TxResult: {
+                    height: '123',
+                    result: {
+                      code: 0,
+                      log: '',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    )
+  }
+}
+
+const makeTxRaw = () =>
+  CosmosTxV1Beta1TxPb.TxRaw.create({
+    bodyBytes: new Uint8Array([1]),
+    authInfoBytes: new Uint8Array([2]),
+    signatures: [new Uint8Array([3])],
+  })
 
 describe('TxGrpcApi V2 Migration', () => {
   let txApi: TxGrpcApi
@@ -287,5 +359,140 @@ describe('TxGrpcApi.broadcast event ordering', () => {
     ).rejects.toThrow(TransactionException)
 
     expect(onBroadcast).not.toHaveBeenCalled()
+  })
+
+  it('subscribes before async broadcast and resolves inclusion from the tx event', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const socket = new FakeWebSocket()
+    const txResponse = makeTxResponse(txHash)
+    const fetchTxPoll = vi.spyOn(txApi, 'fetchTxPoll')
+    const fetchTx = vi.spyOn(txApi, 'fetchTx').mockResolvedValue(txResponse)
+
+    vi.spyOn(txApi as any, 'executeGrpcCall').mockImplementation(async () => {
+      expect(socket.subscriptionReady).toBe(true)
+
+      queueMicrotask(() => {
+        socket.emitTx(txHash)
+      })
+
+      return {
+        txResponse: {
+          txhash: txHash,
+          code: 0,
+          rawLog: '',
+          codespace: '',
+          height: '0',
+          gasWanted: '0',
+          gasUsed: '0',
+        },
+      }
+    })
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+      eventInclusion: {
+        rpcEndpoint: 'http://localhost:26657',
+        webSocketFactory: () => socket as unknown as WebSocket,
+      },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(fetchTx).toHaveBeenCalledWith(txHash)
+    expect(fetchTxPoll).not.toHaveBeenCalled()
+  })
+
+  it('races event and polling when dual inclusion is enabled', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const socket = new FakeWebSocket()
+    const txResponse = makeTxResponse(txHash)
+    const fetchTxPoll = vi.spyOn(txApi, 'fetchTxPoll').mockImplementation(
+      async () =>
+        await new Promise<TxResponse>(() => {
+          // Keep polling pending so the event side wins deterministically.
+        }),
+    )
+    const fetchTx = vi.spyOn(txApi, 'fetchTx').mockResolvedValue(txResponse)
+
+    vi.spyOn(txApi as any, 'executeGrpcCall').mockImplementation(
+      async (request: unknown) => {
+        const broadcastRequest =
+          request as CosmosTxV1Beta1ServicePb.BroadcastTxRequest
+
+        expect(socket.subscriptionReady).toBe(true)
+        expect(broadcastRequest.mode).toBe(
+          CosmosTxV1Beta1ServicePb.BroadcastMode.ASYNC,
+        )
+
+        queueMicrotask(() => {
+          socket.emitTx(txHash)
+        })
+
+        return {
+          txResponse: {
+            txhash: txHash,
+            code: 0,
+            rawLog: '',
+            codespace: '',
+            height: '0',
+            gasWanted: '0',
+            gasUsed: '0',
+          },
+        }
+      },
+    )
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEventAndPoll,
+      eventInclusion: {
+        rpcEndpoint: 'http://localhost:26657',
+        webSocketFactory: () => socket as unknown as WebSocket,
+      },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(fetchTx).toHaveBeenCalledWith(txHash)
+    expect(fetchTxPoll).toHaveBeenCalledWith(txHash, expect.any(Number))
+  })
+
+  it('falls back to sync polling when event inclusion has no rpc endpoint', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const onFallback = vi.fn()
+    const txResponse = makeTxResponse(txHash)
+
+    vi.spyOn(txApi as any, 'executeGrpcCall').mockImplementation(
+      async (request: unknown) => {
+        const broadcastRequest =
+          request as CosmosTxV1Beta1ServicePb.BroadcastTxRequest
+
+        expect(broadcastRequest.mode).toBe(
+          CosmosTxV1Beta1ServicePb.BroadcastMode.SYNC,
+        )
+
+        return {
+          txResponse: {
+            txhash: txHash,
+            code: 0,
+            rawLog: '',
+            codespace: '',
+            height: '0',
+            gasWanted: '0',
+            gasUsed: '0',
+          },
+        }
+      },
+    )
+
+    vi.spyOn(txApi, 'fetchTxPoll').mockResolvedValue(txResponse)
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+      eventInclusion: { onFallback },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(onFallback).toHaveBeenCalledOnce()
   })
 })

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
@@ -17,7 +17,7 @@ import {
 } from '@injectivelabs/utils'
 import { TxInclusionStrategy } from '../types/tx.js'
 import { TxClient } from '../utils/classes/TxClient.js'
-import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
+import { prepareTxInclusionWaiter } from './TxInclusion.js'
 import BaseGrpcConsumer from '../../../client/base/BaseGrpcConsumer.js'
 import type { TxResponse } from '../types/tx.js'
 import type {
@@ -96,21 +96,30 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
   public async fetchTxPoll(
     txHash: string,
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    abortSignal?: AbortSignal,
   ): Promise<TxResponse> {
     const deadline = Date.now() + timeout
 
     for (let start = Date.now(); start < deadline; start = Date.now()) {
+      this.throwIfTxPollingCancelled(abortSignal)
+
       try {
-        const tx = await this.fetchTxDual(txHash, deadline)
+        const tx = await this.fetchTxDual(txHash, deadline, abortSignal)
+
+        this.throwIfTxPollingCancelled(abortSignal)
 
         if (tx) {
           return tx
         }
       } catch (e: unknown) {
+        this.throwIfTxPollingCancelled(abortSignal)
+
         if (e instanceof TransactionException) {
           throw e
         }
       }
+
+      this.throwIfTxPollingCancelled(abortSignal)
 
       const gap = DEFAULT_TX_POLL_INTERVAL_MS - (Date.now() - start)
 
@@ -154,122 +163,31 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
     options?: TxClientInclusionOptions,
   ): Promise<TxInclusionWaiter> {
-    const inclusionStrategy = options?.inclusionStrategy
-
-    if (!this.isTendermintEventStrategy(inclusionStrategy)) {
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-
-    const eventOptions = options?.eventInclusion
-    const rpcEndpoint = eventOptions?.rpcEndpoint
-    const fallbackToPolling = eventOptions?.fallbackToPolling !== false
-
-    if (!rpcEndpoint) {
-      const error = new Error(
-        'Tendermint RPC endpoint is required for event inclusion',
-      )
-
-      if (!fallbackToPolling) {
-        throw new GrpcUnaryRequestException(error, {
-          context: 'TxGrpcApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      eventOptions?.onFallback?.(error)
-
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-
-    try {
-      const subscription = await subscribeToTendermintTxEvent({
-        txHash,
-        endpoint: rpcEndpoint,
-        timeout: eventOptions?.timeout || timeout,
-        webSocketFactory: eventOptions?.webSocketFactory,
-      })
-
-      return {
-        txHash,
-        inclusionStrategy,
-        close: subscription.close,
-        wait: async (includedTxHash = txHash) => {
-          if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
-            subscription.close()
-            eventOptions?.onFallback?.(
-              new Error(
-                `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
-              ),
-            )
-            return this.fetchTxPoll(includedTxHash, timeout)
-          }
-
-          if (
-            inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
-          ) {
-            return this.waitForSubscribedTxInclusionAndPoll(
-              txHash,
-              timeout,
-              subscription,
-              options,
-            )
-          }
-
-          return this.waitForSubscribedTxInclusion(
-            txHash,
-            timeout,
-            subscription,
-            options,
-          )
-        },
-      }
-    } catch (e: unknown) {
-      if (e instanceof TransactionException) {
-        throw e
-      }
-
-      const error = e instanceof Error ? e : new Error(String(e))
-
-      if (!fallbackToPolling) {
-        throw new GrpcUnaryRequestException(error, {
-          context: 'TxGrpcApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      eventOptions?.onFallback?.(error)
-
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-  }
-
-  private isTendermintEventStrategy(inclusionStrategy?: TxInclusionStrategy) {
-    return (
-      inclusionStrategy === TxInclusionStrategy.TendermintEvent ||
-      inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
-    )
-  }
-
-  private createPollingInclusionWaiter(
-    txHash: string,
-    timeout: number,
-  ): TxInclusionWaiter {
-    return {
+    return prepareTxInclusionWaiter({
       txHash,
-      inclusionStrategy: TxInclusionStrategy.Poll,
-      close: () => {},
-      wait: (includedTxHash = txHash) =>
-        this.fetchTxPoll(includedTxHash, timeout),
-    }
+      timeout,
+      options,
+      fetchTx: (includedTxHash) => this.fetchTx(includedTxHash),
+      fetchTxPoll: (includedTxHash, pollTimeout, abortSignal) =>
+        this.fetchTxPoll(includedTxHash, pollTimeout, abortSignal),
+      createRequestException: (error, contextModule) =>
+        new GrpcUnaryRequestException(error, {
+          context: 'TxGrpcApi',
+          contextModule,
+        }),
+    })
   }
 
   private async safeFetchTx(
     txHash: string,
     delay?: number,
+    abortSignal?: AbortSignal,
   ): Promise<TxResponse | null> {
     if (delay) {
       await sleep(delay)
     }
+
+    this.throwIfTxPollingCancelled(abortSignal)
 
     return this.fetchTx(txHash).catch((e: unknown) => {
       if (e instanceof TransactionException) {
@@ -283,6 +201,7 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
   private fetchTxDual(
     txHash: string,
     deadline: number,
+    abortSignal?: AbortSignal,
   ): Promise<TxResponse | null> {
     const STAGGER = 300
     const timeout = Math.max(
@@ -291,8 +210,8 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
     )
 
     const fetches = Promise.all([
-      this.safeFetchTx(txHash),
-      this.safeFetchTx(txHash, STAGGER),
+      this.safeFetchTx(txHash, undefined, abortSignal),
+      this.safeFetchTx(txHash, STAGGER, abortSignal),
     ]).then(([a, b]) => a ?? b)
 
     fetches.catch(() => {})
@@ -301,6 +220,14 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
       fetches,
       sleep(timeout).then(() => null as TxResponse | null),
     ])
+  }
+
+  private throwIfTxPollingCancelled(abortSignal?: AbortSignal) {
+    if (!abortSignal?.aborted) {
+      return
+    }
+
+    throw new Error('Transaction inclusion polling was cancelled')
   }
 
   public async simulate(txRaw: CosmosTxV1Beta1TxPb.TxRaw) {
@@ -426,135 +353,6 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
 
       throw new TransactionException(new Error(e as any))
     }
-  }
-
-  private async waitForSubscribedTxInclusion(
-    txHash: string,
-    timeout: number,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-    options?: TxClientInclusionOptions,
-  ): Promise<TxResponse> {
-    const fallbackToPolling =
-      options?.eventInclusion?.fallbackToPolling !== false
-
-    try {
-      return await this.waitForSubscribedTxEvent(txHash, subscription)
-    } catch (e: unknown) {
-      if (e instanceof TransactionException) {
-        throw e
-      }
-
-      const error = e instanceof Error ? e : new Error(String(e))
-
-      if (!fallbackToPolling) {
-        throw new GrpcUnaryRequestException(error, {
-          context: 'TxGrpcApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      options?.eventInclusion?.onFallback?.(error)
-
-      return this.fetchTxPoll(txHash, timeout)
-    }
-  }
-
-  private async waitForSubscribedTxInclusionAndPoll(
-    txHash: string,
-    timeout: number,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-    options?: TxClientInclusionOptions,
-  ): Promise<TxResponse> {
-    return new Promise<TxResponse>((resolve, reject) => {
-      let settled = false
-      let finishedCount = 0
-      let eventError: Error | undefined
-      let pollError: Error | undefined
-
-      const rejectIfBothFailed = () => {
-        if (finishedCount < 2 || settled) {
-          return
-        }
-
-        reject(pollError || eventError || new Error('Tx inclusion failed'))
-      }
-
-      const resolveOnce = (
-        txResponse: TxResponse,
-        source: 'event' | 'poll',
-      ) => {
-        if (settled) {
-          return
-        }
-
-        settled = true
-
-        if (source === 'poll') {
-          subscription.close()
-        }
-
-        resolve(txResponse)
-      }
-
-      const rejectTerminal = (error: unknown) => {
-        if (settled) {
-          return true
-        }
-
-        if (error instanceof TransactionException) {
-          settled = true
-          subscription.close()
-          reject(error)
-
-          return true
-        }
-
-        return false
-      }
-
-      this.waitForSubscribedTxEvent(txHash, subscription)
-        .then((txResponse) => resolveOnce(txResponse, 'event'))
-        .catch((error: unknown) => {
-          if (rejectTerminal(error)) {
-            return
-          }
-
-          const fallbackError =
-            error instanceof Error ? error : new Error(String(error))
-          eventError = fallbackError
-          finishedCount += 1
-          options?.eventInclusion?.onFallback?.(fallbackError)
-          rejectIfBothFailed()
-        })
-
-      this.fetchTxPoll(txHash, timeout)
-        .then((txResponse) => resolveOnce(txResponse, 'poll'))
-        .catch((error: unknown) => {
-          if (rejectTerminal(error)) {
-            return
-          }
-
-          pollError = error instanceof Error ? error : new Error(String(error))
-          finishedCount += 1
-          rejectIfBothFailed()
-        })
-    })
-  }
-
-  private async waitForSubscribedTxEvent(
-    txHash: string,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-  ): Promise<TxResponse> {
-    const eventTx = await subscription.wait()
-
-    if (eventTx.code !== 0) {
-      throw new TransactionException(new Error(eventTx.rawLog), {
-        contextCode: eventTx.code,
-        contextModule: eventTx.codespace,
-      })
-    }
-
-    return this.fetchTx(txHash)
   }
 
   /** @deprecated - the BLOCK mode broadcasting is deprecated now, use either sync or async */

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
@@ -23,6 +23,7 @@ import type { TxResponse } from '../types/tx.js'
 import type {
   TxConcreteApi,
   TxInclusionWaiter,
+  TxFetchTxPollArgs,
   TxClientBroadcastOptions,
   TxClientInclusionOptions,
   TxClientBroadcastResponse,
@@ -93,11 +94,11 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
     }
   }
 
-  public async fetchTxPoll(
-    txHash: string,
+  public async fetchTxPoll({
+    txHash,
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
-    abortSignal?: AbortSignal,
-  ): Promise<TxResponse> {
+    abortSignal,
+  }: TxFetchTxPollArgs): Promise<TxResponse> {
     const deadline = Date.now() + timeout
 
     for (let start = Date.now(); start < deadline; start = Date.now()) {
@@ -168,8 +169,7 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
       timeout,
       options,
       fetchTx: (includedTxHash) => this.fetchTx(includedTxHash),
-      fetchTxPoll: (includedTxHash, pollTimeout, abortSignal) =>
-        this.fetchTxPoll(includedTxHash, pollTimeout, abortSignal),
+      fetchTxPoll: (args) => this.fetchTxPoll(args),
       createRequestException: (error, contextModule) =>
         new GrpcUnaryRequestException(error, {
           context: 'TxGrpcApi',

--- a/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxGrpcApi.ts
@@ -15,11 +15,16 @@ import {
   DEFAULT_TX_POLL_CALL_TIMEOUT_MS,
   DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
 } from '@injectivelabs/utils'
+import { TxInclusionStrategy } from '../types/tx.js'
+import { TxClient } from '../utils/classes/TxClient.js'
+import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
 import BaseGrpcConsumer from '../../../client/base/BaseGrpcConsumer.js'
 import type { TxResponse } from '../types/tx.js'
 import type {
   TxConcreteApi,
+  TxInclusionWaiter,
   TxClientBroadcastOptions,
+  TxClientInclusionOptions,
   TxClientBroadcastResponse,
 } from '../types/tx.js'
 
@@ -122,6 +127,142 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
     )
   }
 
+  public async waitForTxInclusion(
+    txHash: string,
+    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    const waiter = await this.prepareTxInclusionWait(txHash, timeout, options)
+
+    const txResponse = await waiter.wait()
+
+    if (!txResponse) {
+      throw new GrpcUnaryRequestException(
+        new Error(`The transaction with ${txHash} is not found`),
+        {
+          context: 'TxGrpcApi',
+          contextModule: 'wait-for-tx-inclusion',
+        },
+      )
+    }
+
+    return txResponse
+  }
+
+  public async prepareTxInclusionWait(
+    txHash: string,
+    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxInclusionWaiter> {
+    const inclusionStrategy = options?.inclusionStrategy
+
+    if (!this.isTendermintEventStrategy(inclusionStrategy)) {
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+
+    const eventOptions = options?.eventInclusion
+    const rpcEndpoint = eventOptions?.rpcEndpoint
+    const fallbackToPolling = eventOptions?.fallbackToPolling !== false
+
+    if (!rpcEndpoint) {
+      const error = new Error(
+        'Tendermint RPC endpoint is required for event inclusion',
+      )
+
+      if (!fallbackToPolling) {
+        throw new GrpcUnaryRequestException(error, {
+          context: 'TxGrpcApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      eventOptions?.onFallback?.(error)
+
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+
+    try {
+      const subscription = await subscribeToTendermintTxEvent({
+        txHash,
+        endpoint: rpcEndpoint,
+        timeout: eventOptions?.timeout || timeout,
+        webSocketFactory: eventOptions?.webSocketFactory,
+      })
+
+      return {
+        txHash,
+        inclusionStrategy,
+        close: subscription.close,
+        wait: async (includedTxHash = txHash) => {
+          if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
+            subscription.close()
+            eventOptions?.onFallback?.(
+              new Error(
+                `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
+              ),
+            )
+            return this.fetchTxPoll(includedTxHash, timeout)
+          }
+
+          if (
+            inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
+          ) {
+            return this.waitForSubscribedTxInclusionAndPoll(
+              txHash,
+              timeout,
+              subscription,
+              options,
+            )
+          }
+
+          return this.waitForSubscribedTxInclusion(
+            txHash,
+            timeout,
+            subscription,
+            options,
+          )
+        },
+      }
+    } catch (e: unknown) {
+      if (e instanceof TransactionException) {
+        throw e
+      }
+
+      const error = e instanceof Error ? e : new Error(String(e))
+
+      if (!fallbackToPolling) {
+        throw new GrpcUnaryRequestException(error, {
+          context: 'TxGrpcApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      eventOptions?.onFallback?.(error)
+
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+  }
+
+  private isTendermintEventStrategy(inclusionStrategy?: TxInclusionStrategy) {
+    return (
+      inclusionStrategy === TxInclusionStrategy.TendermintEvent ||
+      inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
+    )
+  }
+
+  private createPollingInclusionWaiter(
+    txHash: string,
+    timeout: number,
+  ): TxInclusionWaiter {
+    return {
+      txHash,
+      inclusionStrategy: TxInclusionStrategy.Poll,
+      close: () => {},
+      wait: (includedTxHash = txHash) =>
+        this.fetchTxPoll(includedTxHash, timeout),
+    }
+  }
+
   private async safeFetchTx(
     txHash: string,
     delay?: number,
@@ -206,19 +347,31 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
     txRaw: CosmosTxV1Beta1TxPb.TxRaw,
     options?: TxClientBroadcastOptions,
   ): Promise<TxResponse> {
-    const mode = options?.mode || CosmosTxV1Beta1ServicePb.BroadcastMode.SYNC
     const timeout =
       options?.timeout ||
       toBigNumber(options?.txTimeout || DEFAULT_BLOCK_TIMEOUT_HEIGHT)
         .times(DEFAULT_BLOCK_TIME_IN_SECONDS * 1000)
         .toNumber()
-
-    const broadcastTxRequest =
-      CosmosTxV1Beta1ServicePb.BroadcastTxRequest.create()
-    broadcastTxRequest.txBytes = CosmosTxV1Beta1TxPb.TxRaw.toBinary(txRaw)
-    broadcastTxRequest.mode = mode as CosmosTxV1Beta1ServicePb.BroadcastMode
+    const txHash = TxClient.hash(txRaw)
+    let inclusionWaiter: TxInclusionWaiter | undefined
 
     try {
+      inclusionWaiter = await this.prepareTxInclusionWait(
+        txHash,
+        timeout,
+        options,
+      )
+
+      const mode =
+        options?.mode ||
+        (inclusionWaiter.inclusionStrategy !== TxInclusionStrategy.Poll
+          ? CosmosTxV1Beta1ServicePb.BroadcastMode.ASYNC
+          : CosmosTxV1Beta1ServicePb.BroadcastMode.SYNC)
+      const broadcastTxRequest =
+        CosmosTxV1Beta1ServicePb.BroadcastTxRequest.create()
+      broadcastTxRequest.txBytes = CosmosTxV1Beta1TxPb.TxRaw.toBinary(txRaw)
+      broadcastTxRequest.mode = mode as CosmosTxV1Beta1ServicePb.BroadcastMode
+
       const response = await this.executeGrpcCall<
         CosmosTxV1Beta1ServicePb.BroadcastTxRequest,
         CosmosTxV1Beta1ServicePb.BroadcastTxResponse
@@ -247,10 +400,22 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
         options.onBroadcast(txResponse.txhash)
       }
 
-      const result = await this.fetchTxPoll(txResponse.txhash, timeout)
+      const result = await inclusionWaiter.wait(txResponse.txhash)
+
+      if (!result) {
+        throw new GrpcUnaryRequestException(
+          new Error(`The transaction with ${txResponse.txhash} is not found`),
+          {
+            context: 'TxGrpcApi.broadcast',
+            contextModule: 'wait-for-tx-inclusion',
+          },
+        )
+      }
 
       return result
     } catch (e: unknown) {
+      inclusionWaiter?.close()
+
       if (e instanceof TransactionException) {
         throw e
       }
@@ -261,6 +426,135 @@ export class TxGrpcApi extends BaseGrpcConsumer implements TxConcreteApi {
 
       throw new TransactionException(new Error(e as any))
     }
+  }
+
+  private async waitForSubscribedTxInclusion(
+    txHash: string,
+    timeout: number,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    const fallbackToPolling =
+      options?.eventInclusion?.fallbackToPolling !== false
+
+    try {
+      return await this.waitForSubscribedTxEvent(txHash, subscription)
+    } catch (e: unknown) {
+      if (e instanceof TransactionException) {
+        throw e
+      }
+
+      const error = e instanceof Error ? e : new Error(String(e))
+
+      if (!fallbackToPolling) {
+        throw new GrpcUnaryRequestException(error, {
+          context: 'TxGrpcApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      options?.eventInclusion?.onFallback?.(error)
+
+      return this.fetchTxPoll(txHash, timeout)
+    }
+  }
+
+  private async waitForSubscribedTxInclusionAndPoll(
+    txHash: string,
+    timeout: number,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    return new Promise<TxResponse>((resolve, reject) => {
+      let settled = false
+      let finishedCount = 0
+      let eventError: Error | undefined
+      let pollError: Error | undefined
+
+      const rejectIfBothFailed = () => {
+        if (finishedCount < 2 || settled) {
+          return
+        }
+
+        reject(pollError || eventError || new Error('Tx inclusion failed'))
+      }
+
+      const resolveOnce = (
+        txResponse: TxResponse,
+        source: 'event' | 'poll',
+      ) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+
+        if (source === 'poll') {
+          subscription.close()
+        }
+
+        resolve(txResponse)
+      }
+
+      const rejectTerminal = (error: unknown) => {
+        if (settled) {
+          return true
+        }
+
+        if (error instanceof TransactionException) {
+          settled = true
+          subscription.close()
+          reject(error)
+
+          return true
+        }
+
+        return false
+      }
+
+      this.waitForSubscribedTxEvent(txHash, subscription)
+        .then((txResponse) => resolveOnce(txResponse, 'event'))
+        .catch((error: unknown) => {
+          if (rejectTerminal(error)) {
+            return
+          }
+
+          const fallbackError =
+            error instanceof Error ? error : new Error(String(error))
+          eventError = fallbackError
+          finishedCount += 1
+          options?.eventInclusion?.onFallback?.(fallbackError)
+          rejectIfBothFailed()
+        })
+
+      this.fetchTxPoll(txHash, timeout)
+        .then((txResponse) => resolveOnce(txResponse, 'poll'))
+        .catch((error: unknown) => {
+          if (rejectTerminal(error)) {
+            return
+          }
+
+          pollError = error instanceof Error ? error : new Error(String(error))
+          finishedCount += 1
+          rejectIfBothFailed()
+        })
+    })
+  }
+
+  private async waitForSubscribedTxEvent(
+    txHash: string,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+  ): Promise<TxResponse> {
+    const eventTx = await subscription.wait()
+
+    if (eventTx.code !== 0) {
+      throw new TransactionException(new Error(eventTx.rawLog), {
+        contextCode: eventTx.code,
+        contextModule: eventTx.codespace,
+      })
+    }
+
+    return this.fetchTx(txHash)
   }
 
   /** @deprecated - the BLOCK mode broadcasting is deprecated now, use either sync or async */

--- a/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
@@ -1,0 +1,285 @@
+import { TransactionException } from '@injectivelabs/exceptions'
+import { TxInclusionStrategy } from '../types/tx.js'
+import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
+import type { TxResponse } from '../types/tx.js'
+import type {
+  TxInclusionWaiter,
+  TxClientInclusionOptions,
+} from '../types/tx.js'
+
+type TxInclusionRequestExceptionFactory = (
+  error: Error,
+  contextModule: string,
+) => Error
+
+interface PrepareTxInclusionWaiterArgs {
+  txHash: string
+  timeout: number
+  options?: TxClientInclusionOptions
+  fetchTx: (txHash: string) => Promise<TxResponse>
+  fetchTxPoll: (
+    txHash: string,
+    timeout: number,
+    abortSignal?: AbortSignal,
+  ) => Promise<TxResponse>
+  createRequestException: TxInclusionRequestExceptionFactory
+}
+
+export function isTendermintEventStrategy(
+  inclusionStrategy?: TxInclusionStrategy,
+) {
+  return (
+    inclusionStrategy === TxInclusionStrategy.TendermintEvent ||
+    inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
+  )
+}
+
+export async function prepareTxInclusionWaiter({
+  txHash,
+  timeout,
+  options,
+  fetchTx,
+  fetchTxPoll,
+  createRequestException,
+}: PrepareTxInclusionWaiterArgs): Promise<TxInclusionWaiter> {
+  const inclusionStrategy = options?.inclusionStrategy
+
+  if (!isTendermintEventStrategy(inclusionStrategy)) {
+    return createPollingInclusionWaiter({ txHash, timeout, fetchTxPoll })
+  }
+
+  const eventOptions = options?.eventInclusion
+  const rpcEndpoint = eventOptions?.rpcEndpoint
+  const fallbackToPolling = eventOptions?.fallbackToPolling !== false
+
+  if (!rpcEndpoint) {
+    const error = new Error(
+      'Tendermint RPC endpoint is required for event inclusion',
+    )
+
+    if (!fallbackToPolling) {
+      throw createRequestException(error, 'event-inclusion')
+    }
+
+    eventOptions?.onFallback?.(error)
+
+    return createPollingInclusionWaiter({ txHash, timeout, fetchTxPoll })
+  }
+
+  try {
+    const subscription = await subscribeToTendermintTxEvent({
+      txHash,
+      endpoint: rpcEndpoint,
+      timeout: eventOptions?.timeout || timeout,
+      webSocketFactory: eventOptions?.webSocketFactory,
+    })
+
+    return {
+      txHash,
+      inclusionStrategy,
+      close: subscription.close,
+      wait: async (includedTxHash = txHash) => {
+        if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
+          subscription.close()
+          eventOptions?.onFallback?.(
+            new Error(
+              `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
+            ),
+          )
+
+          return fetchTxPoll(includedTxHash, timeout)
+        }
+
+        if (inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll) {
+          return waitForSubscribedTxInclusionAndPoll({
+            txHash,
+            timeout,
+            subscription,
+            options,
+            fetchTx,
+            fetchTxPoll,
+          })
+        }
+
+        return waitForSubscribedTxInclusion({
+          txHash,
+          timeout,
+          subscription,
+          options,
+          fetchTx,
+          fetchTxPoll,
+          createRequestException,
+        })
+      },
+    }
+  } catch (e: unknown) {
+    if (e instanceof TransactionException) {
+      throw e
+    }
+
+    const error = e instanceof Error ? e : new Error(String(e))
+
+    if (!fallbackToPolling) {
+      throw createRequestException(error, 'event-inclusion')
+    }
+
+    eventOptions?.onFallback?.(error)
+
+    return createPollingInclusionWaiter({ txHash, timeout, fetchTxPoll })
+  }
+}
+
+function createPollingInclusionWaiter({
+  txHash,
+  timeout,
+  fetchTxPoll,
+}: Pick<
+  PrepareTxInclusionWaiterArgs,
+  'txHash' | 'timeout' | 'fetchTxPoll'
+>): TxInclusionWaiter {
+  return {
+    txHash,
+    inclusionStrategy: TxInclusionStrategy.Poll,
+    close: () => {},
+    wait: (includedTxHash = txHash) => fetchTxPoll(includedTxHash, timeout),
+  }
+}
+
+async function waitForSubscribedTxInclusion({
+  txHash,
+  timeout,
+  subscription,
+  options,
+  fetchTx,
+  fetchTxPoll,
+  createRequestException,
+}: PrepareTxInclusionWaiterArgs & {
+  subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
+}): Promise<TxResponse> {
+  const fallbackToPolling = options?.eventInclusion?.fallbackToPolling !== false
+
+  try {
+    return await waitForSubscribedTxEvent({ txHash, subscription, fetchTx })
+  } catch (e: unknown) {
+    if (e instanceof TransactionException) {
+      throw e
+    }
+
+    const error = e instanceof Error ? e : new Error(String(e))
+
+    if (!fallbackToPolling) {
+      throw createRequestException(error, 'event-inclusion')
+    }
+
+    options?.eventInclusion?.onFallback?.(error)
+
+    return fetchTxPoll(txHash, timeout)
+  }
+}
+
+async function waitForSubscribedTxInclusionAndPoll({
+  txHash,
+  timeout,
+  subscription,
+  options,
+  fetchTx,
+  fetchTxPoll,
+}: Omit<PrepareTxInclusionWaiterArgs, 'createRequestException'> & {
+  subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
+}): Promise<TxResponse> {
+  const pollAbortController = new AbortController()
+
+  return new Promise<TxResponse>((resolve, reject) => {
+    let settled = false
+    let finishedCount = 0
+    let eventError: Error | undefined
+    let pollError: Error | undefined
+
+    const rejectIfBothFailed = () => {
+      if (finishedCount < 2 || settled) {
+        return
+      }
+
+      reject(pollError || eventError || new Error('Tx inclusion failed'))
+    }
+
+    const resolveOnce = (txResponse: TxResponse, source: 'event' | 'poll') => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+
+      if (source === 'poll') {
+        subscription.close()
+      } else {
+        pollAbortController.abort()
+      }
+
+      resolve(txResponse)
+    }
+
+    const rejectTerminal = (error: unknown) => {
+      if (settled) {
+        return true
+      }
+
+      if (error instanceof TransactionException) {
+        settled = true
+        subscription.close()
+        pollAbortController.abort()
+        reject(error)
+
+        return true
+      }
+
+      return false
+    }
+
+    waitForSubscribedTxEvent({ txHash, subscription, fetchTx })
+      .then((txResponse) => resolveOnce(txResponse, 'event'))
+      .catch((error: unknown) => {
+        if (rejectTerminal(error)) {
+          return
+        }
+
+        const fallbackError =
+          error instanceof Error ? error : new Error(String(error))
+        eventError = fallbackError
+        finishedCount += 1
+        options?.eventInclusion?.onFallback?.(fallbackError)
+        rejectIfBothFailed()
+      })
+
+    fetchTxPoll(txHash, timeout, pollAbortController.signal)
+      .then((txResponse) => resolveOnce(txResponse, 'poll'))
+      .catch((error: unknown) => {
+        if (rejectTerminal(error)) {
+          return
+        }
+
+        pollError = error instanceof Error ? error : new Error(String(error))
+        finishedCount += 1
+        rejectIfBothFailed()
+      })
+  })
+}
+
+async function waitForSubscribedTxEvent({
+  txHash,
+  subscription,
+  fetchTx,
+}: Pick<PrepareTxInclusionWaiterArgs, 'txHash' | 'fetchTx'> & {
+  subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
+}): Promise<TxResponse> {
+  const eventTx = await subscription.wait()
+
+  if (eventTx.code !== 0) {
+    throw new TransactionException(new Error(eventTx.rawLog), {
+      contextCode: eventTx.code,
+      contextModule: eventTx.codespace,
+    })
+  }
+
+  return fetchTx(txHash)
+}

--- a/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
@@ -4,29 +4,8 @@ import {
 } from '@injectivelabs/exceptions'
 import { TxInclusionStrategy } from '../types/tx.js'
 import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
-import type { TxResponse } from '../types/tx.js'
-import type {
-  TxInclusionWaiter,
-  TxClientInclusionOptions,
-} from '../types/tx.js'
-
-type TxInclusionRequestExceptionFactory = (
-  error: Error,
-  contextModule: string,
-) => Error
-
-interface PrepareTxInclusionWaiterArgs {
-  txHash: string
-  timeout: number
-  options?: TxClientInclusionOptions
-  fetchTx: (txHash: string) => Promise<TxResponse>
-  fetchTxPoll: (
-    txHash: string,
-    timeout: number,
-    abortSignal?: AbortSignal,
-  ) => Promise<TxResponse>
-  createRequestException: TxInclusionRequestExceptionFactory
-}
+import type { PrepareTxInclusionWaiterArgs } from './types.js'
+import type { TxResponse, TxInclusionWaiter } from '../types/tx.js'
 
 export function isTendermintEventStrategy(
   inclusionStrategy?: TxInclusionStrategy,
@@ -77,10 +56,16 @@ export async function prepareTxInclusionWaiter({
       webSocketFactory: eventOptions?.webSocketFactory,
     })
 
+    const hashMismatchPollAbortController = new AbortController()
+    const close = () => {
+      hashMismatchPollAbortController.abort()
+      subscription.close()
+    }
+
     return {
       txHash,
       inclusionStrategy,
-      close: subscription.close,
+      close,
       wait: async (includedTxHash = txHash) => {
         if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
           subscription.close()
@@ -92,26 +77,30 @@ export async function prepareTxInclusionWaiter({
             ),
           )
 
-          return fetchTxPoll(includedTxHash, timeout)
+          return fetchTxPoll({
+            txHash: includedTxHash,
+            timeout,
+            abortSignal: hashMismatchPollAbortController.signal,
+          })
         }
 
         if (inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll) {
           return waitForSubscribedTxInclusionAndPoll({
             txHash,
             timeout,
-            subscription,
-            options,
             fetchTx,
+            options,
             fetchTxPoll,
+            subscription,
           })
         }
 
         return waitForSubscribedTxInclusion({
           txHash,
           timeout,
-          subscription,
           options,
           fetchTx,
+          subscription,
           fetchTxPoll,
           createRequestException,
         })
@@ -142,21 +131,30 @@ function createPollingInclusionWaiter({
   PrepareTxInclusionWaiterArgs,
   'txHash' | 'timeout' | 'fetchTxPoll'
 >): TxInclusionWaiter {
+  const pollAbortController = new AbortController()
+
   return {
     txHash,
     inclusionStrategy: TxInclusionStrategy.Poll,
-    close: () => {},
-    wait: (includedTxHash = txHash) => fetchTxPoll(includedTxHash, timeout),
+    close: () => {
+      pollAbortController.abort()
+    },
+    wait: (includedTxHash = txHash) =>
+      fetchTxPoll({
+        txHash: includedTxHash,
+        timeout,
+        abortSignal: pollAbortController.signal,
+      }),
   }
 }
 
 async function waitForSubscribedTxInclusion({
   txHash,
   timeout,
-  subscription,
   options,
   fetchTx,
   fetchTxPoll,
+  subscription,
   createRequestException,
 }: PrepareTxInclusionWaiterArgs & {
   subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
@@ -181,17 +179,17 @@ async function waitForSubscribedTxInclusion({
 
     options?.eventInclusion?.onFallback?.(error)
 
-    return fetchTxPoll(txHash, timeout)
+    return fetchTxPoll({ txHash, timeout })
   }
 }
 
 async function waitForSubscribedTxInclusionAndPoll({
   txHash,
   timeout,
-  subscription,
   options,
   fetchTx,
   fetchTxPoll,
+  subscription,
 }: Omit<PrepareTxInclusionWaiterArgs, 'createRequestException'> & {
   subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
 }): Promise<TxResponse> {
@@ -200,6 +198,7 @@ async function waitForSubscribedTxInclusionAndPoll({
   return new Promise<TxResponse>((resolve, reject) => {
     let settled = false
     let finishedCount = 0
+
     let eventError: Error | undefined
     let pollError: Error | undefined
 
@@ -224,10 +223,12 @@ async function waitForSubscribedTxInclusionAndPoll({
 
       if (source === 'poll') {
         subscription.close()
-      } else {
-        pollAbortController.abort()
+        resolve(txResponse)
+
+        return
       }
 
+      pollAbortController.abort()
       resolve(txResponse)
     }
 
@@ -263,7 +264,11 @@ async function waitForSubscribedTxInclusionAndPoll({
         rejectIfBothFailed()
       })
 
-    fetchTxPoll(txHash, timeout, pollAbortController.signal)
+    fetchTxPoll({
+      txHash,
+      timeout,
+      abortSignal: pollAbortController.signal,
+    })
       .then((txResponse) => resolveOnce(txResponse, 'poll'))
       .catch((error: unknown) => {
         if (rejectTerminal(error)) {
@@ -279,8 +284,8 @@ async function waitForSubscribedTxInclusionAndPoll({
 
 async function waitForSubscribedTxEvent({
   txHash,
-  subscription,
   fetchTx,
+  subscription,
 }: Pick<PrepareTxInclusionWaiterArgs, 'txHash' | 'fetchTx'> & {
   subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>
 }): Promise<TxResponse> {

--- a/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxInclusion.ts
@@ -1,4 +1,7 @@
-import { TransactionException } from '@injectivelabs/exceptions'
+import {
+  GeneralException,
+  TransactionException,
+} from '@injectivelabs/exceptions'
 import { TxInclusionStrategy } from '../types/tx.js'
 import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
 import type { TxResponse } from '../types/tx.js'
@@ -53,8 +56,8 @@ export async function prepareTxInclusionWaiter({
   const fallbackToPolling = eventOptions?.fallbackToPolling !== false
 
   if (!rpcEndpoint) {
-    const error = new Error(
-      'Tendermint RPC endpoint is required for event inclusion',
+    const error = new GeneralException(
+      new Error('Tendermint RPC endpoint is required for event inclusion'),
     )
 
     if (!fallbackToPolling) {
@@ -82,8 +85,10 @@ export async function prepareTxInclusionWaiter({
         if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
           subscription.close()
           eventOptions?.onFallback?.(
-            new Error(
-              `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
+            new GeneralException(
+              new Error(
+                `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
+              ),
             ),
           )
 
@@ -165,7 +170,10 @@ async function waitForSubscribedTxInclusion({
       throw e
     }
 
-    const error = e instanceof Error ? e : new Error(String(e))
+    const error =
+      e instanceof GeneralException
+        ? e
+        : new GeneralException(new Error(String(e)))
 
     if (!fallbackToPolling) {
       throw createRequestException(error, 'event-inclusion')
@@ -200,7 +208,11 @@ async function waitForSubscribedTxInclusionAndPoll({
         return
       }
 
-      reject(pollError || eventError || new Error('Tx inclusion failed'))
+      reject(
+        pollError ||
+          eventError ||
+          new GeneralException(new Error('Tx inclusion failed')),
+      )
     }
 
     const resolveOnce = (txResponse: TxResponse, source: 'event' | 'poll') => {

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
@@ -116,7 +116,10 @@ describe('TxRestApi.fetchTxPoll', () => {
     const txResponse = makeTxResponse('FOUND_FAST')
     vi.spyOn(txApi, 'fetchTx').mockResolvedValue(txResponse)
 
-    const result = await txApi.fetchTxPoll('FOUND_FAST', 5000)
+    const result = await txApi.fetchTxPoll({
+      txHash: 'FOUND_FAST',
+      timeout: 5000,
+    })
     expect(result.txHash).toBe('FOUND_FAST')
   })
 
@@ -135,7 +138,10 @@ describe('TxRestApi.fetchTxPoll', () => {
       return txResponse
     })
 
-    const result = await txApi.fetchTxPoll('FOUND_SLOW', 10000)
+    const result = await txApi.fetchTxPoll({
+      txHash: 'FOUND_SLOW',
+      timeout: 10000,
+    })
     expect(result.txHash).toBe('FOUND_SLOW')
   })
 
@@ -149,9 +155,9 @@ describe('TxRestApi.fetchTxPoll', () => {
 
     const timeout = 1500
     const start = Date.now()
-    await expect(txApi.fetchTxPoll('NEVER_FOUND', timeout)).rejects.toThrow(
-      HttpRequestException,
-    )
+    await expect(
+      txApi.fetchTxPoll({ txHash: 'NEVER_FOUND', timeout }),
+    ).rejects.toThrow(HttpRequestException)
     const elapsed = Date.now() - start
 
     expect(elapsed).toBeGreaterThanOrEqual(timeout - 100)
@@ -166,9 +172,9 @@ describe('TxRestApi.fetchTxPoll', () => {
 
     vi.spyOn(txApi, 'fetchTx').mockRejectedValue(txError)
 
-    await expect(txApi.fetchTxPoll('FAIL_TX', 5000)).rejects.toThrow(
-      TransactionException,
-    )
+    await expect(
+      txApi.fetchTxPoll({ txHash: 'FAIL_TX', timeout: 5000 }),
+    ).rejects.toThrow(TransactionException)
   })
 
   // Validates the Promise.race guard added in Step 2 — a hung REST call
@@ -184,9 +190,9 @@ describe('TxRestApi.fetchTxPoll', () => {
 
     const timeout = 2000
     const start = Date.now()
-    await expect(txApi.fetchTxPoll('HUNG_NODE', timeout)).rejects.toThrow(
-      HttpRequestException,
-    )
+    await expect(
+      txApi.fetchTxPoll({ txHash: 'HUNG_NODE', timeout }),
+    ).rejects.toThrow(HttpRequestException)
     const elapsed = Date.now() - start
 
     // Without the fix the loop overshoots by up to the HTTP timeout (15 000 ms).
@@ -284,11 +290,11 @@ describe('TxRestApi.broadcast event inclusion', () => {
     })
 
     expect(result.txHash).toBe(txHash)
-    expect(fetchTxPoll).toHaveBeenCalledWith(
+    expect(fetchTxPoll).toHaveBeenCalledWith({
       txHash,
-      expect.any(Number),
-      expect.any(Object),
-    )
+      timeout: expect.any(Number),
+      abortSignal: expect.any(Object),
+    })
     expect(fetchTx).not.toHaveBeenCalled()
     expect(socket.readyState).toBe(3)
   })

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
@@ -284,7 +284,11 @@ describe('TxRestApi.broadcast event inclusion', () => {
     })
 
     expect(result.txHash).toBe(txHash)
-    expect(fetchTxPoll).toHaveBeenCalledWith(txHash, expect.any(Number))
+    expect(fetchTxPoll).toHaveBeenCalledWith(
+      txHash,
+      expect.any(Number),
+      expect.any(Object),
+    )
     expect(fetchTx).not.toHaveBeenCalled()
     expect(socket.readyState).toBe(3)
   })

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.spec.ts
@@ -2,7 +2,11 @@ import {
   TransactionException,
   HttpRequestException,
 } from '@injectivelabs/exceptions'
+import * as CosmosTxV1Beta1TxPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/tx/v1beta1/tx_pb'
 import { TxRestApi } from './TxRestApi.js'
+import { TxInclusionStrategy } from '../types/tx.js'
+import { TxClient } from '../utils/classes/TxClient.js'
+import { BroadcastMode } from '../types/tx-rest-client.js'
 import type { TxResponse } from '../types/tx.js'
 
 // ---------------------------------------------------------------------------
@@ -28,6 +32,74 @@ const makeTxResponse = (txHash = 'ABC123'): TxResponse =>
   }) as unknown as TxResponse
 
 const delay = (ms: number) => new Promise<void>((res) => setTimeout(res, ms))
+
+class FakeWebSocket extends EventTarget {
+  public readyState = 0
+  public subscriptionReady = false
+
+  constructor() {
+    super()
+    queueMicrotask(() => {
+      this.readyState = 1
+      this.dispatchEvent(new Event('open'))
+    })
+  }
+
+  send(data: string) {
+    const request = JSON.parse(data)
+    queueMicrotask(() => {
+      this.subscriptionReady = true
+      this.dispatchEvent(
+        new MessageEvent('message', {
+          data: JSON.stringify({
+            id: request.id,
+            jsonrpc: '2.0',
+            result: {},
+          }),
+        }),
+      )
+    })
+  }
+
+  close() {
+    this.readyState = 3
+  }
+
+  emitTx(txHash: string) {
+    this.dispatchEvent(
+      new MessageEvent('message', {
+        data: JSON.stringify({
+          jsonrpc: '2.0',
+          params: {
+            result: {
+              data: {
+                events: {
+                  'tx.hash': [txHash],
+                },
+                value: {
+                  TxResult: {
+                    height: '123',
+                    result: {
+                      code: 0,
+                      log: '',
+                    },
+                  },
+                },
+              },
+            },
+          },
+        }),
+      }),
+    )
+  }
+}
+
+const makeTxRaw = () =>
+  CosmosTxV1Beta1TxPb.TxRaw.create({
+    bodyBytes: new Uint8Array([1]),
+    authInfoBytes: new Uint8Array([2]),
+    signatures: [new Uint8Array([3])],
+  })
 
 // ---------------------------------------------------------------------------
 // fetchTxPoll unit tests
@@ -120,5 +192,135 @@ describe('TxRestApi.fetchTxPoll', () => {
     // Without the fix the loop overshoots by up to the HTTP timeout (15 000 ms).
     // With the fix the overshoot is bounded to a small scheduling tolerance.
     expect(elapsed).toBeLessThan(timeout + 600)
+  })
+})
+
+describe('TxRestApi.broadcast event inclusion', () => {
+  let txApi: TxRestApi
+
+  beforeEach(() => {
+    txApi = new TxRestApi('https://lcd.injective.network')
+  })
+
+  it('subscribes before async broadcast and resolves inclusion from the tx event', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const socket = new FakeWebSocket()
+    const txResponse = makeTxResponse(txHash)
+    const fetchTxPoll = vi.spyOn(txApi, 'fetchTxPoll')
+    const fetchTx = vi.spyOn(txApi, 'fetchTx').mockResolvedValue(txResponse)
+
+    vi.spyOn(txApi as any, 'broadcastTx').mockImplementation(
+      async (_txRaw, mode) => {
+        expect(socket.subscriptionReady).toBe(true)
+        expect(mode).toBe(BroadcastMode.Async)
+
+        queueMicrotask(() => {
+          socket.emitTx(txHash)
+        })
+
+        return {
+          tx_response: {
+            txhash: txHash,
+            code: 0,
+            raw_log: '',
+            codespace: '',
+            height: '0',
+            gas_wanted: '0',
+            gas_used: '0',
+          },
+        }
+      },
+    )
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+      eventInclusion: {
+        rpcEndpoint: 'http://localhost:26657',
+        webSocketFactory: () => socket as unknown as WebSocket,
+      },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(fetchTx).toHaveBeenCalledWith(txHash)
+    expect(fetchTxPoll).not.toHaveBeenCalled()
+  })
+
+  it('returns polling result first when dual inclusion polling wins', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const socket = new FakeWebSocket()
+    const txResponse = makeTxResponse(txHash)
+    const fetchTx = vi.spyOn(txApi, 'fetchTx')
+    const fetchTxPoll = vi
+      .spyOn(txApi, 'fetchTxPoll')
+      .mockResolvedValue(txResponse)
+
+    vi.spyOn(txApi as any, 'broadcastTx').mockImplementation(
+      async (_txRaw, mode) => {
+        expect(socket.subscriptionReady).toBe(true)
+        expect(mode).toBe(BroadcastMode.Async)
+
+        return {
+          tx_response: {
+            txhash: txHash,
+            code: 0,
+            raw_log: '',
+            codespace: '',
+            height: '0',
+            gas_wanted: '0',
+            gas_used: '0',
+          },
+        }
+      },
+    )
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEventAndPoll,
+      eventInclusion: {
+        rpcEndpoint: 'http://localhost:26657',
+        webSocketFactory: () => socket as unknown as WebSocket,
+      },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(fetchTxPoll).toHaveBeenCalledWith(txHash, expect.any(Number))
+    expect(fetchTx).not.toHaveBeenCalled()
+    expect(socket.readyState).toBe(3)
+  })
+
+  it('falls back to sync polling when event inclusion has no rpc endpoint', async () => {
+    const txRaw = makeTxRaw()
+    const txHash = TxClient.hash(txRaw)
+    const onFallback = vi.fn()
+    const txResponse = makeTxResponse(txHash)
+
+    vi.spyOn(txApi as any, 'broadcastTx').mockImplementation(
+      async (_txRaw, mode) => {
+        expect(mode).toBe(BroadcastMode.Sync)
+
+        return {
+          tx_response: {
+            txhash: txHash,
+            code: 0,
+            raw_log: '',
+            codespace: '',
+            height: '0',
+            gas_wanted: '0',
+            gas_used: '0',
+          },
+        }
+      },
+    )
+
+    vi.spyOn(txApi, 'fetchTxPoll').mockResolvedValue(txResponse)
+
+    const result = await txApi.broadcast(txRaw, {
+      inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+      eventInclusion: { onFallback },
+    })
+
+    expect(result.txHash).toBe(txHash)
+    expect(onFallback).toHaveBeenCalledOnce()
   })
 })

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
@@ -32,6 +32,7 @@ import type {
 import type {
   TxConcreteApi,
   TxInclusionWaiter,
+  TxFetchTxPollArgs,
   TxClientBroadcastOptions,
   TxClientInclusionOptions,
 } from '../types/tx.js'
@@ -107,11 +108,11 @@ export class TxRestApi implements TxConcreteApi {
     }
   }
 
-  public async fetchTxPoll(
-    txHash: string,
+  public async fetchTxPoll({
+    txHash,
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
-    abortSignal?: AbortSignal,
-  ): Promise<TxResponse> {
+    abortSignal,
+  }: TxFetchTxPollArgs): Promise<TxResponse> {
     const deadline = Date.now() + timeout
 
     for (let start = Date.now(); start < deadline; start = Date.now()) {
@@ -200,8 +201,7 @@ export class TxRestApi implements TxConcreteApi {
       timeout,
       options,
       fetchTx: (includedTxHash) => this.fetchTx(includedTxHash),
-      fetchTxPoll: (includedTxHash, pollTimeout, abortSignal) =>
-        this.fetchTxPoll(includedTxHash, pollTimeout, abortSignal),
+      fetchTxPoll: (args) => this.fetchTxPoll(args),
       createRequestException: (error, contextModule) =>
         new HttpRequestException(error, {
           context: 'TxRestApi',

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
@@ -17,17 +17,24 @@ import {
   DEFAULT_TX_POLL_CALL_TIMEOUT_MS,
   DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
 } from '@injectivelabs/utils'
+import { TxInclusionStrategy } from '../types/tx.js'
 import { TxClient } from '../utils/classes/TxClient.js'
 import { BroadcastMode } from '../types/tx-rest-client.js'
 import { getErrorMessage } from '../../../utils/helpers.js'
+import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
 import type { AxiosError } from 'axios'
 import type { TxResponse } from '../types/tx.js'
-import type { TxConcreteApi, TxClientBroadcastOptions } from '../types/tx.js'
 import type {
   TxInfoResponse,
   TxResultResponse,
   SimulationResponse,
 } from '../types/tx-rest-client.js'
+import type {
+  TxConcreteApi,
+  TxInclusionWaiter,
+  TxClientBroadcastOptions,
+  TxClientInclusionOptions,
+} from '../types/tx.js'
 
 /**
  * It is recommended to use TxGrpcClient instead of TxRestApi
@@ -146,6 +153,142 @@ export class TxRestApi implements TxConcreteApi {
     )
   }
 
+  public async waitForTxInclusion(
+    txHash: string,
+    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    const waiter = await this.prepareTxInclusionWait(txHash, timeout, options)
+
+    const txResponse = await waiter.wait()
+
+    if (!txResponse) {
+      throw new HttpRequestException(
+        new Error(`The transaction with ${txHash} is not found`),
+        {
+          context: 'TxRestApi',
+          contextModule: 'wait-for-tx-inclusion',
+        },
+      )
+    }
+
+    return txResponse
+  }
+
+  public async prepareTxInclusionWait(
+    txHash: string,
+    timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxInclusionWaiter> {
+    const inclusionStrategy = options?.inclusionStrategy
+
+    if (!this.isTendermintEventStrategy(inclusionStrategy)) {
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+
+    const eventOptions = options?.eventInclusion
+    const rpcEndpoint = eventOptions?.rpcEndpoint
+    const fallbackToPolling = eventOptions?.fallbackToPolling !== false
+
+    if (!rpcEndpoint) {
+      const error = new Error(
+        'Tendermint RPC endpoint is required for event inclusion',
+      )
+
+      if (!fallbackToPolling) {
+        throw new HttpRequestException(error, {
+          context: 'TxRestApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      eventOptions?.onFallback?.(error)
+
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+
+    try {
+      const subscription = await subscribeToTendermintTxEvent({
+        txHash,
+        endpoint: rpcEndpoint,
+        timeout: eventOptions?.timeout || timeout,
+        webSocketFactory: eventOptions?.webSocketFactory,
+      })
+
+      return {
+        txHash,
+        inclusionStrategy,
+        close: subscription.close,
+        wait: async (includedTxHash = txHash) => {
+          if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
+            subscription.close()
+            eventOptions?.onFallback?.(
+              new Error(
+                `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
+              ),
+            )
+            return this.fetchTxPoll(includedTxHash, timeout)
+          }
+
+          if (
+            inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
+          ) {
+            return this.waitForSubscribedTxInclusionAndPoll(
+              txHash,
+              timeout,
+              subscription,
+              options,
+            )
+          }
+
+          return this.waitForSubscribedTxInclusion(
+            txHash,
+            timeout,
+            subscription,
+            options,
+          )
+        },
+      }
+    } catch (e: unknown) {
+      if (e instanceof TransactionException) {
+        throw e
+      }
+
+      const error = e instanceof Error ? e : new Error(String(e))
+
+      if (!fallbackToPolling) {
+        throw new HttpRequestException(error, {
+          context: 'TxRestApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      eventOptions?.onFallback?.(error)
+
+      return this.createPollingInclusionWaiter(txHash, timeout)
+    }
+  }
+
+  private isTendermintEventStrategy(inclusionStrategy?: TxInclusionStrategy) {
+    return (
+      inclusionStrategy === TxInclusionStrategy.TendermintEvent ||
+      inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
+    )
+  }
+
+  private createPollingInclusionWaiter(
+    txHash: string,
+    timeout: number,
+  ): TxInclusionWaiter {
+    return {
+      txHash,
+      inclusionStrategy: TxInclusionStrategy.Poll,
+      close: () => {},
+      wait: (includedTxHash = txHash) =>
+        this.fetchTxPoll(includedTxHash, timeout),
+    }
+  }
+
   public async simulate(txRaw: CosmosTxV1Beta1TxPb.TxRaw) {
     const txRawClone = CosmosTxV1Beta1TxPb.TxRaw.create({ ...txRaw })
 
@@ -186,11 +329,24 @@ export class TxRestApi implements TxConcreteApi {
       toBigNumber(options?.txTimeout || DEFAULT_BLOCK_TIMEOUT_HEIGHT)
         .times(DEFAULT_BLOCK_TIME_IN_SECONDS * 1000)
         .toNumber()
+    const txHash = TxClient.hash(txRaw)
+    let inclusionWaiter: TxInclusionWaiter | undefined
 
     try {
+      inclusionWaiter = await this.prepareTxInclusionWait(
+        txHash,
+        timeout,
+        options,
+      )
+
       const { tx_response: txResponse } = await this.broadcastTx<{
         tx_response: TxInfoResponse
-      }>(txRaw, BroadcastMode.Sync)
+      }>(
+        txRaw,
+        inclusionWaiter.inclusionStrategy !== TxInclusionStrategy.Poll
+          ? BroadcastMode.Async
+          : BroadcastMode.Sync,
+      )
 
       if (!txResponse) {
         throw new HttpRequestException(
@@ -213,8 +369,22 @@ export class TxRestApi implements TxConcreteApi {
         options.onBroadcast(txResponse.txhash)
       }
 
-      return await this.fetchTxPoll(txResponse.txhash, timeout)
+      const result = await inclusionWaiter.wait(txResponse.txhash)
+
+      if (!result) {
+        throw new HttpRequestException(
+          new Error(`The transaction with ${txResponse.txhash} is not found`),
+          {
+            context: 'TxRestApi.broadcast',
+            contextModule: 'wait-for-tx-inclusion',
+          },
+        )
+      }
+
+      return result
     } catch (e: unknown) {
+      inclusionWaiter?.close()
+
       if (e instanceof HttpRequestException) {
         if (e.code !== StatusCodes.OK) {
           throw e
@@ -223,6 +393,135 @@ export class TxRestApi implements TxConcreteApi {
 
       throw e
     }
+  }
+
+  private async waitForSubscribedTxInclusion(
+    txHash: string,
+    timeout: number,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    const fallbackToPolling =
+      options?.eventInclusion?.fallbackToPolling !== false
+
+    try {
+      return await this.waitForSubscribedTxEvent(txHash, subscription)
+    } catch (e: unknown) {
+      if (e instanceof TransactionException) {
+        throw e
+      }
+
+      const error = e instanceof Error ? e : new Error(String(e))
+
+      if (!fallbackToPolling) {
+        throw new HttpRequestException(error, {
+          context: 'TxRestApi',
+          contextModule: 'event-inclusion',
+        })
+      }
+
+      options?.eventInclusion?.onFallback?.(error)
+
+      return this.fetchTxPoll(txHash, timeout)
+    }
+  }
+
+  private async waitForSubscribedTxInclusionAndPoll(
+    txHash: string,
+    timeout: number,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxResponse> {
+    return new Promise<TxResponse>((resolve, reject) => {
+      let settled = false
+      let finishedCount = 0
+      let eventError: Error | undefined
+      let pollError: Error | undefined
+
+      const rejectIfBothFailed = () => {
+        if (finishedCount < 2 || settled) {
+          return
+        }
+
+        reject(pollError || eventError || new Error('Tx inclusion failed'))
+      }
+
+      const resolveOnce = (
+        txResponse: TxResponse,
+        source: 'event' | 'poll',
+      ) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+
+        if (source === 'poll') {
+          subscription.close()
+        }
+
+        resolve(txResponse)
+      }
+
+      const rejectTerminal = (error: unknown) => {
+        if (settled) {
+          return true
+        }
+
+        if (error instanceof TransactionException) {
+          settled = true
+          subscription.close()
+          reject(error)
+
+          return true
+        }
+
+        return false
+      }
+
+      this.waitForSubscribedTxEvent(txHash, subscription)
+        .then((txResponse) => resolveOnce(txResponse, 'event'))
+        .catch((error: unknown) => {
+          if (rejectTerminal(error)) {
+            return
+          }
+
+          const fallbackError =
+            error instanceof Error ? error : new Error(String(error))
+          eventError = fallbackError
+          finishedCount += 1
+          options?.eventInclusion?.onFallback?.(fallbackError)
+          rejectIfBothFailed()
+        })
+
+      this.fetchTxPoll(txHash, timeout)
+        .then((txResponse) => resolveOnce(txResponse, 'poll'))
+        .catch((error: unknown) => {
+          if (rejectTerminal(error)) {
+            return
+          }
+
+          pollError = error instanceof Error ? error : new Error(String(error))
+          finishedCount += 1
+          rejectIfBothFailed()
+        })
+    })
+  }
+
+  private async waitForSubscribedTxEvent(
+    txHash: string,
+    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
+  ): Promise<TxResponse> {
+    const eventTx = await subscription.wait()
+
+    if (eventTx.code !== 0) {
+      throw new TransactionException(new Error(eventTx.rawLog), {
+        contextCode: eventTx.code,
+        contextModule: eventTx.codespace,
+      })
+    }
+
+    return this.fetchTx(txHash)
   }
 
   /**

--- a/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
+++ b/packages/sdk-ts/src/core/tx/api/TxRestApi.ts
@@ -21,7 +21,7 @@ import { TxInclusionStrategy } from '../types/tx.js'
 import { TxClient } from '../utils/classes/TxClient.js'
 import { BroadcastMode } from '../types/tx-rest-client.js'
 import { getErrorMessage } from '../../../utils/helpers.js'
-import { subscribeToTendermintTxEvent } from './TxEventInclusion.js'
+import { prepareTxInclusionWaiter } from './TxInclusion.js'
 import type { AxiosError } from 'axios'
 import type { TxResponse } from '../types/tx.js'
 import type {
@@ -110,10 +110,13 @@ export class TxRestApi implements TxConcreteApi {
   public async fetchTxPoll(
     txHash: string,
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
+    abortSignal?: AbortSignal,
   ): Promise<TxResponse> {
     const deadline = Date.now() + timeout
 
     for (let start = Date.now(); start < deadline; start = Date.now()) {
+      this.throwIfTxPollingCancelled(abortSignal)
+
       const callTimeout = Math.max(
         0,
         Math.min(DEFAULT_TX_POLL_CALL_TIMEOUT_MS, deadline - Date.now()),
@@ -129,10 +132,14 @@ export class TxRestApi implements TxConcreteApi {
           return txResponse
         }
       } catch (e: unknown) {
+        this.throwIfTxPollingCancelled(abortSignal)
+
         if (e instanceof TransactionException) {
           throw e
         }
       }
+
+      this.throwIfTxPollingCancelled(abortSignal)
 
       const elapsed = Date.now() - start
       const remaining = DEFAULT_TX_POLL_INTERVAL_MS - elapsed
@@ -151,6 +158,14 @@ export class TxRestApi implements TxConcreteApi {
         contextModule: 'TxRestApi.fetch-tx-poll',
       },
     )
+  }
+
+  private throwIfTxPollingCancelled(abortSignal?: AbortSignal) {
+    if (!abortSignal?.aborted) {
+      return
+    }
+
+    throw new Error('Transaction inclusion polling was cancelled')
   }
 
   public async waitForTxInclusion(
@@ -180,113 +195,19 @@ export class TxRestApi implements TxConcreteApi {
     timeout = DEFAULT_TX_BLOCK_INCLUSION_TIMEOUT_IN_MS,
     options?: TxClientInclusionOptions,
   ): Promise<TxInclusionWaiter> {
-    const inclusionStrategy = options?.inclusionStrategy
-
-    if (!this.isTendermintEventStrategy(inclusionStrategy)) {
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-
-    const eventOptions = options?.eventInclusion
-    const rpcEndpoint = eventOptions?.rpcEndpoint
-    const fallbackToPolling = eventOptions?.fallbackToPolling !== false
-
-    if (!rpcEndpoint) {
-      const error = new Error(
-        'Tendermint RPC endpoint is required for event inclusion',
-      )
-
-      if (!fallbackToPolling) {
-        throw new HttpRequestException(error, {
-          context: 'TxRestApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      eventOptions?.onFallback?.(error)
-
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-
-    try {
-      const subscription = await subscribeToTendermintTxEvent({
-        txHash,
-        endpoint: rpcEndpoint,
-        timeout: eventOptions?.timeout || timeout,
-        webSocketFactory: eventOptions?.webSocketFactory,
-      })
-
-      return {
-        txHash,
-        inclusionStrategy,
-        close: subscription.close,
-        wait: async (includedTxHash = txHash) => {
-          if (includedTxHash.toUpperCase() !== txHash.toUpperCase()) {
-            subscription.close()
-            eventOptions?.onFallback?.(
-              new Error(
-                `Broadcast tx hash ${includedTxHash} did not match subscribed tx hash ${txHash}`,
-              ),
-            )
-            return this.fetchTxPoll(includedTxHash, timeout)
-          }
-
-          if (
-            inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
-          ) {
-            return this.waitForSubscribedTxInclusionAndPoll(
-              txHash,
-              timeout,
-              subscription,
-              options,
-            )
-          }
-
-          return this.waitForSubscribedTxInclusion(
-            txHash,
-            timeout,
-            subscription,
-            options,
-          )
-        },
-      }
-    } catch (e: unknown) {
-      if (e instanceof TransactionException) {
-        throw e
-      }
-
-      const error = e instanceof Error ? e : new Error(String(e))
-
-      if (!fallbackToPolling) {
-        throw new HttpRequestException(error, {
-          context: 'TxRestApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      eventOptions?.onFallback?.(error)
-
-      return this.createPollingInclusionWaiter(txHash, timeout)
-    }
-  }
-
-  private isTendermintEventStrategy(inclusionStrategy?: TxInclusionStrategy) {
-    return (
-      inclusionStrategy === TxInclusionStrategy.TendermintEvent ||
-      inclusionStrategy === TxInclusionStrategy.TendermintEventAndPoll
-    )
-  }
-
-  private createPollingInclusionWaiter(
-    txHash: string,
-    timeout: number,
-  ): TxInclusionWaiter {
-    return {
+    return prepareTxInclusionWaiter({
       txHash,
-      inclusionStrategy: TxInclusionStrategy.Poll,
-      close: () => {},
-      wait: (includedTxHash = txHash) =>
-        this.fetchTxPoll(includedTxHash, timeout),
-    }
+      timeout,
+      options,
+      fetchTx: (includedTxHash) => this.fetchTx(includedTxHash),
+      fetchTxPoll: (includedTxHash, pollTimeout, abortSignal) =>
+        this.fetchTxPoll(includedTxHash, pollTimeout, abortSignal),
+      createRequestException: (error, contextModule) =>
+        new HttpRequestException(error, {
+          context: 'TxRestApi',
+          contextModule,
+        }),
+    })
   }
 
   public async simulate(txRaw: CosmosTxV1Beta1TxPb.TxRaw) {
@@ -393,135 +314,6 @@ export class TxRestApi implements TxConcreteApi {
 
       throw e
     }
-  }
-
-  private async waitForSubscribedTxInclusion(
-    txHash: string,
-    timeout: number,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-    options?: TxClientInclusionOptions,
-  ): Promise<TxResponse> {
-    const fallbackToPolling =
-      options?.eventInclusion?.fallbackToPolling !== false
-
-    try {
-      return await this.waitForSubscribedTxEvent(txHash, subscription)
-    } catch (e: unknown) {
-      if (e instanceof TransactionException) {
-        throw e
-      }
-
-      const error = e instanceof Error ? e : new Error(String(e))
-
-      if (!fallbackToPolling) {
-        throw new HttpRequestException(error, {
-          context: 'TxRestApi',
-          contextModule: 'event-inclusion',
-        })
-      }
-
-      options?.eventInclusion?.onFallback?.(error)
-
-      return this.fetchTxPoll(txHash, timeout)
-    }
-  }
-
-  private async waitForSubscribedTxInclusionAndPoll(
-    txHash: string,
-    timeout: number,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-    options?: TxClientInclusionOptions,
-  ): Promise<TxResponse> {
-    return new Promise<TxResponse>((resolve, reject) => {
-      let settled = false
-      let finishedCount = 0
-      let eventError: Error | undefined
-      let pollError: Error | undefined
-
-      const rejectIfBothFailed = () => {
-        if (finishedCount < 2 || settled) {
-          return
-        }
-
-        reject(pollError || eventError || new Error('Tx inclusion failed'))
-      }
-
-      const resolveOnce = (
-        txResponse: TxResponse,
-        source: 'event' | 'poll',
-      ) => {
-        if (settled) {
-          return
-        }
-
-        settled = true
-
-        if (source === 'poll') {
-          subscription.close()
-        }
-
-        resolve(txResponse)
-      }
-
-      const rejectTerminal = (error: unknown) => {
-        if (settled) {
-          return true
-        }
-
-        if (error instanceof TransactionException) {
-          settled = true
-          subscription.close()
-          reject(error)
-
-          return true
-        }
-
-        return false
-      }
-
-      this.waitForSubscribedTxEvent(txHash, subscription)
-        .then((txResponse) => resolveOnce(txResponse, 'event'))
-        .catch((error: unknown) => {
-          if (rejectTerminal(error)) {
-            return
-          }
-
-          const fallbackError =
-            error instanceof Error ? error : new Error(String(error))
-          eventError = fallbackError
-          finishedCount += 1
-          options?.eventInclusion?.onFallback?.(fallbackError)
-          rejectIfBothFailed()
-        })
-
-      this.fetchTxPoll(txHash, timeout)
-        .then((txResponse) => resolveOnce(txResponse, 'poll'))
-        .catch((error: unknown) => {
-          if (rejectTerminal(error)) {
-            return
-          }
-
-          pollError = error instanceof Error ? error : new Error(String(error))
-          finishedCount += 1
-          rejectIfBothFailed()
-        })
-    })
-  }
-
-  private async waitForSubscribedTxEvent(
-    txHash: string,
-    subscription: Awaited<ReturnType<typeof subscribeToTendermintTxEvent>>,
-  ): Promise<TxResponse> {
-    const eventTx = await subscription.wait()
-
-    if (eventTx.code !== 0) {
-      throw new TransactionException(new Error(eventTx.rawLog), {
-        contextCode: eventTx.code,
-        contextModule: eventTx.codespace,
-      })
-    }
-
-    return this.fetchTx(txHash)
   }
 
   /**

--- a/packages/sdk-ts/src/core/tx/api/index.ts
+++ b/packages/sdk-ts/src/core/tx/api/index.ts
@@ -1,3 +1,4 @@
 export * from './utils.js'
 export * from './TxGrpcApi.js'
 export * from './TxRestApi.js'
+export * from './TxEventInclusion.js'

--- a/packages/sdk-ts/src/core/tx/api/types.ts
+++ b/packages/sdk-ts/src/core/tx/api/types.ts
@@ -1,0 +1,35 @@
+import type {
+  TxResponse,
+  TxFetchTxPollArgs,
+  TxEventWebSocketFactory,
+  TxClientInclusionOptions,
+  TxClientBroadcastResponse,
+} from '../types/tx.js'
+
+export interface TendermintTxEventSubscription {
+  close: () => void
+  wait: () => Promise<TxClientBroadcastResponse>
+}
+
+export interface SubscribeToTendermintTxEventArgs {
+  txHash: string
+  timeout: number
+  endpoint: string
+  webSocketFactory?: TxEventWebSocketFactory
+}
+
+export type TxInclusionRequestExceptionFactory = (
+  error: Error,
+  contextModule: string,
+) => Error
+
+export interface PrepareTxInclusionWaiterArgs {
+  txHash: string
+  timeout: number
+  options?: TxClientInclusionOptions
+  fetchTx: (txHash: string) => Promise<TxResponse>
+  fetchTxPoll: (
+    args: TxFetchTxPollArgs & { timeout: number },
+  ) => Promise<TxResponse>
+  createRequestException: TxInclusionRequestExceptionFactory
+}

--- a/packages/sdk-ts/src/core/tx/api/utils.ts
+++ b/packages/sdk-ts/src/core/tx/api/utils.ts
@@ -18,6 +18,6 @@ export const waitTxBroadcasted = (
     .toNumber()
 
   return options.endpoints.grpc
-    ? new TxGrpcApi(options.endpoints.grpc).fetchTxPoll(txHash, timeout)
-    : new TxRestApi(options.endpoints.rest).fetchTxPoll(txHash, timeout)
+    ? new TxGrpcApi(options.endpoints.grpc).fetchTxPoll({ txHash, timeout })
+    : new TxRestApi(options.endpoints.rest).fetchTxPoll({ txHash, timeout })
 }

--- a/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
+++ b/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
@@ -1,11 +1,11 @@
 import { Network } from '@injectivelabs/networks'
 import { EvmChainId } from '@injectivelabs/ts-types'
 import { DEFAULT_BLOCK_TIME_IN_SECONDS } from '@injectivelabs/utils'
-import { IndexerGrpcTransactionApi } from '../../../client/index.js'
+import { TxGrpcApi } from '../api/TxGrpcApi.js'
 import { MsgSend } from '../../modules/bank/index.js'
 import { PrivateKey } from '../../accounts/PrivateKey.js'
-import { TxGrpcApi } from '../api/TxGrpcApi.js'
 import { MsgBroadcasterWithPk } from './MsgBroadcasterWithPk.js'
+import { IndexerGrpcTransactionApi } from '../../../client/index.js'
 
 // TODO
 describe.skip('MsgBroadcasterWithPk', () => {

--- a/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
+++ b/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.spec.ts
@@ -1,7 +1,10 @@
 import { Network } from '@injectivelabs/networks'
 import { EvmChainId } from '@injectivelabs/ts-types'
+import { DEFAULT_BLOCK_TIME_IN_SECONDS } from '@injectivelabs/utils'
+import { IndexerGrpcTransactionApi } from '../../../client/index.js'
 import { MsgSend } from '../../modules/bank/index.js'
 import { PrivateKey } from '../../accounts/PrivateKey.js'
+import { TxGrpcApi } from '../api/TxGrpcApi.js'
 import { MsgBroadcasterWithPk } from './MsgBroadcasterWithPk.js'
 
 // TODO
@@ -83,4 +86,68 @@ describe.skip('MsgBroadcasterWithPk', () => {
 
     expect(response.result).toBeDefined()
   }, 60000)
+})
+
+describe('MsgBroadcasterWithPk fee delegation', () => {
+  test('forwards txTimeout to transaction polling', async () => {
+    const txTimeout = 11
+    const privateKey = PrivateKey.fromHex(
+      '0x0000000000000000000000000000000000000000000000000000000000000001',
+    )
+    const injectiveAddress = privateKey.toBech32()
+    const message = MsgSend.fromJSON({
+      srcInjectiveAddress: injectiveAddress,
+      dstInjectiveAddress: injectiveAddress,
+      amount: {
+        amount: '1',
+        denom: 'inj',
+      },
+    })
+    const txResponse = {
+      txHash: 'FEE_DELEGATION_HASH',
+      height: 1,
+      code: 0,
+      rawLog: '',
+      gasWanted: 1,
+      gasUsed: 1,
+      timestamp: '',
+      codespace: '',
+    }
+
+    vi.spyOn(PrivateKey.prototype, 'signTypedData').mockResolvedValue(
+      new Uint8Array([1, 2, 3]),
+    )
+    vi.spyOn(
+      IndexerGrpcTransactionApi.prototype,
+      'prepareTxRequest',
+    ).mockResolvedValue({
+      data: '{}',
+    } as any)
+    vi.spyOn(
+      IndexerGrpcTransactionApi.prototype,
+      'broadcastTxRequest',
+    ).mockResolvedValue({
+      txHash: txResponse.txHash,
+    } as any)
+    const fetchTxPoll = vi
+      .spyOn(TxGrpcApi.prototype, 'fetchTxPoll')
+      .mockResolvedValue(txResponse)
+
+    const response = await new MsgBroadcasterWithPk({
+      network: Network.Devnet,
+      privateKey,
+      evmChainId: EvmChainId.Sepolia,
+      txTimeout,
+    }).broadcastWithFeeDelegation({ msgs: message })
+
+    expect(response).toBe(txResponse)
+    expect(fetchTxPoll).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txHash: txResponse.txHash,
+      }),
+    )
+    expect(fetchTxPoll.mock.calls[0]?.[0].timeout).toBeCloseTo(
+      txTimeout * DEFAULT_BLOCK_TIME_IN_SECONDS * 1000,
+    )
+  })
 })

--- a/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.ts
+++ b/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.ts
@@ -216,7 +216,9 @@ export class MsgBroadcasterWithPk {
       signature: `0x${uint8ArrayToHex(signature)}`,
     })
 
-    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll(response.txHash)
+    return await new TxGrpcApi(endpoints.grpc).fetchTxPoll({
+      txHash: response.txHash,
+    })
   }
 
   /**

--- a/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.ts
+++ b/packages/sdk-ts/src/core/tx/broadcaster/MsgBroadcasterWithPk.ts
@@ -9,6 +9,7 @@ import {
   toBigNumber,
   getDefaultStdFee,
   DEFAULT_BLOCK_TIMEOUT_HEIGHT,
+  DEFAULT_BLOCK_TIME_IN_SECONDS,
 } from '@injectivelabs/utils'
 import { createTransaction } from '../tx.js'
 import { TxGrpcApi } from '../api/TxGrpcApi.js'
@@ -216,8 +217,14 @@ export class MsgBroadcasterWithPk {
       signature: `0x${uint8ArrayToHex(signature)}`,
     })
 
+    const timeoutInMs = toBigNumber(txTimeout)
+      .times(DEFAULT_BLOCK_TIME_IN_SECONDS)
+      .times(1000)
+      .toNumber()
+
     return await new TxGrpcApi(endpoints.grpc).fetchTxPoll({
       txHash: response.txHash,
+      timeout: timeoutInMs,
     })
   }
 

--- a/packages/sdk-ts/src/core/tx/types/tx.ts
+++ b/packages/sdk-ts/src/core/tx/types/tx.ts
@@ -5,11 +5,42 @@ import type * as CosmosTxV1Beta1ServicePb from '@injectivelabs/core-proto-ts-v2/
 import type * as CosmosTxSigningV1Beta1SigningPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/tx/signing/v1beta1/signing_pb'
 import type { Msgs } from '../../modules/msgs.js'
 
-export interface TxClientBroadcastOptions {
+export type TxEventWebSocketFactory = (endpoint: string) => WebSocket
+
+export const TxInclusionStrategy = {
+  Poll: 'poll',
+  TendermintEvent: 'tendermint-event',
+  TendermintEventAndPoll: 'tendermint-event-and-poll',
+} as const
+
+export type TxInclusionStrategy =
+  (typeof TxInclusionStrategy)[keyof typeof TxInclusionStrategy]
+
+export interface TxEventInclusionOptions {
+  rpcEndpoint?: string
+  timeout?: number
+  fallbackToPolling?: boolean
+  webSocketFactory?: TxEventWebSocketFactory
+  onFallback?: (error: Error) => void
+}
+
+export interface TxClientInclusionOptions {
+  inclusionStrategy?: TxInclusionStrategy
+  eventInclusion?: TxEventInclusionOptions
+}
+
+export interface TxInclusionWaiter {
+  txHash: string
+  inclusionStrategy: TxInclusionStrategy
+  close: () => void
+  wait: (txHash?: string) => Promise<TxClientBroadcastResponse | undefined>
+}
+
+export interface TxClientBroadcastOptions extends TxClientInclusionOptions {
   mode?: CosmosTxV1Beta1ServicePb.BroadcastMode
   timeout?: number // timeout in ms
   txTimeout?: number // blocks to wait for tx to be included in a block
-  onBroadcast?: (txHash: string) => void // called after SYNC broadcast, before polling
+  onBroadcast?: (txHash: string) => void // called after broadcast, before inclusion detection
 }
 
 export interface TxClientBroadcastResponse {
@@ -48,7 +79,20 @@ export interface TxConcreteApi {
     txRaw: CosmosTxV1Beta1TxPb.TxRaw,
   ): Promise<TxClientBroadcastResponse>
   fetchTx(txHash: string): Promise<TxClientBroadcastResponse | undefined>
-  fetchTxPoll(txHash: string): Promise<TxClientBroadcastResponse | undefined>
+  fetchTxPoll(
+    txHash: string,
+    timeout?: number,
+  ): Promise<TxClientBroadcastResponse | undefined>
+  waitForTxInclusion(
+    txHash: string,
+    timeout?: number,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxClientBroadcastResponse | undefined>
+  prepareTxInclusionWait(
+    txHash: string,
+    timeout?: number,
+    options?: TxClientInclusionOptions,
+  ): Promise<TxInclusionWaiter>
   simulate(txRaw: CosmosTxV1Beta1TxPb.TxRaw): Promise<TxClientSimulateResponse>
 }
 

--- a/packages/sdk-ts/src/core/tx/types/tx.ts
+++ b/packages/sdk-ts/src/core/tx/types/tx.ts
@@ -36,6 +36,12 @@ export interface TxInclusionWaiter {
   wait: (txHash?: string) => Promise<TxClientBroadcastResponse | undefined>
 }
 
+export interface TxFetchTxPollArgs {
+  txHash: string
+  timeout?: number
+  abortSignal?: AbortSignal
+}
+
 export interface TxClientBroadcastOptions extends TxClientInclusionOptions {
   mode?: CosmosTxV1Beta1ServicePb.BroadcastMode
   timeout?: number // timeout in ms
@@ -80,9 +86,7 @@ export interface TxConcreteApi {
   ): Promise<TxClientBroadcastResponse>
   fetchTx(txHash: string): Promise<TxClientBroadcastResponse | undefined>
   fetchTxPoll(
-    txHash: string,
-    timeout?: number,
-    abortSignal?: AbortSignal,
+    args: TxFetchTxPollArgs,
   ): Promise<TxClientBroadcastResponse | undefined>
   waitForTxInclusion(
     txHash: string,

--- a/packages/sdk-ts/src/core/tx/types/tx.ts
+++ b/packages/sdk-ts/src/core/tx/types/tx.ts
@@ -82,6 +82,7 @@ export interface TxConcreteApi {
   fetchTxPoll(
     txHash: string,
     timeout?: number,
+    abortSignal?: AbortSignal,
   ): Promise<TxClientBroadcastResponse | undefined>
   waitForTxInclusion(
     txHash: string,

--- a/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
+++ b/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.ts
@@ -52,6 +52,7 @@ import {
   WalletStrategyEmitterEventType,
 } from '@injectivelabs/wallet-base'
 import {
+  TxClient,
   TxGrpcApi,
   SIGN_DIRECT,
   SIGN_EIP712,
@@ -73,13 +74,15 @@ import type { DirectSignResponse } from '@injectivelabs/sdk-ts/types'
 import type { Wallet as WalletType } from '@injectivelabs/wallet-base'
 import type { AuthBaseAccount } from '@injectivelabs/sdk-ts/client/chain'
 import type {
-  TxResponse,
-  CreateTransactionWithSignersArgs,
-} from '@injectivelabs/sdk-ts/core/tx'
-import type {
   ChainId as ChainIdType,
   EvmChainId as EvmChainIdType,
 } from '@injectivelabs/ts-types'
+import type {
+  TxResponse,
+  TxInclusionWaiter,
+  TxClientInclusionOptions,
+  CreateTransactionWithSignersArgs,
+} from '@injectivelabs/sdk-ts/core/tx'
 import type BaseWalletStrategy from '../strategy/BaseWalletStrategy.js'
 import type {
   MsgBroadcasterOptions,
@@ -148,6 +151,8 @@ export class MsgBroadcaster {
 
   public httpHeaders?: Record<string, string>
 
+  public txInclusion?: TxClientInclusionOptions
+
   constructor(options: MsgBroadcasterOptions) {
     const networkInfo = getNetworkInfo(options.network)
 
@@ -165,6 +170,7 @@ export class MsgBroadcaster {
     this.endpoints = options.endpoints || getNetworkEndpoints(options.network)
     this.walletStrategy = options.walletStrategy
     this.httpHeaders = options.httpHeaders
+    this.txInclusion = options.txInclusion
   }
 
   setOptions(options: Partial<MsgBroadcasterOptions>) {
@@ -172,6 +178,7 @@ export class MsgBroadcaster {
     this.txTimeout = options.txTimeout || this.txTimeout
     this.txTimeoutOnFeeDelegation =
       options.txTimeoutOnFeeDelegation || this.txTimeoutOnFeeDelegation
+    this.txInclusion = options.txInclusion || this.txInclusion
   }
 
   async getEvmChainId(): Promise<EvmChainId | undefined> {
@@ -371,12 +378,14 @@ export class MsgBroadcaster {
     privateKey,
     feePayerSig,
     accountNumber,
+    txInclusion,
     txTimeoutInBlocks: txTimeoutInBlocksParam,
   }: {
     privateKey: string
     feePayerSig: string
     accountNumber: number
     tx: Uint8Array | string
+    txInclusion?: TxClientInclusionOptions
     txTimeoutInBlocks?: number // blocks to wait for tx to be included in a block
   }): Promise<TxResponse> {
     const { chainId, endpoints, walletStrategy } = this
@@ -425,6 +434,7 @@ export class MsgBroadcaster {
 
       const txResponse = await new TxGrpcApi(endpoints.grpc).broadcast(txRaw, {
         txTimeout: txTimeoutInBlocks,
+        ...this.resolveTxInclusionOptions({ txInclusion }),
         onBroadcast: () => {
           walletStrategy.emit(
             WalletStrategyEmitterEventType.TransactionBroadcastSynced,
@@ -469,6 +479,83 @@ export class MsgBroadcaster {
       override > 0
       ? override
       : this.txTimeout
+  }
+
+  private resolveTxInclusionOptions(
+    tx?: Pick<MsgBroadcasterTxOptions, 'txInclusion'>,
+  ): TxClientInclusionOptions | undefined {
+    const txInclusion = tx?.txInclusion || this.txInclusion
+
+    if (!txInclusion) {
+      return undefined
+    }
+
+    return {
+      ...txInclusion,
+      eventInclusion: {
+        ...txInclusion.eventInclusion,
+        rpcEndpoint:
+          txInclusion.eventInclusion?.rpcEndpoint || this.endpoints.rpc,
+      },
+    }
+  }
+
+  private createTxGrpcApi(): TxGrpcApi {
+    const client = new TxGrpcApi(this.endpoints.grpc)
+
+    if (this.httpHeaders) {
+      client.setMetadata(this.httpHeaders)
+    }
+
+    return client
+  }
+
+  private async waitForTxInclusion(
+    txHash: string,
+    timeout: number,
+    tx?: Pick<MsgBroadcasterTxOptions, 'txInclusion'>,
+  ): Promise<TxResponse> {
+    return this.createTxGrpcApi().waitForTxInclusion(
+      txHash,
+      timeout,
+      this.resolveTxInclusionOptions(tx),
+    )
+  }
+
+  private async prepareTxInclusionWaiter(
+    txRawOrSignResponse: CosmosTxV1Beta1TxPb.TxRaw | DirectSignResponse,
+    timeout: number,
+    tx?: Pick<MsgBroadcasterTxOptions, 'txInclusion'>,
+  ): Promise<TxInclusionWaiter> {
+    const txRaw = createTxRawFromSigResponse(txRawOrSignResponse)
+    const txHash = TxClient.hash(txRaw)
+
+    return this.createTxGrpcApi().prepareTxInclusionWait(
+      txHash,
+      timeout,
+      this.resolveTxInclusionOptions(tx),
+    )
+  }
+
+  private async waitForPreparedTxInclusion(
+    responseTxHash: string,
+    timeout: number,
+    tx: Pick<MsgBroadcasterTxOptions, 'txInclusion'>,
+    inclusionWaiter?: TxInclusionWaiter,
+  ): Promise<TxResponse> {
+    if (!inclusionWaiter) {
+      return this.waitForTxInclusion(responseTxHash, timeout, tx)
+    }
+
+    const confirmedTx = await inclusionWaiter.wait(responseTxHash)
+
+    if (!confirmedTx) {
+      throw new TransactionException(
+        new Error(`The transaction with ${responseTxHash} is not found`),
+      )
+    }
+
+    return confirmedTx
   }
 
   /**
@@ -576,20 +663,35 @@ export class MsgBroadcaster {
     /** Append Signatures */
     txRawEip712.signatures = [hexToBuff(signature)]
 
-    const response = await walletStrategy.sendTransaction(txRawEip712, {
-      chainId,
-      endpoints,
-      txTimeout: txTimeoutInBlocks,
-      address: tx.injectiveAddress,
-    })
+    const inclusionWaiter = await this.prepareTxInclusionWaiter(
+      txRawEip712,
+      txTimeoutTimeInMilliSeconds,
+      tx,
+    )
+
+    let response: TxResponse
+
+    try {
+      response = await walletStrategy.sendTransaction(txRawEip712, {
+        chainId,
+        endpoints,
+        txTimeout: txTimeoutInBlocks,
+        address: tx.injectiveAddress,
+      })
+    } catch (e) {
+      inclusionWaiter.close()
+      throw e
+    }
 
     walletStrategy.emit(
       WalletStrategyEmitterEventType.TransactionBroadcastSynced,
     )
 
-    const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+    const confirmedTx = await this.waitForPreparedTxInclusion(
       response.txHash,
       txTimeoutTimeInMilliSeconds,
+      tx,
+      inclusionWaiter,
     )
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
@@ -714,20 +816,35 @@ export class MsgBroadcaster {
     /** Append Signatures */
     txRawEip712.signatures = [hexToBuff(signature)]
 
-    const response = await walletStrategy.sendTransaction(txRawEip712, {
-      chainId,
-      endpoints,
-      txTimeout: txTimeoutInBlocks,
-      address: tx.injectiveAddress,
-    })
+    const inclusionWaiter = await this.prepareTxInclusionWaiter(
+      txRawEip712,
+      txTimeoutTimeInMilliSeconds,
+      tx,
+    )
+
+    let response: TxResponse
+
+    try {
+      response = await walletStrategy.sendTransaction(txRawEip712, {
+        chainId,
+        endpoints,
+        txTimeout: txTimeoutInBlocks,
+        address: tx.injectiveAddress,
+      })
+    } catch (e) {
+      inclusionWaiter.close()
+      throw e
+    }
 
     walletStrategy.emit(
       WalletStrategyEmitterEventType.TransactionBroadcastSynced,
     )
 
-    const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+    const confirmedTx = await this.waitForPreparedTxInclusion(
       response.txHash,
       txTimeoutTimeInMilliSeconds,
+      tx,
+      inclusionWaiter,
     )
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
@@ -831,9 +948,10 @@ export class MsgBroadcaster {
         WalletStrategyEmitterEventType.TransactionBroadcastSynced,
       )
 
-      const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      const confirmedTx = await this.waitForTxInclusion(
         response.txHash,
         txTimeoutTimeInMilliSeconds,
+        tx,
       )
 
       walletStrategy.emit(
@@ -967,20 +1085,35 @@ export class MsgBroadcaster {
         WalletStrategyEmitterEventType.TransactionBroadcastStart,
       )
 
-      const response = await walletStrategy.sendTransaction(txRaw, {
-        chainId,
-        endpoints,
-        address: tx.injectiveAddress,
-        txTimeout: txTimeoutInBlocks,
-      })
+      const inclusionWaiter = await this.prepareTxInclusionWaiter(
+        txRaw,
+        txTimeoutTimeInMilliSeconds,
+        tx,
+      )
+
+      let response: TxResponse
+
+      try {
+        response = await walletStrategy.sendTransaction(txRaw, {
+          chainId,
+          endpoints,
+          address: tx.injectiveAddress,
+          txTimeout: txTimeoutInBlocks,
+        })
+      } catch (e) {
+        inclusionWaiter.close()
+        throw e
+      }
 
       walletStrategy.emit(
         WalletStrategyEmitterEventType.TransactionBroadcastSynced,
       )
 
-      const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      const confirmedTx = await this.waitForPreparedTxInclusion(
         response.txHash,
         txTimeoutTimeInMilliSeconds,
+        tx,
+        inclusionWaiter,
       )
 
       walletStrategy.emit(
@@ -1001,20 +1134,35 @@ export class MsgBroadcaster {
       WalletStrategyEmitterEventType.TransactionBroadcastStart,
     )
 
-    const response = await walletStrategy.sendTransaction(directSignResponse, {
-      chainId,
-      endpoints,
-      txTimeout: txTimeoutInBlocks,
-      address: tx.injectiveAddress,
-    })
+    const inclusionWaiter = await this.prepareTxInclusionWaiter(
+      directSignResponse,
+      txTimeoutTimeInMilliSeconds,
+      tx,
+    )
+
+    let response: TxResponse
+
+    try {
+      response = await walletStrategy.sendTransaction(directSignResponse, {
+        chainId,
+        endpoints,
+        txTimeout: txTimeoutInBlocks,
+        address: tx.injectiveAddress,
+      })
+    } catch (e) {
+      inclusionWaiter.close()
+      throw e
+    }
 
     walletStrategy.emit(
       WalletStrategyEmitterEventType.TransactionBroadcastSynced,
     )
 
-    const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+    const confirmedTx = await this.waitForPreparedTxInclusion(
       response.txHash,
       txTimeoutTimeInMilliSeconds,
+      tx,
+      inclusionWaiter,
     )
 
     walletStrategy.emit(WalletStrategyEmitterEventType.TransactionBroadcastEnd)
@@ -1137,6 +1285,7 @@ export class MsgBroadcaster {
       txRawEip712,
       {
         txTimeout: txTimeoutInBlocks,
+        ...this.resolveTxInclusionOptions(tx),
         onBroadcast: () => {
           walletStrategy.emit(
             WalletStrategyEmitterEventType.TransactionBroadcastSynced,
@@ -1316,10 +1465,11 @@ export class MsgBroadcaster {
       WalletStrategyEmitterEventType.TransactionPreparationEnd,
     )
 
+    const signedTxRaw = createTxRawFromSigResponse(directSignResponse)
     const broadcast = async () =>
       await transactionApi.broadcastCosmosTxRequest({
         address: tx.injectiveAddress,
-        txRaw: createTxRawFromSigResponse(directSignResponse),
+        txRaw: signedTxRaw,
         signature: directSignResponse.signature.signature,
         pubKey: directSignResponse.signature.pub_key || {
           value: pubKey,
@@ -1332,7 +1482,20 @@ export class MsgBroadcaster {
         WalletStrategyEmitterEventType.TransactionBroadcastStart,
       )
 
-      const response = await broadcast()
+      const inclusionWaiter = await this.prepareTxInclusionWaiter(
+        signedTxRaw,
+        txTimeoutTimeInMilliSeconds,
+        tx,
+      )
+
+      let response: Awaited<ReturnType<typeof broadcast>>
+
+      try {
+        response = await broadcast()
+      } catch (e) {
+        inclusionWaiter.close()
+        throw e
+      }
 
       walletStrategy.emit(
         WalletStrategyEmitterEventType.TransactionBroadcastSynced,
@@ -1343,9 +1506,11 @@ export class MsgBroadcaster {
         cosmosWallet.enableGasCheck(chainId)
       }
 
-      const confirmedTx = await new TxGrpcApi(endpoints.grpc).fetchTxPoll(
+      const confirmedTx = await this.waitForPreparedTxInclusion(
         response.txHash,
         txTimeoutTimeInMilliSeconds,
+        tx,
+        inclusionWaiter,
       )
 
       walletStrategy.emit(

--- a/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.unit.spec.ts
+++ b/packages/wallets/wallet-core/src/broadcaster/MsgBroadcaster.unit.spec.ts
@@ -3,7 +3,12 @@ import { Network } from '@injectivelabs/networks'
 import { TransactionException } from '@injectivelabs/exceptions'
 import { PrivateKey } from '@injectivelabs/sdk-ts/core/accounts'
 import { WalletStrategyEmitterEventType } from '@injectivelabs/wallet-base'
-import { TxGrpcApi, CosmosTxV1Beta1TxPb } from '@injectivelabs/sdk-ts/core/tx'
+import {
+  TxClient,
+  TxGrpcApi,
+  TxInclusionStrategy,
+  CosmosTxV1Beta1TxPb,
+} from '@injectivelabs/sdk-ts/core/tx'
 import { MsgBroadcaster } from './MsgBroadcaster.js'
 import type { TxResponse } from '@injectivelabs/sdk-ts/core/tx'
 import type { MsgBroadcasterOptions } from './types.js'
@@ -143,6 +148,87 @@ describe('MsgBroadcaster event emission order', () => {
       expect(broadcastSpy).toHaveBeenCalledWith(
         expect.anything(),
         expect.objectContaining({ txTimeout: 5 }),
+      )
+    })
+
+    it('passes configured tx inclusion options to the SDK broadcaster', async () => {
+      const broadcastSpy = vi
+        .spyOn(TxGrpcApi.prototype, 'broadcast')
+        .mockResolvedValue(makeTxResponse('EVENT_INCLUSION'))
+
+      broadcaster = new MsgBroadcaster({
+        network: Network.Devnet,
+        walletStrategy: mockStrategy,
+        endpoints: {
+          indexer: 'http://localhost:8888',
+          grpc: 'http://localhost:9901',
+          rest: 'http://localhost:10337',
+          rpc: 'http://localhost:26657',
+        },
+        txInclusion: {
+          inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+        },
+      })
+
+      await broadcaster.broadcastWithFeePayerSig({
+        tx: validTxBytes,
+        privateKey: '0x' + 'ab'.repeat(32),
+        feePayerSig: 'bW9ja1NpZw==',
+        accountNumber: 1,
+      })
+
+      expect(broadcastSpy).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+          eventInclusion: expect.objectContaining({
+            rpcEndpoint: 'http://localhost:26657',
+          }),
+        }),
+      )
+    })
+
+    it('prepares inclusion waiting with the hash computed from final tx bytes', async () => {
+      const txRaw = CosmosTxV1Beta1TxPb.TxRaw.create({
+        bodyBytes: new Uint8Array([1]),
+        authInfoBytes: new Uint8Array([2]),
+        signatures: [new Uint8Array([3])],
+      })
+      const txHash = TxClient.hash(txRaw)
+      const prepareSpy = vi
+        .spyOn(TxGrpcApi.prototype, 'prepareTxInclusionWait')
+        .mockResolvedValue({
+          txHash,
+          inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+          close: vi.fn(),
+          wait: vi.fn().mockResolvedValue(makeTxResponse(txHash)),
+        })
+
+      broadcaster = new MsgBroadcaster({
+        network: Network.Devnet,
+        walletStrategy: mockStrategy,
+        endpoints: {
+          indexer: 'http://localhost:8888',
+          grpc: 'http://localhost:9901',
+          rest: 'http://localhost:10337',
+          rpc: 'http://localhost:26657',
+        },
+        txInclusion: {
+          inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+        },
+      })
+
+      await (broadcaster as any).prepareTxInclusionWaiter(txRaw, 1000, {})
+
+      expect(prepareSpy).toHaveBeenCalledWith(
+        txHash,
+        1000,
+        expect.objectContaining({
+          inclusionStrategy: TxInclusionStrategy.TendermintEvent,
+          eventInclusion: expect.objectContaining({
+            rpcEndpoint: 'http://localhost:26657',
+          }),
+        }),
       )
     })
 

--- a/packages/wallets/wallet-core/src/broadcaster/types.ts
+++ b/packages/wallets/wallet-core/src/broadcaster/types.ts
@@ -2,6 +2,7 @@ import type { Msgs } from '@injectivelabs/sdk-ts/core/modules'
 import type { ChainId, EvmChainId } from '@injectivelabs/ts-types'
 import type { Network, NetworkEndpoints } from '@injectivelabs/networks'
 import type { AuthBaseAccount } from '@injectivelabs/sdk-ts/client/chain'
+import type { TxClientInclusionOptions } from '@injectivelabs/sdk-ts/core/tx'
 import type BaseWalletStrategy from '../strategy/BaseWalletStrategy.js'
 
 export interface MsgBroadcasterTxOptions {
@@ -11,6 +12,7 @@ export interface MsgBroadcasterTxOptions {
   injectiveAddress?: string
   accountDetails?: AuthBaseAccount
   txTimeoutInBlocks?: number // blocks to wait for tx to be included in a block
+  txInclusion?: TxClientInclusionOptions
   gas?: {
     gasPrice?: string
     gas?: number /** gas limit */
@@ -33,6 +35,7 @@ export interface MsgBroadcasterOptions {
   simulateTx?: boolean
   txTimeoutOnFeeDelegation?: boolean
   txTimeout?: number // blocks to wait for tx to be included in a block
+  txInclusion?: TxClientInclusionOptions
   walletStrategy: BaseWalletStrategy
   gasBufferCoefficient?: number
   httpHeaders?: Record<string, string>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tendermint event-based transaction inclusion via WebSocket with optional poll fallback and combined event+poll strategies
  * Public APIs to prepare/wait for transaction inclusion and to normalize websocket endpoints; polling supports cancellation and new options-style call shapes
  * Wallet broadcaster accepts configurable tx-inclusion options, prepares inclusion waiters, and propagates timeouts to inclusion polling

* **Tests**
  * Expanded coverage for websocket subscriptions, inclusion strategies, broadcast ordering/races, cancellation, and fallback handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->