### PR TITLE
fix(auction): map highestBidder from response.highestBidder

### DIFF
--- a/packages/sdk-ts/src/client/chain/transformers/ChainGrpcAuctionTransformer.ts
+++ b/packages/sdk-ts/src/client/chain/transformers/ChainGrpcAuctionTransformer.ts
@@ -66,7 +66,7 @@ export class ChainGrpcAuctionTransformer {
       ),
       auctionRound: Number(response.auctionRound),
       auctionClosingTime: Number(response.auctionClosingTime),
-      highestBidder: response.highestBidAmount,
+      highestBidder: response.highestBidder,
       highestBidAmount: response.highestBidAmount,
     }
   }


### PR DESCRIPTION
`ChainGrpcAuctionTransformer.currentBasketResponseToCurrentBasket` reads the bidder from `response.highestBidAmount`:

```ts
highestBidder: response.highestBidAmount,
highestBidAmount: response.highestBidAmount,
```

So `ChainGrpcAuctionApi.fetchCurrentBasket()` returns the **bid amount** in the `highestBidder` field instead of the bidder address. The proto response (`QueryCurrentAuctionBasketResponse`) exposes both `highestBidder` (field 4) and `highestBidAmount` (field 5); this maps each to its own field.

Verified on mainnet: the chain sends the correct address in field 4; only the SDK mapping was wrong

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Auction data now includes the highest bidder alongside the highest bid amount, improving the completeness of current basket details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->