### PR TITLE
fix: destroyed stream manager can be retried

### DIFF
--- a/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.spec.ts
@@ -171,6 +171,36 @@ describe('StreamManagerV2', () => {
       expect(streamFactory).toHaveBeenCalledTimes(2)
     })
 
+    it('should not call connect if a retry listener destroys the manager', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+          maxAttempts: 3,
+          initialDelayMs: 1000,
+          maxDelayMs: 10000,
+          backoffMultiplier: 2,
+          persistent: false,
+        },
+      })
+
+      manager.on('retry', () => {
+        manager.destroy()
+      })
+
+      vi.mocked(streamFactory).mockImplementationOnce(() => {
+        throw new Error('Connection failed')
+      })
+
+      manager.start()
+
+      expect(() => vi.advanceTimersByTime(1000)).not.toThrow()
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(streamFactory).toHaveBeenCalledTimes(1)
+    })
+
     it('should not reset retry attempts when a stream errors before it is stable', () => {
       const manager = new StreamManagerV2({
         id: 'test-stream',
@@ -972,6 +1002,227 @@ describe('StreamManagerV2', () => {
       expect(streamFactory).toHaveBeenCalledTimes(1)
     })
 
+    it('should throw when start is called after destroy', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      const stateChanges: any[] = []
+      manager.on('state:change', (payload) => stateChanges.push(payload))
+
+      manager.destroy()
+
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(stateChanges).toEqual([
+        {
+          from: StreamState.Idle,
+          to: StreamState.Destroyed,
+        },
+      ])
+      expect(() => manager.start()).toThrow(
+        'Cannot start destroyed stream manager: test-stream',
+      )
+      expect(streamFactory).not.toHaveBeenCalled()
+    })
+
+    it('should not create a subscription if a connecting state-change listener destroys the manager', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      manager.on('state:change', ({ to }) => {
+        if (to === StreamState.Connecting) {
+          manager.destroy()
+        }
+      })
+
+      expect(() => manager.start()).not.toThrow()
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(streamFactory).not.toHaveBeenCalled()
+      expect(mockSubscription.on).not.toHaveBeenCalled()
+    })
+
+    it('should emit a final non-retrying disconnect when destroyed', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+        },
+      })
+
+      const disconnectEvents: any[] = []
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+
+      manager.start()
+      manager.destroy()
+
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(disconnectEvents.at(-1)).toEqual({
+        reason: StreamDisconnectReason.UserStopped,
+        willRetry: false,
+        attempt: 0,
+      })
+      expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
+    it('should keep destroyed state and clean up listeners if a disconnect listener throws during destroy', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      manager.start()
+      manager.on('disconnect', () => {
+        throw new Error('disconnect listener failed')
+      })
+
+      expect(() => manager.destroy()).toThrow('disconnect listener failed')
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(manager.listenerCount('disconnect')).toBe(0)
+      expect(manager.listenerCount('state:change')).toBe(0)
+    })
+
+    it('should still transition to stopped if a disconnect listener throws during stop', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      manager.start()
+      manager.on('disconnect', () => {
+        throw new Error('disconnect listener failed')
+      })
+
+      expect(() => manager.stop()).toThrow('disconnect listener failed')
+      expect(manager.getState()).toBe(StreamState.Stopped)
+    })
+
+    it('should still transition to reconnecting if a disconnect listener throws on retryable error', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+          maxAttempts: 3,
+          initialDelayMs: 1000,
+          maxDelayMs: 5000,
+          backoffMultiplier: 2,
+          persistent: true,
+        },
+      })
+
+      manager.start()
+      manager.on('disconnect', () => {
+        throw new Error('disconnect listener failed')
+      })
+
+      expect(() =>
+        mockSubscription._errorHandler?.({
+          code: GrpcStatusCode.UNAVAILABLE,
+          details: 'Connection lost',
+        }),
+      ).toThrow('disconnect listener failed')
+
+      expect(manager.getState()).toBe(StreamState.Reconnecting)
+    })
+
+    it('should finish destroy cleanup if a state-change listener throws', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      const disconnectEvents: any[] = []
+      manager.start()
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+      manager.on('state:change', ({ to }) => {
+        if (to === StreamState.Destroyed) {
+          throw new Error('state change failed')
+        }
+      })
+
+      expect(() => manager.destroy()).toThrow('state change failed')
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(disconnectEvents.at(-1)).toEqual({
+        reason: StreamDisconnectReason.UserStopped,
+        willRetry: false,
+        attempt: 0,
+      })
+      expect(manager.listenerCount('disconnect')).toBe(0)
+      expect(manager.listenerCount('state:change')).toBe(0)
+    })
+
+    it('should finish destroy cleanup if a warn listener throws during unsubscribe', () => {
+      mockSubscription.unsubscribe = vi.fn(() => {
+        throw new Error('unsubscribe failed')
+      })
+
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      const disconnectEvents: any[] = []
+      manager.start()
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+      manager.on('warn', () => {
+        throw new Error('warn listener failed')
+      })
+
+      expect(() => manager.destroy()).toThrow('warn listener failed')
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(disconnectEvents.at(-1)).toEqual({
+        reason: StreamDisconnectReason.UserStopped,
+        willRetry: false,
+        attempt: 0,
+      })
+      expect(manager.listenerCount('disconnect')).toBe(0)
+      expect(manager.listenerCount('warn')).toBe(0)
+    })
+
+    it('should treat repeated destroy calls as a no-op', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      const stateChanges: any[] = []
+      const disconnectEvents: any[] = []
+      manager.on('state:change', (payload) => stateChanges.push(payload))
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+
+      manager.start()
+      manager.destroy()
+      manager.destroy()
+
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(stateChanges.at(-1)).toEqual({
+        from: StreamState.Connected,
+        to: StreamState.Destroyed,
+      })
+      expect(
+        stateChanges.filter((change) => change.to === StreamState.Destroyed),
+      ).toHaveLength(1)
+      expect(disconnectEvents.at(-1)).toEqual({
+        reason: StreamDisconnectReason.UserStopped,
+        willRetry: false,
+        attempt: 0,
+      })
+      expect(mockSubscription.unsubscribe).toHaveBeenCalledTimes(1)
+    })
+
     it('should handle callback errors gracefully', () => {
       const manager = new StreamManagerV2({
         id: 'test-stream',
@@ -1023,6 +1274,115 @@ describe('StreamManagerV2', () => {
       manager.stop()
 
       expect(manager.getState()).toBe(StreamState.Stopped)
+    })
+
+    it('should swallow abort errors thrown during unsubscribe on stop', () => {
+      mockSubscription.unsubscribe = vi.fn(() => {
+        const error = new Error('signal is aborted without reason')
+        error.name = 'AbortError'
+        throw error
+      })
+
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      manager.start()
+
+      expect(() => manager.stop()).not.toThrow()
+      expect(manager.getState()).toBe(StreamState.Stopped)
+    })
+
+    it('should emit a warning when unsubscribe throws a non-abort error', () => {
+      mockSubscription.unsubscribe = vi.fn(() => {
+        throw new Error('unsubscribe failed')
+      })
+
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+      })
+
+      const warnEvents: any[] = []
+      manager.on('warn', (payload) => warnEvents.push(payload))
+
+      manager.start()
+
+      expect(() => manager.stop()).not.toThrow()
+      expect(manager.getState()).toBe(StreamState.Stopped)
+      expect(warnEvents).toContainEqual({
+        message: 'Stream unsubscribe failed: unsubscribe failed',
+      })
+    })
+
+    it('should not retry after destroy during reconnect backoff', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+          maxAttempts: 3,
+          initialDelayMs: 1000,
+          maxDelayMs: 5000,
+          backoffMultiplier: 2,
+          persistent: true,
+        },
+      })
+
+      const disconnectEvents: any[] = []
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+
+      manager.start()
+
+      mockSubscription._errorHandler?.({
+        code: GrpcStatusCode.UNAVAILABLE,
+        details: 'Connection lost',
+      })
+
+      expect(manager.getState()).toBe(StreamState.Reconnecting)
+      expect(disconnectEvents.at(-1)?.willRetry).toBe(true)
+
+      manager.destroy()
+
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+
+      vi.advanceTimersByTime(1000)
+
+      expect(streamFactory).toHaveBeenCalledTimes(1)
+    })
+
+    it('should report willRetry=false for late errors after destroy', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+          maxAttempts: 3,
+          initialDelayMs: 1000,
+          maxDelayMs: 5000,
+          backoffMultiplier: 2,
+          persistent: true,
+        },
+      })
+
+      const disconnectEvents: any[] = []
+      manager.on('disconnect', (payload) => disconnectEvents.push(payload))
+
+      manager.start()
+      manager.destroy()
+
+      mockSubscription._errorHandler?.({
+        code: GrpcStatusCode.UNAVAILABLE,
+        details: 'Late connection lost',
+      })
+
+      expect(manager.getState()).toBe(StreamState.Destroyed)
+      expect(disconnectEvents.at(-1)?.willRetry).toBe(false)
     })
 
     it('should handle unknown error codes gracefully', () => {
@@ -1243,7 +1603,7 @@ describe('StreamManagerV2', () => {
       // Destroy should stop stream and remove listeners
       manager.destroy()
 
-      expect(manager.getState()).toBe(StreamState.Stopped)
+      expect(manager.getState()).toBe(StreamState.Destroyed)
 
       // Wait a bit to ensure no more events are emitted
       const countBeforeWait = eventCount

--- a/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.ts
@@ -142,6 +142,12 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
   }
 
   public start(): void {
+    if (this.isDestroyed) {
+      throw new Error(
+        `Cannot start destroyed stream manager: ${this.config.id}`,
+      )
+    }
+
     if (this.state !== StreamState.Idle && this.state !== StreamState.Stopped) {
       this.emit(StreamEvent.Warn, {
         message: `Stream already started (state: ${this.state})`,
@@ -166,8 +172,29 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
    * Call this when the stream manager is no longer needed
    */
   public destroy(): void {
-    this.stop()
-    this.removeAllListeners()
+    if (this.isDestroyed) {
+      return
+    }
+
+    let teardownError: unknown
+    const captureTeardownError = (callback: () => void) => {
+      try {
+        callback()
+      } catch (error) {
+        teardownError ??= error
+      }
+    }
+
+    captureTeardownError(() => this.cleanupForDisconnect())
+    captureTeardownError(() => this.updateState(StreamState.Destroyed))
+    captureTeardownError(() =>
+      this.emitDisconnectEvent(StreamDisconnectReason.UserStopped, false),
+    )
+    captureTeardownError(() => this.removeAllListeners())
+
+    if (teardownError) {
+      throw teardownError
+    }
   }
 
   public getState(): StreamState {
@@ -175,6 +202,10 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
   }
 
   private updateState(newState: StreamState): void {
+    if (this.state === newState) {
+      return
+    }
+
     const oldState = this.state
 
     this.state = newState
@@ -182,13 +213,57 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
     this.emit(StreamEvent.StateChange, { from: oldState, to: newState })
   }
 
+  private get isDestroyed(): boolean {
+    return this.state === StreamState.Destroyed
+  }
+
+  private clearActiveConnection(): void {
+    this.clearSubscription()
+    this.clearStableConnectionTimeout()
+  }
+
+  private cleanupForDisconnect(): void {
+    this.clearActiveConnection()
+    this.clearRetryTimeout()
+  }
+
+  private emitDisconnectEvent(
+    reason: StreamDisconnectReason,
+    willRetry: boolean,
+  ): void {
+    this.emit(StreamEvent.Disconnect, {
+      reason,
+      willRetry,
+      attempt: this.retryAttempt,
+    })
+  }
+
   private clearSubscription(): void {
     if (!this.subscription) {
       return
     }
 
-    this.subscription.unsubscribe()
+    const subscription = this.subscription
     this.subscription = null
+
+    try {
+      subscription.unsubscribe()
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.name === 'AbortError' ||
+          error.message.toLowerCase().includes('signal is aborted'))
+      ) {
+        return
+      }
+
+      this.emit(StreamEvent.Warn, {
+        message:
+          error instanceof Error
+            ? `Stream unsubscribe failed: ${error.message}`
+            : 'Stream unsubscribe failed with unknown error',
+      })
+    }
   }
 
   private clearRetryTimeout(): void {
@@ -233,7 +308,7 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
   }
 
   private scheduleRetry(reason?: StreamDisconnectReason): void {
-    if (!this.config.retryConfig.enabled) {
+    if (this.isDestroyed || !this.config.retryConfig.enabled) {
       return
     }
 
@@ -246,6 +321,10 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
     }
 
     this.retryTimeoutId = setTimeout(() => {
+      if (this.isDestroyed) {
+        return
+      }
+
       this.retryAttempt++
 
       this.emit(StreamEvent.Retry, {
@@ -253,6 +332,10 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
         delayMs: nextBackoff,
         nextBackoff: this.calculateNextBackoff(reason),
       })
+
+      if (this.isDestroyed) {
+        return
+      }
 
       this.connect()
     }, nextBackoff)
@@ -296,6 +379,11 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
 
   private handleConnected(isReconnect: boolean): void {
     this.updateState(StreamState.Connected)
+
+    if (this.isDestroyed) {
+      return
+    }
+
     this.scheduleStableConnectionReset()
 
     this.emit(StreamEvent.Connect, {
@@ -336,36 +424,59 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
   }
 
   private handleDisconnect(reason: StreamDisconnectReason): void {
-    this.clearSubscription()
-    this.clearRetryTimeout()
-    this.clearStableConnectionTimeout()
+    this.cleanupForDisconnect()
 
-    // Determine if retry should be attempted based on disconnect reason
     const willRetry =
-      isRetryableReason(reason) && this.config.retryConfig.enabled
+      !this.isDestroyed &&
+      isRetryableReason(reason) &&
+      this.config.retryConfig.enabled
 
-    this.emit(StreamEvent.Disconnect, {
-      reason,
-      willRetry,
-      attempt: this.retryAttempt,
-    })
+    const nextState = this.isDestroyed
+      ? StreamState.Destroyed
+      : willRetry
+        ? StreamState.Reconnecting
+        : StreamState.Stopped
 
-    if (willRetry) {
-      this.updateState(StreamState.Reconnecting)
-      this.scheduleRetry(reason)
+    let disconnectError: unknown
+    const captureDisconnectError = (callback: () => void) => {
+      try {
+        callback()
+      } catch (error) {
+        disconnectError ??= error
+      }
+    }
+
+    captureDisconnectError(() => this.emitDisconnectEvent(reason, willRetry))
+
+    if (nextState === StreamState.Reconnecting) {
+      captureDisconnectError(() => this.updateState(StreamState.Reconnecting))
+      captureDisconnectError(() => this.scheduleRetry(reason))
     } else {
-      this.updateState(StreamState.Stopped)
+      captureDisconnectError(() => this.updateState(nextState))
+    }
+
+    if (disconnectError) {
+      throw disconnectError
     }
   }
 
   private connect(): void {
-    this.clearSubscription()
-    this.clearStableConnectionTimeout()
+    if (this.isDestroyed) {
+      throw new Error(
+        `Cannot connect destroyed stream manager: ${this.config.id}`,
+      )
+    }
 
     const isReconnect = this.state === StreamState.Reconnecting
+    this.clearActiveConnection()
+
     this.updateState(
       isReconnect ? StreamState.Reconnecting : StreamState.Connecting,
     )
+
+    if (this.isDestroyed) {
+      return
+    }
 
     try {
       this.subscription = this.config.streamFactory()

--- a/packages/sdk-ts/src/types/stream.ts
+++ b/packages/sdk-ts/src/types/stream.ts
@@ -52,6 +52,7 @@ export const StreamState = {
   Connected: 'connected',
   Reconnecting: 'reconnecting',
   Stopped: 'stopped',
+  Destroyed: 'destroyed',
 } as const
 
 export type StreamState = (typeof StreamState)[keyof typeof StreamState]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a terminal **Destroyed** stream state.
- **Bug Fixes**
  - Streams can no longer start/connect/retry after being destroyed, including during in-flight reconnect handling.
  - Destruction now performs immediate cleanup, cancels pending retries, and emits a final disconnect with `willRetry: false` (once), transitioning to **Destroyed**.
  - Repeated `destroy()` calls are safe no-ops; teardown is more robust—unsubscribe abort errors are suppressed, other failures emit warnings, and disconnect listener exceptions during destroy are handled cleanly.
- **Tests**
  - Expanded lifecycle and edge-case coverage for destruction semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->