### PR TITLE
fix(auction): expose injBasketMaxCap and biddersWhitelist in module params

### DIFF
--- a/packages/sdk-ts/src/client/chain/transformers/ChainGrpcAuctionTransformer.ts
+++ b/packages/sdk-ts/src/client/chain/transformers/ChainGrpcAuctionTransformer.ts
@@ -54,6 +54,8 @@ export class ChainGrpcAuctionTransformer {
     return {
       auctionPeriod: Number(params.auctionPeriod ?? 0n),
       minNextBidIncrementRate: params.minNextBidIncrementRate ?? '0',
+      injBasketMaxCap: params.injBasketMaxCap ?? '',
+      biddersWhitelist: params.biddersWhitelist ?? [],
     }
   }
 
@@ -93,6 +95,8 @@ export class ChainGrpcAuctionTransformer {
       params: {
         auctionPeriod: Number(params.auctionPeriod),
         minNextBidIncrementRate: params.minNextBidIncrementRate,
+        injBasketMaxCap: params.injBasketMaxCap ?? '',
+        biddersWhitelist: params.biddersWhitelist ?? [],
       },
       auctionRound: Number(state.auctionRound),
       highestBid: state.highestBid

--- a/packages/sdk-ts/src/client/chain/types/auction.ts
+++ b/packages/sdk-ts/src/client/chain/types/auction.ts
@@ -5,6 +5,7 @@ export interface AuctionParams {
   auctionPeriod: number
   minNextBidIncrementRate: string
   injBasketMaxCap: string
+  biddersWhitelist: string[]
 }
 
 export interface AuctionBid {
@@ -52,6 +53,8 @@ export interface AuctionModuleParams {
 export interface AuctionModuleStateParams {
   auctionPeriod: number
   minNextBidIncrementRate: string
+  injBasketMaxCap: string
+  biddersWhitelist: string[]
 }
 export interface AuctionModuleState {
   params?: AuctionModuleStateParams


### PR DESCRIPTION
`moduleParamsResponseToModuleParams` returns only two of the four fields the chain sends, dropping `injBasketMaxCap` and `biddersWhitelist`. `injBasketMaxCap` is already declared on `AuctionParams` but never populated (the type promises a `string`, the runtime value is `undefined`).

`biddersWhitelist` is the one that matters for correctness. When it is non-empty, the auction module rejects `MsgBid` from any sender not on the list (`ErrUnauthorized`) — on mainnet today it holds two addresses. A consumer reading the typed params has no way to discover that bidding is permissioned, because the field is stripped before it reaches them. The proto layer and the on-chain params both carry it; only the transformer drops it.

This adds both fields to `AuctionModuleStateParams` (and `biddersWhitelist` to `AuctionParams`) and maps them in the two transformer sites that build module params. The only constructors of `AuctionModuleStateParams` are those two sites, so nothing else changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added auction configuration details for the maximum basket cap and bidder whitelist.
  * Updated auction data returned by the SDK to consistently include these fields, with safe defaults when unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->