### PR TITLE
fix/uis-package-bump-automation

### DIFF
--- a/.github/workflows/package-bump.yaml
+++ b/.github/workflows/package-bump.yaml
@@ -247,4 +247,4 @@ jobs:
           gh_token: ${{ steps.app-token.outputs.token }}
           repository_url: InjectiveLabs/injective-uis
           repository_branch: dev
-          post_install_command: 'pnpm update:injectivelabs'
+          post_install_command: 'pnpm update:injectivelabs && pnpm bootstrap'

--- a/.github/workflows/package-bump.yaml
+++ b/.github/workflows/package-bump.yaml
@@ -223,7 +223,7 @@ jobs:
         with:
           gh_token: ${{ steps.app-token.outputs.token }}
           repository_url: injectiveLabs/injective-do-ui
-          repository_branch: master
+          repository_branch: dev
 
   package-bump-uis:
     name: 'Package bump UIS'


### PR DESCRIPTION
solution options
1. pnpm bootstrap to went through `nuxi prepare` step
2. to bypass pre-push as this is package bump process
3. other suggestion if have

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the package update workflow by adding an automatic bootstrap step after updates complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->