### PR TITLE
Chore/clean up v2 messages

### DIFF
--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -1,0 +1,70 @@
+name: Codex PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, synchronize]
+
+concurrency:
+  group: codex-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  codex-review:
+    if: |
+      github.event.pull_request.head.repo.fork == false &&
+      github.event.pull_request.draft == false &&
+      !startsWith(github.event.pull_request.head.ref, 'release/') &&
+      github.event.pull_request.title != 'chore: release'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Fetch PR diff
+        id: pr_diff
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          github-token: ${{ github.token }}
+          script: |
+            const MAX_DIFF_LENGTH = 100000
+            const pr = context.payload.pull_request
+
+            try {
+              const diff = await github.request(
+                'GET /repos/{owner}/{repo}/pulls/{pull_number}',
+                {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: pr.number,
+                  mediaType: { format: "diff" }
+                }
+              )
+
+              if (!diff.data) {
+                core.setFailed('PR diff response was empty')
+                return
+              }
+
+              const raw = String(diff.data)
+              if (raw.length > MAX_DIFF_LENGTH) {
+                core.setFailed(
+                  `PR diff exceeded ${MAX_DIFF_LENGTH} characters; refusing partial Codex review`
+                )
+                return
+              }
+
+              core.setOutput("diff", raw)
+            } catch (err) {
+              core.setFailed(`Failed to fetch PR diff: ${err.message}`)
+            }
+
+      - name: Codex Review
+        uses: InjectiveLabs/github-fe/actions/codex-review@447a04bef383ffc3bdc5d37f01c1de0aa4181212
+        with:
+          github-token: ${{ github.token }}
+          openai-api-key: ${{ secrets.OPENAI_FE_API_KEY }}
+          pr-diff: ${{ steps.pr_diff.outputs.diff }}
+          pr-title: ${{ github.event.pull_request.title }}
+          pr-body: ${{ github.event.pull_request.body }}
+          pr-number: ${{ github.event.pull_request.number }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Features
+
+* sdk-ts: expose RFQ websocket heartbeat `ping` events with `sentAt` metadata for taker and maker streams
+
+### Bug Fixes
+
+* sdk-ts: emit RFQ websocket heartbeat `ping` only after a successful heartbeat send
+
+
 ## [1.14.40](https://github.com/InjectiveLabs/injective-ts/compare/v1.14.35...v1.14.40) (2025-01-21)
 
 **Note:** Version bump only for package @injectivelabs/injective-ts

--- a/packages/sdk-ts/src/client/indexer/types/rfq.ts
+++ b/packages/sdk-ts/src/client/indexer/types/rfq.ts
@@ -214,6 +214,10 @@ export interface RFQMakerStreamAckData {
   status: string
 }
 
+export interface RFQStreamPingData {
+  sentAt: number
+}
+
 // # Event payloads for TakerStream
 export interface TakerStreamEvents {
   /** Received a quote from a maker */
@@ -232,6 +236,8 @@ export interface TakerStreamEvents {
   }
   /** Error received from server */
   error: RFQStreamErrorData
+  /** Heartbeat ping sent via the local transport */
+  ping: RFQStreamPingData
   /** Pong received (response to ping) */
   pong: void
   connect: {
@@ -288,6 +294,8 @@ export interface MakerStreamEvents {
   challenge: {
     challenge: RFQMakerChallenge
   }
+  /** Heartbeat ping sent via the local transport */
+  ping: RFQStreamPingData
   /** Pong received (response to ping) */
   pong: void
   connect: {

--- a/packages/sdk-ts/src/client/indexer/ws/README.md
+++ b/packages/sdk-ts/src/client/indexer/ws/README.md
@@ -58,6 +58,7 @@ High-level API for takers:
 - `quote` - Received a quote from a maker
 - `request_ack` - Request was acknowledged
 - `error` - Error received from server
+- `ping` - Heartbeat ping sent via the local transport, includes `sentAt`
 - `pong` - Pong received (response to ping)
 - `connect` - Connection established
 - `disconnect` - Connection closed
@@ -81,6 +82,7 @@ High-level API for makers:
 - `request` - Received an RFQ request from a taker
 - `quote_ack` - Quote was acknowledged
 - `error` - Error received from server
+- `ping` - Heartbeat ping sent via the local transport, includes `sentAt`
 - `pong` - Pong received (response to ping)
 - `connect` - Connection established
 - `disconnect` - Connection closed
@@ -108,6 +110,10 @@ takerStream.on('request_ack', ({ rfqId, status }) => {
 
 takerStream.on('error', ({ code, message }) => {
   console.error('Stream error:', code, message)
+})
+
+takerStream.on('ping', ({ sentAt }) => {
+  console.log('Heartbeat ping sent at:', sentAt)
 })
 
 // Connect to the stream
@@ -167,6 +173,10 @@ makerStream.on('quote_ack', ({ rfqId, status }) => {
 
 makerStream.on('error', ({ code, message }) => {
   console.error('Stream error:', code, message)
+})
+
+makerStream.on('ping', ({ sentAt }) => {
+  console.log('Heartbeat ping sent at:', sentAt)
 })
 
 // Connect to the stream

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
@@ -1,0 +1,95 @@
+import { vi } from 'vitest'
+import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
+import { WsState, WsDisconnectReason } from '../../types'
+import {
+  createPongFrame,
+  describeHeartbeatStreamBehavior,
+} from './heartbeatTestUtils.js'
+
+const { mockTransportInstances, MockGrpcWebSocketTransport } = vi.hoisted(
+  () => {
+    const mockTransportInstances: MockGrpcWebSocketTransport[] = []
+
+    class MockGrpcWebSocketTransport {
+      private listeners = new Map<string, Set<(data: any) => void>>()
+      private connected = false
+      send = vi.fn<(data: Uint8Array) => void>()
+
+      constructor(_config: unknown) {
+        mockTransportInstances.push(this)
+      }
+
+      getState(): WsState {
+        return this.connected ? WsState.Connected : WsState.Idle
+      }
+
+      isConnected(): boolean {
+        return this.connected
+      }
+
+      async connect(): Promise<void> {
+        this.connected = true
+        this.emit('connect', { isReconnect: false })
+      }
+
+      disconnect(): void {
+        this.connected = false
+        this.emit('disconnect', {
+          reason: WsDisconnectReason.UserStopped,
+          willRetry: false,
+        })
+      }
+
+      destroy(): void {
+        this.connected = false
+        this.listeners.clear()
+      }
+
+      on(event: string, listener: (data: any) => void): void {
+        if (!this.listeners.has(event)) {
+          this.listeners.set(event, new Set())
+        }
+
+        this.listeners.get(event)!.add(listener)
+      }
+
+      off(event: string, listener: (data: any) => void): void {
+        this.listeners.get(event)?.delete(listener)
+      }
+
+      emit(event: string, data: any): void {
+        this.listeners.get(event)?.forEach((listener) => listener(data))
+      }
+    }
+
+    return { mockTransportInstances, MockGrpcWebSocketTransport }
+  },
+)
+
+vi.mock('../GrpcWebSocketTransport.js', () => ({
+  GrpcWebSocketTransport: MockGrpcWebSocketTransport,
+}))
+
+import { IndexerWsMakerStream } from './IndexerWsMakerStream.js'
+
+function createMakerPongFrame() {
+  const response = InjectiveRFQExchangeRpcPb.MakerStreamResponse.create({
+    messageType: 'pong',
+  })
+
+  return createPongFrame(
+    InjectiveRFQExchangeRpcPb.MakerStreamResponse.toBinary(response),
+  )
+}
+
+describeHeartbeatStreamBehavior({
+  title: 'IndexerWsMakerStream heartbeat events',
+  mockTransportInstances,
+  createStream: (pingIntervalMs) =>
+    new IndexerWsMakerStream({
+      url: 'wss://rfq.example',
+      makerAddress: 'inj1maker',
+      ...(pingIntervalMs ? { pingIntervalMs } : {}),
+    }),
+  createPongFrame: createMakerPongFrame,
+})

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
 import { WsState, WsDisconnectReason } from '../../types'
+import { GrpcWebSocketCodec } from '../GrpcWebSocketCodec.js'
 import {
   createPongFrame,
   describeHeartbeatStreamBehavior,
@@ -92,4 +93,47 @@ describeHeartbeatStreamBehavior({
       ...(pingIntervalMs ? { pingIntervalMs } : {}),
     }),
   createPongFrame: createMakerPongFrame,
+})
+
+describe('IndexerWsMakerStream heartbeat encode failures', () => {
+  it('logs send failure and skips ping when ping encoding throws', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const encodeSpy = vi
+      .spyOn(GrpcWebSocketCodec, 'encodeMakerPing')
+      .mockImplementation(() => {
+        throw new Error('encode failed')
+      })
+
+    const stream = new IndexerWsMakerStream({
+      url: 'wss://rfq.example',
+      makerAddress: 'inj1maker',
+      pingIntervalMs: 100,
+    })
+    const pingListener = vi.fn()
+    stream.on('ping', pingListener)
+
+    await stream.connect()
+
+    const transport = mockTransportInstances.at(-1)
+    if (!transport) {
+      throw new Error('Expected mock transport instance')
+    }
+
+    vi.advanceTimersByTime(100)
+
+    expect(transport.send).not.toHaveBeenCalled()
+    expect(pingListener).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to send ping:',
+      expect.objectContaining({ message: 'encode failed' }),
+    )
+
+    encodeSpy.mockRestore()
+    errorSpy.mockRestore()
+    vi.useRealTimers()
+  })
 })

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.ts
@@ -259,8 +259,10 @@ export class IndexerWsMakerStream {
     this.pingInterval = setInterval(() => {
       if (this.isConnected()) {
         try {
+          const sentAt = Date.now()
           const pingMessage = GrpcWebSocketCodec.encodeMakerPing()
           this.transport.send(pingMessage)
+          this.emit('ping', { sentAt })
         } catch (error) {
           console.error('Failed to send ping:', error)
         }

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
@@ -1,0 +1,95 @@
+import { vi } from 'vitest'
+import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
+import { WsState, WsDisconnectReason } from '../../types'
+import {
+  createPongFrame,
+  describeHeartbeatStreamBehavior,
+} from './heartbeatTestUtils.js'
+
+const { mockTransportInstances, MockGrpcWebSocketTransport } = vi.hoisted(
+  () => {
+    const mockTransportInstances: MockGrpcWebSocketTransport[] = []
+
+    class MockGrpcWebSocketTransport {
+      private listeners = new Map<string, Set<(data: any) => void>>()
+      private connected = false
+      send = vi.fn<(data: Uint8Array) => void>()
+
+      constructor(_config: unknown) {
+        mockTransportInstances.push(this)
+      }
+
+      getState(): WsState {
+        return this.connected ? WsState.Connected : WsState.Idle
+      }
+
+      isConnected(): boolean {
+        return this.connected
+      }
+
+      async connect(): Promise<void> {
+        this.connected = true
+        this.emit('connect', { isReconnect: false })
+      }
+
+      disconnect(): void {
+        this.connected = false
+        this.emit('disconnect', {
+          reason: WsDisconnectReason.UserStopped,
+          willRetry: false,
+        })
+      }
+
+      destroy(): void {
+        this.connected = false
+        this.listeners.clear()
+      }
+
+      on(event: string, listener: (data: any) => void): void {
+        if (!this.listeners.has(event)) {
+          this.listeners.set(event, new Set())
+        }
+
+        this.listeners.get(event)!.add(listener)
+      }
+
+      off(event: string, listener: (data: any) => void): void {
+        this.listeners.get(event)?.delete(listener)
+      }
+
+      emit(event: string, data: any): void {
+        this.listeners.get(event)?.forEach((listener) => listener(data))
+      }
+    }
+
+    return { mockTransportInstances, MockGrpcWebSocketTransport }
+  },
+)
+
+vi.mock('../GrpcWebSocketTransport.js', () => ({
+  GrpcWebSocketTransport: MockGrpcWebSocketTransport,
+}))
+
+import { IndexerWsTakerStream } from './IndexerWsTakerStream.js'
+
+function createTakerPongFrame() {
+  const response = InjectiveRFQExchangeRpcPb.TakerStreamResponse.create({
+    messageType: 'pong',
+  })
+
+  return createPongFrame(
+    InjectiveRFQExchangeRpcPb.TakerStreamResponse.toBinary(response),
+  )
+}
+
+describeHeartbeatStreamBehavior({
+  title: 'IndexerWsTakerStream heartbeat events',
+  mockTransportInstances,
+  createStream: (pingIntervalMs) =>
+    new IndexerWsTakerStream({
+      url: 'wss://rfq.example',
+      requestAddress: 'inj1test',
+      ...(pingIntervalMs ? { pingIntervalMs } : {}),
+    }),
+  createPongFrame: createTakerPongFrame,
+})

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
@@ -1,6 +1,7 @@
 import { vi } from 'vitest'
 import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
 import { WsState, WsDisconnectReason } from '../../types'
+import { GrpcWebSocketCodec } from '../GrpcWebSocketCodec.js'
 import {
   createPongFrame,
   describeHeartbeatStreamBehavior,
@@ -92,4 +93,47 @@ describeHeartbeatStreamBehavior({
       ...(pingIntervalMs ? { pingIntervalMs } : {}),
     }),
   createPongFrame: createTakerPongFrame,
+})
+
+describe('IndexerWsTakerStream heartbeat encode failures', () => {
+  it('logs send failure and skips ping when ping encoding throws', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+    const errorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined)
+    const encodeSpy = vi
+      .spyOn(GrpcWebSocketCodec, 'encodeTakerPing')
+      .mockImplementation(() => {
+        throw new Error('encode failed')
+      })
+
+    const stream = new IndexerWsTakerStream({
+      url: 'wss://rfq.example',
+      requestAddress: 'inj1test',
+      pingIntervalMs: 100,
+    })
+    const pingListener = vi.fn()
+    stream.on('ping', pingListener)
+
+    await stream.connect()
+
+    const transport = mockTransportInstances.at(-1)
+    if (!transport) {
+      throw new Error('Expected mock transport instance')
+    }
+
+    vi.advanceTimersByTime(100)
+
+    expect(transport.send).not.toHaveBeenCalled()
+    expect(pingListener).not.toHaveBeenCalled()
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Failed to send ping:',
+      expect.objectContaining({ message: 'encode failed' }),
+    )
+
+    encodeSpy.mockRestore()
+    errorSpy.mockRestore()
+    vi.useRealTimers()
+  })
 })

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
@@ -236,8 +236,10 @@ export class IndexerWsTakerStream {
     this.pingInterval = setInterval(() => {
       if (this.isConnected()) {
         try {
+          const sentAt = Date.now()
           const pingMessage = GrpcWebSocketCodec.encodeTakerPing()
           this.transport.send(pingMessage)
+          this.emit('ping', { sentAt })
         } catch (error) {
           console.error('Failed to send ping:', error)
         }

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
@@ -1,0 +1,112 @@
+import { it, vi, expect, describe, afterEach, beforeEach } from 'vitest'
+
+type MockTransportInstance = {
+  send: ReturnType<typeof vi.fn<(data: Uint8Array) => void>>
+  emit: (event: string, data: any) => void
+}
+
+function getLatestTransport(mockTransportInstances: MockTransportInstance[]) {
+  const transport = mockTransportInstances.at(-1)
+
+  if (!transport) {
+    throw new Error('Expected mock transport instance')
+  }
+
+  return transport
+}
+
+function encodeGrpcFrame(payload: Uint8Array) {
+  const frame = new Uint8Array(5 + payload.length)
+
+  new DataView(frame.buffer).setUint32(1, payload.length, false)
+  frame.set(payload, 5)
+
+  return frame
+}
+
+export function createPongFrame(payload: Uint8Array) {
+  return encodeGrpcFrame(payload)
+}
+
+type HeartbeatStreamSpecOptions<TStream> = {
+  title: string
+  mockTransportInstances: MockTransportInstance[]
+  createStream: (pingIntervalMs?: number) => TStream
+  createPongFrame: () => Uint8Array
+}
+
+type HeartbeatStream = {
+  connect: () => Promise<void>
+  on: (event: 'ping' | 'pong', listener: (...args: any[]) => void) => void
+}
+
+export function describeHeartbeatStreamBehavior<
+  TStream extends HeartbeatStream,
+>(options: HeartbeatStreamSpecOptions<TStream>) {
+  describe(options.title, () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      options.mockTransportInstances.length = 0
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+      options.mockTransportInstances.length = 0
+    })
+
+    it('emits ping after a successful heartbeat send', async () => {
+      const stream = options.createStream(100)
+      const pingListener = vi.fn()
+
+      stream.on('ping', pingListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      vi.advanceTimersByTime(100)
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(pingListener).toHaveBeenCalledTimes(1)
+      expect(pingListener).toHaveBeenCalledWith({
+        sentAt: Date.parse('2026-07-27T00:00:00.100Z'),
+      })
+    })
+
+    it('does not emit ping when the heartbeat send throws', async () => {
+      const stream = options.createStream(100)
+      const pingListener = vi.fn()
+
+      stream.on('ping', pingListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      transport.send.mockImplementationOnce(() => {
+        throw new Error('send failed')
+      })
+
+      vi.advanceTimersByTime(100)
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(pingListener).not.toHaveBeenCalled()
+      expect(console.error).toHaveBeenCalledTimes(1)
+    })
+
+    it('continues to emit pong for heartbeat responses', async () => {
+      const stream = options.createStream()
+      const pongListener = vi.fn()
+
+      stream.on('pong', pongListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      transport.emit('message', options.createPongFrame().buffer)
+
+      expect(pongListener).toHaveBeenCalledTimes(1)
+    })
+  })
+}

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
@@ -95,6 +95,33 @@ export function describeHeartbeatStreamBehavior<
       expect(console.error).toHaveBeenCalledTimes(1)
     })
 
+    it('does not report a send failure when a ping listener throws', async () => {
+      const stream = options.createStream(100)
+
+      stream.on('ping', () => {
+        throw new Error('listener failed')
+      })
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+
+      vi.advanceTimersByTime(100)
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(console.error).toHaveBeenCalledTimes(1)
+      expect(console.error).toHaveBeenCalledWith(
+        'Error in ping listener:',
+        expect.objectContaining({
+          message: 'listener failed',
+        }),
+      )
+      expect(console.error).not.toHaveBeenCalledWith(
+        'Failed to send ping:',
+        expect.anything(),
+      )
+    })
+
     it('continues to emit pong for heartbeat responses', async () => {
       const stream = options.createStream()
       const pongListener = vi.fn()

--- a/packages/sdk-ts/src/core/modules/exchange/index.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/index.ts
@@ -8,6 +8,7 @@ import MsgRewardsOptOut from './msgs/MsgRewardsOptOut.js'
 import MsgCancelSpotOrder from './msgs/MsgCancelSpotOrder.js'
 import MsgRewardsOptOutV2 from './msgs/MsgRewardsOptOutV2.js'
 import MsgExternalTransfer from './msgs/MsgExternalTransfer.js'
+import MsgOffsetPositionV2 from './msgs/MsgOffsetPositionV2.js'
 import MsgBatchUpdateOrders from './msgs/MsgBatchUpdateOrders.js'
 import MsgLiquidatePosition from './msgs/MsgLiquidatePosition.js'
 import MsgCancelSpotOrderV2 from './msgs/MsgCancelSpotOrderV2.js'
@@ -17,9 +18,11 @@ import MsgExternalTransferV2 from './msgs/MsgExternalTransferV2.js'
 import MsgBatchUpdateOrdersV2 from './msgs/MsgBatchUpdateOrdersV2.js'
 import MsgLiquidatePositionV2 from './msgs/MsgLiquidatePositionV2.js'
 import MsgCancelPostOnlyModeV2 from './msgs/MsgCancelPostOnlyModeV2.js'
+import MsgSubaccountTransferV2 from './msgs/MsgSubaccountTransferV2.js'
 import MsgCreateSpotLimitOrder from './msgs/MsgCreateSpotLimitOrder.js'
 import MsgAuthorizeStakeGrants from './msgs/MsgAuthorizeStakeGrants.js'
 import MsgReclaimLockedFundsV2 from './msgs/MsgReclaimLockedFundsV2.js'
+import MsgActivateStakeGrantV2 from './msgs/MsgActivateStakeGrantV2.js'
 import MsgBatchCancelSpotOrders from './msgs/MsgBatchCancelSpotOrders.js'
 import MsgCancelDerivativeOrder from './msgs/MsgCancelDerivativeOrder.js'
 import MsgCreateSpotMarketOrder from './msgs/MsgCreateSpotMarketOrder.js'
@@ -27,6 +30,7 @@ import MsgIncreasePositionMargin from './msgs/MsgIncreasePositionMargin.js'
 import MsgDecreasePositionMargin from './msgs/MsgDecreasePositionMargin.js'
 import MsgAuthorizeStakeGrantsV2 from './msgs/MsgAuthorizeStakeGrantsV2.js'
 import MsgCreateSpotLimitOrderV2 from './msgs/MsgCreateSpotLimitOrderV2.js'
+import MsgActivatePostOnlyModeV2 from './msgs/MsgActivatePostOnlyModeV2.js'
 import MsgInstantSpotMarketLaunch from './msgs/MsgInstantSpotMarketLaunch.js'
 import MsgCancelDerivativeOrderV2 from './msgs/MsgCancelDerivativeOrderV2.js'
 import MsgBatchCancelSpotOrdersV2 from './msgs/MsgBatchCancelSpotOrdersV2.js'
@@ -36,6 +40,7 @@ import MsgCancelBinaryOptionsOrder from './msgs/MsgCancelBinaryOptionsOrder.js'
 import MsgIncreasePositionMarginV2 from './msgs/MsgIncreasePositionMarginV2.js'
 import MsgDecreasePositionMarginV2 from './msgs/MsgDecreasePositionMarginV2.js'
 import MsgInstantSpotMarketLaunchV2 from './msgs/MsgInstantSpotMarketLaunchV2.js'
+import MsgLiquidateCrossMarginPoolV2 from './msgs/MsgLiquidateCrossMarginPoolV2.js'
 import MsgCreateDerivativeLimitOrder from './msgs/MsgCreateDerivativeLimitOrder.js'
 import MsgCancelBinaryOptionsOrderV2 from './msgs/MsgCancelBinaryOptionsOrderV2.js'
 import MsgBatchCancelDerivativeOrders from './msgs/MsgBatchCancelDerivativeOrders.js'
@@ -44,6 +49,7 @@ import MsgCreateDerivativeLimitOrderV2 from './msgs/MsgCreateDerivativeLimitOrde
 import MsgCreateBinaryOptionsLimitOrder from './msgs/MsgCreateBinaryOptionsLimitOrder.js'
 import MsgBatchCancelDerivativeOrdersV2 from './msgs/MsgBatchCancelDerivativeOrdersV2.js'
 import MsgCreateDerivativeMarketOrderV2 from './msgs/MsgCreateDerivativeMarketOrderV2.js'
+import MsgUpdateSubaccountRiskProfileV2 from './msgs/MsgUpdateSubaccountRiskProfileV2.js'
 import MsgAdminUpdateBinaryOptionsMarket from './msgs/MsgAdminUpdateBinaryOptionsMarket.js'
 import MsgBatchCancelBinaryOptionsOrders from './msgs/MsgBatchCancelBinaryOptionsOrders.js'
 import MsgCreateBinaryOptionsMarketOrder from './msgs/MsgCreateBinaryOptionsMarketOrder.js'
@@ -93,8 +99,12 @@ export {
   MsgExternalTransferV2,
   MsgBatchUpdateOrdersV2,
   MsgLiquidatePositionV2,
+  MsgOffsetPositionV2,
   MsgReclaimLockedFundsV2,
+  MsgSubaccountTransferV2,
+  MsgActivateStakeGrantV2,
   MsgAuthorizeStakeGrantsV2,
+  MsgActivatePostOnlyModeV2,
   MsgCancelDerivativeOrderV2,
   MsgBatchCancelSpotOrdersV2,
   MsgCreateSpotLimitOrderV2,
@@ -103,6 +113,7 @@ export {
   MsgDecreasePositionMarginV2,
   MsgInstantSpotMarketLaunchV2,
   MsgCancelBinaryOptionsOrderV2,
+  MsgLiquidateCrossMarginPoolV2,
   MsgCreateDerivativeLimitOrderV2,
   MsgBatchCancelDerivativeOrdersV2,
   MsgCreateDerivativeMarketOrderV2,
@@ -112,6 +123,7 @@ export {
   MsgBatchCancelBinaryOptionsOrdersV2,
   MsgCreateBinaryOptionsMarketOrderV2,
   MsgInstantBinaryOptionsMarketLaunchV2,
+  MsgUpdateSubaccountRiskProfileV2,
 }
 
 export * from './utils/index.js'

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivatePostOnlyModeV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivatePostOnlyModeV2.spec.ts
@@ -1,60 +1,40 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
-import MsgSetDelegationTransferReceiversV2 from './MsgSetDelegationTransferReceiversV2.js'
+import MsgActivatePostOnlyModeV2 from './MsgActivatePostOnlyModeV2.js'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
 } from '../../../tx/eip712/eip712.js'
 import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
 
-const params: MsgSetDelegationTransferReceiversV2['params'] = {
+const params: MsgActivatePostOnlyModeV2['params'] = {
   sender: mockFactory.injectiveAddress,
-  receivers: [mockFactory.injectiveAddress2],
+  blocksAmount: 10,
 }
 
-const protoType = '/injective.exchange.v2.MsgSetDelegationTransferReceivers'
-const protoTypeAmino = 'exchange/MsgSetDelegationTransferReceivers'
-const protoParams = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const protoParamsAmino = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const message = MsgSetDelegationTransferReceiversV2.fromJSON(params)
+const protoType = '/injective.exchange.v2.MsgActivatePostOnlyMode'
+const protoTypeShort = 'exchange/MsgActivatePostOnlyMode'
+const message = MsgActivatePostOnlyModeV2.fromJSON(params)
 
-describe('MsgSetDelegationTransferReceiversV2', () => {
+describe('MsgActivatePostOnlyModeV2', () => {
   it('generates proper proto', () => {
-    const proto = message.toProto()
-
-    expect(proto).toStrictEqual(protoParams)
+    expect(message.toProto()).toStrictEqual(params)
   })
 
   it('generates proper data', () => {
-    const data = message.toData()
-
-    expect(data).toStrictEqual({
+    expect(message.toData()).toStrictEqual({
       '@type': protoType,
-      ...protoParams,
+      ...params,
     })
   })
 
   it('generates proper amino', () => {
-    const amino = message.toAmino()
-
-    expect(amino).toStrictEqual({
-      type: protoTypeAmino,
-      value: protoParamsAmino,
-    })
-  })
-
-  it('generates proper web3Gw', () => {
-    const web3 = message.toWeb3Gw()
-
-    expect(web3).toStrictEqual({
-      '@type': protoType,
-      ...protoParamsAmino,
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        blocks_amount: params.blocksAmount,
+      },
     })
   })
 
@@ -65,7 +45,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v1', async () => {
       const eip712TypedData = getEip712TypedData(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({
@@ -78,7 +57,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v2', async () => {
       const eip712TypedData = getEip712TypedDataV2(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivatePostOnlyModeV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivatePostOnlyModeV2.ts
@@ -1,0 +1,91 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+import type { TypedDataField } from '../../../tx/eip712/types.js'
+
+export declare namespace MsgActivatePostOnlyModeV2 {
+  export interface Params {
+    sender: string
+    blocksAmount: number
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgActivatePostOnlyMode
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgActivatePostOnlyModeV2 extends MsgBase<
+  MsgActivatePostOnlyModeV2.Params,
+  MsgActivatePostOnlyModeV2.Proto
+> {
+  static fromJSON(
+    params: MsgActivatePostOnlyModeV2.Params,
+  ): MsgActivatePostOnlyModeV2 {
+    return new MsgActivatePostOnlyModeV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgActivatePostOnlyMode.create({
+      sender: params.sender,
+      blocksAmount: params.blocksAmount,
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgActivatePostOnlyMode',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgActivatePostOnlyMode',
+      value: {
+        sender: proto.sender,
+        blocks_amount: proto.blocksAmount,
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgActivatePostOnlyMode',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgActivatePostOnlyMode',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgActivatePostOnlyMode.toBinary(
+      this.toProto(),
+    )
+  }
+
+  public toEip712Types(): Map<string, TypedDataField[]> {
+    const map = new Map<string, TypedDataField[]>()
+
+    map.set('MsgValue', [
+      { name: 'sender', type: 'string' },
+      { name: 'blocks_amount', type: 'uint32' },
+    ])
+
+    return map
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivateStakeGrantV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivateStakeGrantV2.spec.ts
@@ -1,60 +1,37 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
-import MsgSetDelegationTransferReceiversV2 from './MsgSetDelegationTransferReceiversV2.js'
+import MsgActivateStakeGrantV2 from './MsgActivateStakeGrantV2.js'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
 } from '../../../tx/eip712/eip712.js'
 import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
 
-const params: MsgSetDelegationTransferReceiversV2['params'] = {
+const params: MsgActivateStakeGrantV2['params'] = {
   sender: mockFactory.injectiveAddress,
-  receivers: [mockFactory.injectiveAddress2],
+  granter: mockFactory.injectiveAddress2,
 }
 
-const protoType = '/injective.exchange.v2.MsgSetDelegationTransferReceivers'
-const protoTypeAmino = 'exchange/MsgSetDelegationTransferReceivers'
-const protoParams = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const protoParamsAmino = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const message = MsgSetDelegationTransferReceiversV2.fromJSON(params)
+const protoType = '/injective.exchange.v2.MsgActivateStakeGrant'
+const protoTypeShort = 'exchange/MsgActivateStakeGrant'
+const message = MsgActivateStakeGrantV2.fromJSON(params)
 
-describe('MsgSetDelegationTransferReceiversV2', () => {
+describe('MsgActivateStakeGrantV2', () => {
   it('generates proper proto', () => {
-    const proto = message.toProto()
-
-    expect(proto).toStrictEqual(protoParams)
+    expect(message.toProto()).toStrictEqual(params)
   })
 
   it('generates proper data', () => {
-    const data = message.toData()
-
-    expect(data).toStrictEqual({
+    expect(message.toData()).toStrictEqual({
       '@type': protoType,
-      ...protoParams,
+      ...params,
     })
   })
 
   it('generates proper amino', () => {
-    const amino = message.toAmino()
-
-    expect(amino).toStrictEqual({
-      type: protoTypeAmino,
-      value: protoParamsAmino,
-    })
-  })
-
-  it('generates proper web3Gw', () => {
-    const web3 = message.toWeb3Gw()
-
-    expect(web3).toStrictEqual({
-      '@type': protoType,
-      ...protoParamsAmino,
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: params,
     })
   })
 
@@ -65,7 +42,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v1', async () => {
       const eip712TypedData = getEip712TypedData(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({
@@ -78,7 +54,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v2', async () => {
       const eip712TypedData = getEip712TypedDataV2(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivateStakeGrantV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgActivateStakeGrantV2.ts
@@ -1,0 +1,79 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgActivateStakeGrantV2 {
+  export interface Params {
+    sender: string
+    granter: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgActivateStakeGrant
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgActivateStakeGrantV2 extends MsgBase<
+  MsgActivateStakeGrantV2.Params,
+  MsgActivateStakeGrantV2.Proto
+> {
+  static fromJSON(
+    params: MsgActivateStakeGrantV2.Params,
+  ): MsgActivateStakeGrantV2 {
+    return new MsgActivateStakeGrantV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgActivateStakeGrant.create({
+      sender: params.sender,
+      granter: params.granter,
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgActivateStakeGrant',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgActivateStakeGrant',
+      value: {
+        sender: proto.sender,
+        granter: proto.granter,
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgActivateStakeGrant',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgActivateStakeGrant',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgActivateStakeGrant.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.spec.ts
@@ -1,5 +1,6 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
@@ -28,8 +29,58 @@ const params: MsgInstantBinaryOptionsMarketLaunchV2['params'] = {
 }
 
 const message = MsgInstantBinaryOptionsMarketLaunchV2.fromJSON(params)
+const openNotionalCap: InjectiveExchangeV2MarketPb.OpenNotionalCap = {
+  cap: {
+    oneofKind: 'capped',
+    capped: {
+      value: '1000',
+    },
+  },
+}
 
 describe('MsgInstantBinaryOptionsMarketLaunchV2', () => {
+  it('generates proper proto with human-readable decimals', () => {
+    const proto = message.toProto()
+
+    expect(proto.sender).toStrictEqual(params.proposer)
+    expect(proto.minPriceTickSize).toStrictEqual(params.market.minPriceTickSize)
+    expect(proto.minQuantityTickSize).toStrictEqual(
+      params.market.minQuantityTickSize,
+    )
+    expect(proto.minNotional).toStrictEqual(params.market.minNotional)
+    expect(proto.makerFeeRate).toStrictEqual(params.market.makerFeeRate)
+    expect(proto.takerFeeRate).toStrictEqual(params.market.takerFeeRate)
+  })
+
+  it('supports openNotionalCap', () => {
+    const msgWithOpenNotionalCap =
+      MsgInstantBinaryOptionsMarketLaunchV2.fromJSON({
+        ...params,
+        market: {
+          ...params.market,
+          openNotionalCap,
+        },
+      })
+
+    expect(msgWithOpenNotionalCap.toProto().openNotionalCap).toStrictEqual(
+      openNotionalCap,
+    )
+    expect(
+      (msgWithOpenNotionalCap.toWeb3Gw() as any).open_notional_cap,
+    ).toStrictEqual({
+      capped: {
+        value: '1000',
+      },
+    })
+    expect(
+      (msgWithOpenNotionalCap.toEip712V2() as any).open_notional_cap,
+    ).toStrictEqual({
+      capped: {
+        value: '1000.000000000000000000',
+      },
+    })
+  })
+
   describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
     const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
       messages: message,

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.ts
@@ -1,9 +1,10 @@
-import { toChainFormat } from '@injectivelabs/utils'
 import { GeneralException } from '@injectivelabs/exceptions'
 import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
 import * as InjectiveOracleV1Beta1OraclePb from '@injectivelabs/core-proto-ts-v2/generated/injective/oracle/v1beta1/oracle_pb'
 import { MsgBase } from '../../MsgBase.js'
+import { toOpenNotionalCap } from './utils/openNotionalCap.js'
 import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+import type * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
 
 export declare namespace MsgInstantBinaryOptionsMarketLaunchV2 {
   export interface Params {
@@ -23,6 +24,7 @@ export declare namespace MsgInstantBinaryOptionsMarketLaunchV2 {
       minPriceTickSize: string
       minQuantityTickSize: string
       minNotional: string
+      openNotionalCap?: InjectiveExchangeV2MarketPb.OpenNotionalCap
     }
   }
 
@@ -50,6 +52,9 @@ const createMessage = (
       minPriceTickSize: params.market.minPriceTickSize,
       minQuantityTickSize: params.market.minQuantityTickSize,
       minNotional: params.market.minNotional,
+      ...(params.market.openNotionalCap && {
+        openNotionalCap: params.market.openNotionalCap,
+      }),
     })
 
   return message
@@ -69,29 +74,7 @@ export default class MsgInstantBinaryOptionsMarketLaunchV2 extends MsgBase<
   }
 
   public toProto() {
-    const { params: initialParams } = this
-
-    const params = {
-      ...initialParams,
-      market: {
-        ...initialParams.market,
-        minPriceTickSize: toChainFormat(
-          initialParams.market.minPriceTickSize,
-        ).toFixed(),
-        makerFeeRate: toChainFormat(
-          initialParams.market.makerFeeRate,
-        ).toFixed(),
-        takerFeeRate: toChainFormat(
-          initialParams.market.takerFeeRate,
-        ).toFixed(),
-        minQuantityTickSize: toChainFormat(
-          initialParams.market.minQuantityTickSize,
-        ).toFixed(),
-        minNotional: toChainFormat(initialParams.market.minNotional).toFixed(),
-      },
-    } as MsgInstantBinaryOptionsMarketLaunchV2.Params
-
-    return createMessage(params)
+    return createMessage(this.params)
   }
 
   public toData() {
@@ -121,6 +104,9 @@ export default class MsgInstantBinaryOptionsMarketLaunchV2 extends MsgBase<
       min_price_tick_size: params.market.minPriceTickSize,
       min_quantity_tick_size: params.market.minQuantityTickSize,
       min_notional: params.market.minNotional,
+      ...(params.market.openNotionalCap && {
+        open_notional_cap: toOpenNotionalCap(params.market.openNotionalCap),
+      }),
     }
 
     return {
@@ -164,7 +150,11 @@ export default class MsgInstantBinaryOptionsMarketLaunchV2 extends MsgBase<
       maker_fee_rate: numberToCosmosSdkDecString(params.market.makerFeeRate),
       oracle_type:
         InjectiveOracleV1Beta1OraclePb.OracleType[params.market.oracleType],
-      open_notional_cap: {},
+      open_notional_cap:
+        toOpenNotionalCap(
+          params.market.openNotionalCap,
+          numberToCosmosSdkDecString,
+        ) ?? {},
     }
 
     return messageAdjusted

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.spec.ts
@@ -35,6 +35,11 @@ describe('MsgInstantSpotMarketLaunchV2', () => {
     expect(proto.ticker).toStrictEqual(params.market.ticker)
     expect(proto.baseDenom).toStrictEqual(params.market.baseDenom)
     expect(proto.quoteDenom).toStrictEqual(params.market.quoteDenom)
+    expect(proto.minPriceTickSize).toStrictEqual(params.market.minPriceTickSize)
+    expect(proto.minQuantityTickSize).toStrictEqual(
+      params.market.minQuantityTickSize,
+    )
+    expect(proto.minNotional).toStrictEqual(params.market.minNotional)
   })
 
   it('generates proper data', () => {
@@ -43,6 +48,11 @@ describe('MsgInstantSpotMarketLaunchV2', () => {
     expect(data['@type']).toStrictEqual(protoType)
     expect(data.sender).toStrictEqual(params.proposer)
     expect(data.ticker).toStrictEqual(params.market.ticker)
+    expect(data.minPriceTickSize).toStrictEqual(params.market.minPriceTickSize)
+    expect(data.minQuantityTickSize).toStrictEqual(
+      params.market.minQuantityTickSize,
+    )
+    expect(data.minNotional).toStrictEqual(params.market.minNotional)
   })
 
   it('generates proper amino', () => {

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgInstantSpotMarketLaunchV2.ts
@@ -51,23 +51,7 @@ export default class MsgInstantSpotMarketLaunchV2 extends MsgBase<
   }
 
   public toProto() {
-    const { params: initialParams } = this
-
-    const params = {
-      ...initialParams,
-      market: {
-        ...initialParams.market,
-        minPriceTickSize: toChainFormat(
-          initialParams.market.minPriceTickSize,
-        ).toFixed(),
-        minQuantityTickSize: toChainFormat(
-          initialParams.market.minQuantityTickSize,
-        ).toFixed(),
-        minNotional: toChainFormat(initialParams.market.minNotional).toFixed(),
-      },
-    } as MsgInstantSpotMarketLaunchV2.Params
-
-    return createMessage(params)
+    return createMessage(this.params)
   }
 
   public toData() {

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidateCrossMarginPoolV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidateCrossMarginPoolV2.spec.ts
@@ -1,60 +1,42 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
-import MsgSetDelegationTransferReceiversV2 from './MsgSetDelegationTransferReceiversV2.js'
+import MsgLiquidateCrossMarginPoolV2 from './MsgLiquidateCrossMarginPoolV2.js'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
 } from '../../../tx/eip712/eip712.js'
 import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
 
-const params: MsgSetDelegationTransferReceiversV2['params'] = {
+const params: MsgLiquidateCrossMarginPoolV2['params'] = {
   sender: mockFactory.injectiveAddress,
-  receivers: [mockFactory.injectiveAddress2],
+  subaccountId: mockFactory.subaccountId,
+  quoteDenom: 'inj',
 }
 
-const protoType = '/injective.exchange.v2.MsgSetDelegationTransferReceivers'
-const protoTypeAmino = 'exchange/MsgSetDelegationTransferReceivers'
-const protoParams = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const protoParamsAmino = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const message = MsgSetDelegationTransferReceiversV2.fromJSON(params)
+const protoType = '/injective.exchange.v2.MsgLiquidateCrossMarginPool'
+const protoTypeShort = 'exchange/MsgLiquidateCrossMarginPool'
+const message = MsgLiquidateCrossMarginPoolV2.fromJSON(params)
 
-describe('MsgSetDelegationTransferReceiversV2', () => {
+describe('MsgLiquidateCrossMarginPoolV2', () => {
   it('generates proper proto', () => {
-    const proto = message.toProto()
-
-    expect(proto).toStrictEqual(protoParams)
+    expect(message.toProto()).toStrictEqual(params)
   })
 
   it('generates proper data', () => {
-    const data = message.toData()
-
-    expect(data).toStrictEqual({
+    expect(message.toData()).toStrictEqual({
       '@type': protoType,
-      ...protoParams,
+      ...params,
     })
   })
 
   it('generates proper amino', () => {
-    const amino = message.toAmino()
-
-    expect(amino).toStrictEqual({
-      type: protoTypeAmino,
-      value: protoParamsAmino,
-    })
-  })
-
-  it('generates proper web3Gw', () => {
-    const web3 = message.toWeb3Gw()
-
-    expect(web3).toStrictEqual({
-      '@type': protoType,
-      ...protoParamsAmino,
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        subaccount_id: params.subaccountId,
+        quote_denom: params.quoteDenom,
+      },
     })
   })
 
@@ -65,7 +47,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v1', async () => {
       const eip712TypedData = getEip712TypedData(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({
@@ -78,7 +59,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v2', async () => {
       const eip712TypedData = getEip712TypedDataV2(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidateCrossMarginPoolV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgLiquidateCrossMarginPoolV2.ts
@@ -1,0 +1,82 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgLiquidateCrossMarginPoolV2 {
+  export interface Params {
+    sender: string
+    subaccountId: string
+    quoteDenom: string
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgLiquidateCrossMarginPool
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgLiquidateCrossMarginPoolV2 extends MsgBase<
+  MsgLiquidateCrossMarginPoolV2.Params,
+  MsgLiquidateCrossMarginPoolV2.Proto
+> {
+  static fromJSON(
+    params: MsgLiquidateCrossMarginPoolV2.Params,
+  ): MsgLiquidateCrossMarginPoolV2 {
+    return new MsgLiquidateCrossMarginPoolV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgLiquidateCrossMarginPool.create({
+      sender: params.sender,
+      subaccountId: params.subaccountId,
+      quoteDenom: params.quoteDenom,
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgLiquidateCrossMarginPool',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgLiquidateCrossMarginPool',
+      value: {
+        sender: proto.sender,
+        subaccount_id: proto.subaccountId,
+        quote_denom: proto.quoteDenom,
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgLiquidateCrossMarginPool',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgLiquidateCrossMarginPool',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgLiquidateCrossMarginPool.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgOffsetPositionV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgOffsetPositionV2.spec.ts
@@ -1,60 +1,44 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
-import MsgSetDelegationTransferReceiversV2 from './MsgSetDelegationTransferReceiversV2.js'
+import MsgOffsetPositionV2 from './MsgOffsetPositionV2.js'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
 } from '../../../tx/eip712/eip712.js'
 import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
 
-const params: MsgSetDelegationTransferReceiversV2['params'] = {
+const params: MsgOffsetPositionV2['params'] = {
   sender: mockFactory.injectiveAddress,
-  receivers: [mockFactory.injectiveAddress2],
+  subaccountId: mockFactory.subaccountId,
+  marketId: mockFactory.injUsdtDerivativeMarket.marketId,
+  offsettingSubaccountIds: [mockFactory.subaccountId2],
 }
 
-const protoType = '/injective.exchange.v2.MsgSetDelegationTransferReceivers'
-const protoTypeAmino = 'exchange/MsgSetDelegationTransferReceivers'
-const protoParams = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const protoParamsAmino = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const message = MsgSetDelegationTransferReceiversV2.fromJSON(params)
+const protoType = '/injective.exchange.v2.MsgOffsetPosition'
+const protoTypeShort = 'exchange/MsgOffsetPosition'
+const message = MsgOffsetPositionV2.fromJSON(params)
 
-describe('MsgSetDelegationTransferReceiversV2', () => {
+describe('MsgOffsetPositionV2', () => {
   it('generates proper proto', () => {
-    const proto = message.toProto()
-
-    expect(proto).toStrictEqual(protoParams)
+    expect(message.toProto()).toStrictEqual(params)
   })
 
   it('generates proper data', () => {
-    const data = message.toData()
-
-    expect(data).toStrictEqual({
+    expect(message.toData()).toStrictEqual({
       '@type': protoType,
-      ...protoParams,
+      ...params,
     })
   })
 
   it('generates proper amino', () => {
-    const amino = message.toAmino()
-
-    expect(amino).toStrictEqual({
-      type: protoTypeAmino,
-      value: protoParamsAmino,
-    })
-  })
-
-  it('generates proper web3Gw', () => {
-    const web3 = message.toWeb3Gw()
-
-    expect(web3).toStrictEqual({
-      '@type': protoType,
-      ...protoParamsAmino,
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        subaccount_id: params.subaccountId,
+        market_id: params.marketId,
+        offsetting_subaccount_ids: params.offsettingSubaccountIds,
+      },
     })
   })
 
@@ -65,7 +49,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v1', async () => {
       const eip712TypedData = getEip712TypedData(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({
@@ -78,7 +61,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v2', async () => {
       const eip712TypedData = getEip712TypedDataV2(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgOffsetPositionV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgOffsetPositionV2.ts
@@ -1,0 +1,81 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgOffsetPositionV2 {
+  export interface Params {
+    sender: string
+    subaccountId: string
+    marketId: string
+    offsettingSubaccountIds: string[]
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgOffsetPosition
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgOffsetPositionV2 extends MsgBase<
+  MsgOffsetPositionV2.Params,
+  MsgOffsetPositionV2.Proto
+> {
+  static fromJSON(params: MsgOffsetPositionV2.Params): MsgOffsetPositionV2 {
+    return new MsgOffsetPositionV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgOffsetPosition.create({
+      sender: params.sender,
+      subaccountId: params.subaccountId,
+      marketId: params.marketId,
+      offsettingSubaccountIds: params.offsettingSubaccountIds,
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgOffsetPosition',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgOffsetPosition',
+      value: {
+        sender: proto.sender,
+        subaccount_id: proto.subaccountId,
+        market_id: proto.marketId,
+        offsetting_subaccount_ids: proto.offsettingSubaccountIds,
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgOffsetPosition',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgOffsetPosition',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgOffsetPosition.toBinary(this.toProto())
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.spec.ts
@@ -1,5 +1,10 @@
 import { mockFactory } from '@injectivelabs/utils/test-utils'
+import { prepareEip712 } from '@injectivelabs/utils/test-utils'
 import MsgReclaimLockedFundsV2 from './MsgReclaimLockedFundsV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
 
 const params: MsgReclaimLockedFundsV2['params'] = {
   sender: mockFactory.injectiveAddress,
@@ -24,11 +29,82 @@ describe('MsgReclaimLockedFundsV2', () => {
 
     expect(amino.type).toStrictEqual(protoTypeShort)
     expect(amino.value.sender).toStrictEqual(params.sender)
+    expect(amino.value.lockedAccountPubKey).toStrictEqual(
+      params.lockedAccountPubKey,
+    )
   })
 
-  it('throws for EIP712', () => {
-    expect(() => message.toWeb3Gw()).toThrow()
-    expect(() => message.toEip712()).toThrow()
-    expect(() => message.toEip712V2()).toThrow()
+  it('generates proper web3Gw', () => {
+    const web3 = message.toWeb3Gw()
+
+    expect(web3).toStrictEqual({
+      '@type': protoType,
+      sender: params.sender,
+      lockedAccountPubKey: params.lockedAccountPubKey,
+      signature: 'AQID',
+    })
+  })
+
+  it('generates uint8 arrays for EIP712 v1', () => {
+    expect(message.toEip712()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        lockedAccountPubKey: Array.from(
+          new TextEncoder().encode('test-pubkey'),
+        ),
+        signature: [1, 2, 3],
+      },
+    })
+    expect(message.toEip712Types().get('MsgValue')).toStrictEqual([
+      { name: 'sender', type: 'string' },
+      { name: 'lockedAccountPubKey', type: 'uint8[]' },
+      { name: 'signature', type: 'uint8[]' },
+    ])
+  })
+
+  describe('generates proper EIP712 payloads', () => {
+    const { eip712Args } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+      const expectedTypedData = {
+        ...eip712TypedData,
+        message: {
+          ...eip712TypedData.message,
+          msgs: [
+            {
+              type: protoTypeShort,
+              value: {
+                sender: params.sender,
+                lockedAccountPubKey: Array.from(
+                  message.toProto().lockedAccountPubKey,
+                ),
+                signature: Array.from(message.toProto().signature),
+              },
+            },
+          ],
+        },
+      }
+
+      expect(eip712TypedData).toStrictEqual(expectedTypedData)
+    })
+
+    it('EIP712 v2', () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+
+      expect(eip712TypedData.message.msgs).toStrictEqual(
+        JSON.stringify([
+          {
+            '@type': protoType,
+            sender: params.sender,
+            lockedAccountPubKey: params.lockedAccountPubKey,
+            signature: 'AQID',
+          },
+        ]),
+      )
+    })
   })
 })

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgReclaimLockedFundsV2.ts
@@ -1,10 +1,10 @@
-import { GeneralException } from '@injectivelabs/exceptions'
 import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
 import { MsgBase } from '../../MsgBase.js'
 import {
   base64ToUint8Array,
   uint8ArrayToBase64,
 } from '../../../../utils/encoding.js'
+import type { TypedDataField } from '../../../tx/eip712/types.js'
 
 export declare namespace MsgReclaimLockedFundsV2 {
   export interface Params {
@@ -65,22 +65,39 @@ export default class MsgReclaimLockedFundsV2 extends MsgBase<
     }
   }
 
-  public toWeb3Gw(): never {
-    throw new GeneralException(
-      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
-    )
+  public toWeb3Gw() {
+    const amino = this.toAmino()
+    const { value } = amino
+
+    return {
+      '@type': '/injective.exchange.v2.MsgReclaimLockedFunds',
+      ...value,
+    }
   }
 
-  public toEip712(): never {
-    throw new GeneralException(
-      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
-    )
+  public toEip712() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgReclaimLockedFunds',
+      value: {
+        sender: proto.sender,
+        lockedAccountPubKey: Array.from(proto.lockedAccountPubKey),
+        signature: Array.from(proto.signature),
+      },
+    }
   }
 
-  public toEip712V2(): never {
-    throw new GeneralException(
-      new Error('EIP712 is not supported for MsgReclaimLockedFunds.'),
-    )
+  public toEip712Types(): Map<string, TypedDataField[]> {
+    const map = new Map<string, TypedDataField[]>()
+
+    map.set('MsgValue', [
+      { name: 'sender', type: 'string' },
+      { name: 'lockedAccountPubKey', type: 'uint8[]' },
+      { name: 'signature', type: 'uint8[]' },
+    ])
+
+    return map
   }
 
   public toDirectSign() {

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSubaccountTransferV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSubaccountTransferV2.spec.ts
@@ -1,60 +1,57 @@
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
-import MsgSetDelegationTransferReceiversV2 from './MsgSetDelegationTransferReceiversV2.js'
+import MsgSubaccountTransferV2 from './MsgSubaccountTransferV2.js'
 import {
   getEip712TypedData,
   getEip712TypedDataV2,
 } from '../../../tx/eip712/eip712.js'
 import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
 
-const params: MsgSetDelegationTransferReceiversV2['params'] = {
+const params: MsgSubaccountTransferV2['params'] = {
   sender: mockFactory.injectiveAddress,
-  receivers: [mockFactory.injectiveAddress2],
+  sourceSubaccountId: mockFactory.subaccountId,
+  destinationSubaccountId: mockFactory.subaccountId2,
+  amount: {
+    denom: 'inj',
+    amount: '1000000000000000000',
+  },
 }
 
-const protoType = '/injective.exchange.v2.MsgSetDelegationTransferReceivers'
-const protoTypeAmino = 'exchange/MsgSetDelegationTransferReceivers'
-const protoParams = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const protoParamsAmino = {
-  sender: params.sender,
-  receivers: params.receivers,
-}
-const message = MsgSetDelegationTransferReceiversV2.fromJSON(params)
+const protoType = '/injective.exchange.v2.MsgSubaccountTransfer'
+const protoTypeShort = 'exchange/MsgSubaccountTransfer'
+const message = MsgSubaccountTransferV2.fromJSON(params)
 
-describe('MsgSetDelegationTransferReceiversV2', () => {
+describe('MsgSubaccountTransferV2', () => {
   it('generates proper proto', () => {
-    const proto = message.toProto()
-
-    expect(proto).toStrictEqual(protoParams)
+    expect(message.toProto()).toStrictEqual(params)
   })
 
   it('generates proper data', () => {
-    const data = message.toData()
-
-    expect(data).toStrictEqual({
+    expect(message.toData()).toStrictEqual({
       '@type': protoType,
-      ...protoParams,
+      ...params,
     })
   })
 
   it('generates proper amino', () => {
-    const amino = message.toAmino()
-
-    expect(amino).toStrictEqual({
-      type: protoTypeAmino,
-      value: protoParamsAmino,
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        source_subaccount_id: params.sourceSubaccountId,
+        destination_subaccount_id: params.destinationSubaccountId,
+        amount: params.amount,
+      },
     })
   })
 
   it('generates proper web3Gw', () => {
-    const web3 = message.toWeb3Gw()
-
-    expect(web3).toStrictEqual({
+    expect(message.toWeb3Gw()).toStrictEqual({
       '@type': protoType,
-      ...protoParamsAmino,
+      sender: params.sender,
+      source_subaccount_id: params.sourceSubaccountId,
+      destination_subaccount_id: params.destinationSubaccountId,
+      amount: params.amount,
     })
   })
 
@@ -65,7 +62,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v1', async () => {
       const eip712TypedData = getEip712TypedData(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({
@@ -78,7 +74,6 @@ describe('MsgSetDelegationTransferReceiversV2', () => {
 
     it('EIP712 v2', async () => {
       const eip712TypedData = getEip712TypedDataV2(eip712Args)
-
       const txResponse = await new IndexerGrpcWeb3GwApi(
         endpoints.indexer,
       ).prepareEip712Request({

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSubaccountTransferV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgSubaccountTransferV2.ts
@@ -1,0 +1,89 @@
+import * as CosmosBaseV1Beta1CoinPb from '@injectivelabs/core-proto-ts-v2/generated/cosmos/base/v1beta1/coin_pb'
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import { MsgBase } from '../../MsgBase.js'
+
+export declare namespace MsgSubaccountTransferV2 {
+  export interface Params {
+    sender: string
+    sourceSubaccountId: string
+    destinationSubaccountId: string
+    amount: {
+      amount: string
+      denom: string
+    }
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgSubaccountTransfer
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgSubaccountTransferV2 extends MsgBase<
+  MsgSubaccountTransferV2.Params,
+  MsgSubaccountTransferV2.Proto
+> {
+  static fromJSON(
+    params: MsgSubaccountTransferV2.Params,
+  ): MsgSubaccountTransferV2 {
+    return new MsgSubaccountTransferV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgSubaccountTransfer.create({
+      sender: params.sender,
+      sourceSubaccountId: params.sourceSubaccountId,
+      destinationSubaccountId: params.destinationSubaccountId,
+      amount: CosmosBaseV1Beta1CoinPb.Coin.create(params.amount),
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgSubaccountTransfer',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgSubaccountTransfer',
+      value: {
+        sender: proto.sender,
+        source_subaccount_id: proto.sourceSubaccountId,
+        destination_subaccount_id: proto.destinationSubaccountId,
+        amount: proto.amount,
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgSubaccountTransfer',
+      ...value,
+    }
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgSubaccountTransfer',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgSubaccountTransfer.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateDerivativeMarketV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateDerivativeMarketV2.spec.ts
@@ -1,6 +1,7 @@
 import snakecaseKeys from 'snakecase-keys'
 import { EIP712Version } from '@injectivelabs/ts-types'
 import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
 import * as InjectiveExchangeV2ProposalPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/proposal_pb'
 import MsgUpdateDerivativeMarketV2 from './MsgUpdateDerivativeMarketV2.js'
 import {
@@ -38,19 +39,20 @@ const protoParams = {
 }
 const protoParamsAmino = snakecaseKeys(protoParams)
 const message = MsgUpdateDerivativeMarketV2.fromJSON(params)
+const newOpenNotionalCap: InjectiveExchangeV2MarketPb.OpenNotionalCap = {
+  cap: {
+    oneofKind: 'capped',
+    capped: {
+      value: '1000',
+    },
+  },
+}
 
 describe('MsgUpdateDerivativeMarketV2', () => {
   it('generates proper proto', () => {
     const proto = message.toProto()
 
-    expect(proto).toStrictEqual({
-      ...protoParams,
-      newMinPriceTickSize: '100000000000',
-      newMinQuantityTickSize: '10000000000000000000',
-      newInitialMarginRatio: '50000000000000000',
-      newMaintenanceMarginRatio: '50000000000000000',
-      newReduceMarginRatio: '50000000000000000',
-    })
+    expect(proto).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -59,11 +61,6 @@ describe('MsgUpdateDerivativeMarketV2', () => {
     expect(data).toStrictEqual({
       '@type': protoType,
       ...protoParams,
-      newMinPriceTickSize: '100000000000',
-      newMinQuantityTickSize: '10000000000000000000',
-      newInitialMarginRatio: '50000000000000000',
-      newMaintenanceMarginRatio: '50000000000000000',
-      newReduceMarginRatio: '50000000000000000',
     })
   })
 
@@ -82,6 +79,31 @@ describe('MsgUpdateDerivativeMarketV2', () => {
     expect(web3).toStrictEqual({
       '@type': protoType,
       ...protoParamsAmino,
+    })
+  })
+
+  it('supports newOpenNotionalCap', () => {
+    const msgWithOpenNotionalCap = MsgUpdateDerivativeMarketV2.fromJSON({
+      ...params,
+      newOpenNotionalCap,
+    })
+
+    expect(msgWithOpenNotionalCap.toProto().newOpenNotionalCap).toStrictEqual(
+      newOpenNotionalCap,
+    )
+    expect(
+      (msgWithOpenNotionalCap.toWeb3Gw() as any).new_open_notional_cap,
+    ).toStrictEqual({
+      capped: {
+        value: '1000',
+      },
+    })
+    expect(
+      (msgWithOpenNotionalCap.toEip712V2() as any).new_open_notional_cap,
+    ).toStrictEqual({
+      capped: {
+        value: '1000.000000000000000000',
+      },
     })
   })
 

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateDerivativeMarketV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateDerivativeMarketV2.ts
@@ -1,8 +1,9 @@
-import { toChainFormat } from '@injectivelabs/utils'
 import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
 import * as InjectiveExchangeV2ProposalPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/proposal_pb'
 import { MsgBase } from '../../MsgBase.js'
+import { toOpenNotionalCap } from './utils/openNotionalCap.js'
 import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
+import type * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
 
 export declare namespace MsgUpdateDerivativeMarketV2 {
   export interface Params {
@@ -15,6 +16,7 @@ export declare namespace MsgUpdateDerivativeMarketV2 {
     newInitialMarginRatio?: string
     newMaintenanceMarginRatio?: string
     newReduceMarginRatio?: string
+    newOpenNotionalCap?: InjectiveExchangeV2MarketPb.OpenNotionalCap
     crossMarginEligibility?: InjectiveExchangeV2ProposalPb.CrossMarginEligibility
   }
 
@@ -36,6 +38,9 @@ const createMessage = (params: MsgUpdateDerivativeMarketV2.Params) => {
     newInitialMarginRatio: params.newInitialMarginRatio || '0',
     newMaintenanceMarginRatio: params.newMaintenanceMarginRatio || '0',
     newReduceMarginRatio: params.newReduceMarginRatio || '0',
+    ...(params.newOpenNotionalCap && {
+      newOpenNotionalCap: params.newOpenNotionalCap,
+    }),
     crossMarginEligibility:
       params.crossMarginEligibility ?? defaultCrossMarginEligibility,
   })
@@ -57,32 +62,7 @@ export default class MsgUpdateDerivativeMarketV2 extends MsgBase<
   }
 
   public toProto() {
-    const { params: initialParams } = this
-
-    const params = {
-      ...initialParams,
-      newMinNotional: toChainFormat(
-        initialParams.newMinNotional || '0',
-      ).toFixed(),
-      newMinQuantityTickSize: toChainFormat(
-        initialParams.newMinQuantityTickSize || '0',
-      ).toFixed(),
-      newMinPriceTickSize: toChainFormat(
-        initialParams.newMinPriceTickSize || '0',
-      ).toFixed(),
-      newInitialMarginRatio: toChainFormat(
-        initialParams.newInitialMarginRatio || '0',
-      ).toFixed(),
-      newMaintenanceMarginRatio: toChainFormat(
-        initialParams.newMaintenanceMarginRatio || '0',
-      ).toFixed(),
-      newReduceMarginRatio: toChainFormat(
-        initialParams.newReduceMarginRatio || '0',
-      ).toFixed(),
-      crossMarginEligibility: initialParams.crossMarginEligibility,
-    } as MsgUpdateDerivativeMarketV2.Params
-
-    return createMessage(params)
+    return createMessage(this.params)
   }
 
   public toData() {
@@ -106,6 +86,9 @@ export default class MsgUpdateDerivativeMarketV2 extends MsgBase<
       new_initial_margin_ratio: params.newInitialMarginRatio,
       new_maintenance_margin_ratio: params.newMaintenanceMarginRatio,
       new_reduce_margin_ratio: params.newReduceMarginRatio,
+      ...(params.newOpenNotionalCap && {
+        new_open_notional_cap: toOpenNotionalCap(params.newOpenNotionalCap),
+      }),
       cross_margin_eligibility:
         params.crossMarginEligibility ?? defaultCrossMarginEligibility,
     }
@@ -166,7 +149,11 @@ export default class MsgUpdateDerivativeMarketV2 extends MsgBase<
       new_reduce_margin_ratio: numberToCosmosSdkDecString(
         params.newReduceMarginRatio || '0',
       ),
-      new_open_notional_cap: {},
+      new_open_notional_cap:
+        toOpenNotionalCap(
+          params.newOpenNotionalCap,
+          numberToCosmosSdkDecString,
+        ) ?? {},
       cross_margin_eligibility:
         InjectiveExchangeV2ProposalPb.CrossMarginEligibility[
           params.crossMarginEligibility ?? defaultCrossMarginEligibility

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSpotMarketV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSpotMarketV2.spec.ts
@@ -33,11 +33,7 @@ describe('MsgUpdateSpotMarketV2', () => {
   it('generates proper proto', () => {
     const proto = message.toProto()
 
-    expect(proto).toStrictEqual({
-      ...protoParams,
-      newMinPriceTickSize: '100000000000',
-      newMinQuantityTickSize: '10000000000000000000',
-    })
+    expect(proto).toStrictEqual(protoParams)
   })
 
   it('generates proper data', () => {
@@ -46,8 +42,6 @@ describe('MsgUpdateSpotMarketV2', () => {
     expect(data).toStrictEqual({
       '@type': protoType,
       ...protoParams,
-      newMinPriceTickSize: '100000000000',
-      newMinQuantityTickSize: '10000000000000000000',
     })
   })
 

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSpotMarketV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSpotMarketV2.ts
@@ -1,4 +1,3 @@
-import { toChainFormat } from '@injectivelabs/utils'
 import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
 import { MsgBase } from '../../MsgBase.js'
 import { numberToCosmosSdkDecString } from '../../../../utils/numbers.js'
@@ -41,22 +40,7 @@ export default class MsgUpdateSpotMarketV2 extends MsgBase<
   }
 
   public toProto() {
-    const { params: initialParams } = this
-
-    const params = {
-      ...initialParams,
-      newMinNotional: toChainFormat(
-        initialParams.newMinNotional || '0',
-      ).toFixed(),
-      newMinQuantityTickSize: toChainFormat(
-        initialParams.newMinQuantityTickSize || '0',
-      ).toFixed(),
-      newMinPriceTickSize: toChainFormat(
-        initialParams.newMinPriceTickSize || '0',
-      ).toFixed(),
-    } as MsgUpdateSpotMarketV2.Params
-
-    return createMessage(params)
+    return createMessage(this.params)
   }
 
   public toData() {

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSubaccountRiskProfileV2.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSubaccountRiskProfileV2.spec.ts
@@ -1,0 +1,100 @@
+import { EIP712Version } from '@injectivelabs/ts-types'
+import { mockFactory, prepareEip712 } from '@injectivelabs/utils/test-utils'
+import * as InjectiveExchangeV2ExchangePb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/exchange_pb'
+import MsgUpdateSubaccountRiskProfileV2 from './MsgUpdateSubaccountRiskProfileV2.js'
+import {
+  getEip712TypedData,
+  getEip712TypedDataV2,
+} from '../../../tx/eip712/eip712.js'
+import { IndexerGrpcWeb3GwApi } from './../../../../client/indexer/grpc/IndexerGrpcWeb3GwApi.js'
+
+const params: MsgUpdateSubaccountRiskProfileV2['params'] = {
+  sender: mockFactory.injectiveAddress,
+  subaccountId: mockFactory.subaccountId,
+  riskProfile: {
+    mode: InjectiveExchangeV2ExchangePb.RiskMode.CROSS,
+    reservationPolicy:
+      InjectiveExchangeV2ExchangePb.ReservationPolicy.FULL_HOLD,
+    creditLineId: '',
+  },
+}
+
+const protoType = '/injective.exchange.v2.MsgUpdateSubaccountRiskProfile'
+const protoTypeShort = 'exchange/MsgUpdateSubaccountRiskProfile'
+const message = MsgUpdateSubaccountRiskProfileV2.fromJSON(params)
+
+describe('MsgUpdateSubaccountRiskProfileV2', () => {
+  it('generates proper proto', () => {
+    expect(message.toProto()).toStrictEqual(params)
+  })
+
+  it('generates proper data', () => {
+    expect(message.toData()).toStrictEqual({
+      '@type': protoType,
+      ...params,
+    })
+  })
+
+  it('generates proper amino', () => {
+    expect(message.toAmino()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        subaccount_id: params.subaccountId,
+        risk_profile: {
+          mode: params.riskProfile.mode,
+          reservation_policy: params.riskProfile.reservationPolicy,
+          credit_line_id: params.riskProfile.creditLineId,
+        },
+      },
+    })
+  })
+
+  it('matches chain-compatible EIP712 v1 risk profile fields', () => {
+    expect(message.toEip712()).toStrictEqual({
+      type: protoTypeShort,
+      value: {
+        sender: params.sender,
+        subaccount_id: params.subaccountId,
+        risk_profile: {
+          mode: params.riskProfile.mode,
+          reservation_policy: params.riskProfile.reservationPolicy,
+        },
+      },
+    })
+    expect(message.toEip712Types().get('TypeRiskProfile')).toStrictEqual([
+      { name: 'mode', type: 'int32' },
+      { name: 'reservation_policy', type: 'int32' },
+    ])
+  })
+
+  describe('generates proper EIP712 compared to the Web3Gw (chain)', () => {
+    const { endpoints, eip712Args, prepareEip712Request } = prepareEip712({
+      messages: message,
+    })
+
+    it('EIP712 v1', async () => {
+      const eip712TypedData = getEip712TypedData(eip712Args)
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V1,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+
+    it('EIP712 v2', async () => {
+      const eip712TypedData = getEip712TypedDataV2(eip712Args)
+      const txResponse = await new IndexerGrpcWeb3GwApi(
+        endpoints.indexer,
+      ).prepareEip712Request({
+        ...prepareEip712Request,
+        eip712Version: EIP712Version.V2,
+      })
+
+      expect(eip712TypedData).toStrictEqual(JSON.parse(txResponse.data))
+    })
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSubaccountRiskProfileV2.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/MsgUpdateSubaccountRiskProfileV2.ts
@@ -1,0 +1,151 @@
+import * as InjectiveExchangeV2TxPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/tx_pb'
+import * as InjectiveExchangeV2ExchangePb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/exchange_pb'
+import { MsgBase } from '../../MsgBase.js'
+import type { TypedDataField } from '../../../tx/eip712/types.js'
+
+export declare namespace MsgUpdateSubaccountRiskProfileV2 {
+  export interface Params {
+    sender: string
+    subaccountId: string
+    riskProfile: InjectiveExchangeV2ExchangePb.SubaccountRiskProfile
+  }
+
+  export type Proto = InjectiveExchangeV2TxPb.MsgUpdateSubaccountRiskProfile
+}
+
+const riskProfileToWeb3Gw = (
+  riskProfile?: InjectiveExchangeV2ExchangePb.SubaccountRiskProfile,
+  useEnumNames = false,
+) => {
+  if (!riskProfile) {
+    return undefined
+  }
+
+  return {
+    mode: useEnumNames
+      ? `RISK_MODE_${InjectiveExchangeV2ExchangePb.RiskMode[riskProfile.mode]}`
+      : riskProfile.mode,
+    reservation_policy: useEnumNames
+      ? `RESERVATION_POLICY_${
+          InjectiveExchangeV2ExchangePb.ReservationPolicy[
+            riskProfile.reservationPolicy
+          ]
+        }`
+      : riskProfile.reservationPolicy,
+    credit_line_id: riskProfile.creditLineId,
+  }
+}
+
+/**
+ * @category Messages
+ */
+export default class MsgUpdateSubaccountRiskProfileV2 extends MsgBase<
+  MsgUpdateSubaccountRiskProfileV2.Params,
+  MsgUpdateSubaccountRiskProfileV2.Proto
+> {
+  static fromJSON(
+    params: MsgUpdateSubaccountRiskProfileV2.Params,
+  ): MsgUpdateSubaccountRiskProfileV2 {
+    return new MsgUpdateSubaccountRiskProfileV2(params)
+  }
+
+  public toProto() {
+    const { params } = this
+
+    return InjectiveExchangeV2TxPb.MsgUpdateSubaccountRiskProfile.create({
+      sender: params.sender,
+      subaccountId: params.subaccountId,
+      riskProfile: params.riskProfile,
+    })
+  }
+
+  public toData() {
+    const proto = this.toProto()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgUpdateSubaccountRiskProfile',
+      ...proto,
+    }
+  }
+
+  public toAmino() {
+    const proto = this.toProto()
+
+    return {
+      type: 'exchange/MsgUpdateSubaccountRiskProfile',
+      value: {
+        sender: proto.sender,
+        subaccount_id: proto.subaccountId,
+        risk_profile: riskProfileToWeb3Gw(proto.riskProfile),
+      },
+    }
+  }
+
+  public toWeb3Gw() {
+    const { value } = this.toAmino()
+
+    return {
+      '@type': '/injective.exchange.v2.MsgUpdateSubaccountRiskProfile',
+      ...value,
+    }
+  }
+
+  public toEip712V2() {
+    const { params } = this
+    const web3gw = this.toWeb3Gw()
+
+    return {
+      ...web3gw,
+      risk_profile: riskProfileToWeb3Gw(params.riskProfile, true),
+    }
+  }
+
+  public toEip712() {
+    const amino = this.toAmino()
+    const { value, type } = amino
+    const riskProfile = (value as any).risk_profile
+
+    return {
+      type,
+      value: {
+        ...value,
+        risk_profile: {
+          mode: riskProfile.mode,
+          reservation_policy: riskProfile.reservation_policy,
+        },
+      },
+    }
+  }
+
+  public toEip712Types(): Map<string, TypedDataField[]> {
+    const map = new Map<string, TypedDataField[]>()
+
+    map.set('TypeRiskProfile', [
+      { name: 'mode', type: 'int32' },
+      { name: 'reservation_policy', type: 'int32' },
+    ])
+
+    map.set('MsgValue', [
+      { name: 'sender', type: 'string' },
+      { name: 'subaccount_id', type: 'string' },
+      { name: 'risk_profile', type: 'TypeRiskProfile' },
+    ])
+
+    return map
+  }
+
+  public toDirectSign() {
+    const proto = this.toProto()
+
+    return {
+      type: '/injective.exchange.v2.MsgUpdateSubaccountRiskProfile',
+      message: proto,
+    }
+  }
+
+  public toBinary(): Uint8Array {
+    return InjectiveExchangeV2TxPb.MsgUpdateSubaccountRiskProfile.toBinary(
+      this.toProto(),
+    )
+  }
+}

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/utils/openNotionalCap.spec.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/utils/openNotionalCap.spec.ts
@@ -1,0 +1,57 @@
+import { toOpenNotionalCap } from './openNotionalCap.js'
+import type * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
+
+describe('toOpenNotionalCap', () => {
+  it('returns undefined when not provided', () => {
+    expect(toOpenNotionalCap()).toBeUndefined()
+  })
+
+  it('throws when cap is missing', () => {
+    expect(() =>
+      toOpenNotionalCap({} as InjectiveExchangeV2MarketPb.OpenNotionalCap),
+    ).toThrow('Invalid OpenNotionalCap: missing cap union value')
+  })
+
+  it('returns uncapped when the proto union is uncapped', () => {
+    expect(
+      toOpenNotionalCap({
+        cap: {
+          oneofKind: 'uncapped',
+          uncapped: {},
+        },
+      }),
+    ).toStrictEqual({
+      uncapped: {},
+    })
+  })
+
+  it('formats capped values when the proto union is capped', () => {
+    expect(
+      toOpenNotionalCap(
+        {
+          cap: {
+            oneofKind: 'capped',
+            capped: {
+              value: '1000',
+            },
+          },
+        },
+        (value) => `formatted:${value}`,
+      ),
+    ).toStrictEqual({
+      capped: {
+        value: 'formatted:1000',
+      },
+    })
+  })
+
+  it('throws when the cap union kind is unsupported', () => {
+    expect(() =>
+      toOpenNotionalCap({
+        cap: {
+          oneofKind: 'unknown' as never,
+        } as InjectiveExchangeV2MarketPb.OpenNotionalCap['cap'],
+      }),
+    ).toThrow('Invalid OpenNotionalCap: unsupported cap kind unknown')
+  })
+})

--- a/packages/sdk-ts/src/core/modules/exchange/msgs/utils/openNotionalCap.ts
+++ b/packages/sdk-ts/src/core/modules/exchange/msgs/utils/openNotionalCap.ts
@@ -1,0 +1,32 @@
+import type * as InjectiveExchangeV2MarketPb from '@injectivelabs/core-proto-ts-v2/generated/injective/exchange/v2/market_pb'
+
+export const toOpenNotionalCap = (
+  openNotionalCap?: InjectiveExchangeV2MarketPb.OpenNotionalCap,
+  formatValue: (value: string) => string = (value) => value,
+) => {
+  if (!openNotionalCap) {
+    return undefined
+  }
+
+  const { cap } = openNotionalCap
+
+  if (!cap) {
+    throw new Error('Invalid OpenNotionalCap: missing cap union value')
+  }
+
+  if (cap.oneofKind === 'uncapped') {
+    return { uncapped: {} }
+  }
+
+  if (cap.oneofKind === 'capped') {
+    return {
+      capped: {
+        value: formatValue(cap.capped.value),
+      },
+    }
+  }
+
+  throw new Error(
+    `Invalid OpenNotionalCap: unsupported cap kind ${cap.oneofKind}`,
+  )
+}

--- a/packages/sdk-ts/src/core/modules/msgs.ts
+++ b/packages/sdk-ts/src/core/modules/msgs.ts
@@ -70,6 +70,32 @@ import type MsgCreateBinaryOptionsLimitOrder from './exchange/msgs/MsgCreateBina
 import type MsgAdminUpdateBinaryOptionsMarket from './exchange/msgs/MsgAdminUpdateBinaryOptionsMarket.js'
 import type MsgBatchCancelBinaryOptionsOrders from './exchange/msgs/MsgBatchCancelBinaryOptionsOrders.js'
 import type MsgCreateBinaryOptionsMarketOrder from './exchange/msgs/MsgCreateBinaryOptionsMarketOrder.js'
+import type MsgDepositV2 from './exchange/msgs/MsgDepositV2.js'
+import type MsgSignDataV2 from './exchange/msgs/MsgSignDataV2.js'
+import type MsgWithdrawV2 from './exchange/msgs/MsgWithdrawV2.js'
+import type MsgRewardsOptOutV2 from './exchange/msgs/MsgRewardsOptOutV2.js'
+import type MsgCancelSpotOrderV2 from './exchange/msgs/MsgCancelSpotOrderV2.js'
+import type MsgExternalTransferV2 from './exchange/msgs/MsgExternalTransferV2.js'
+import type MsgBatchUpdateOrdersV2 from './exchange/msgs/MsgBatchUpdateOrdersV2.js'
+import type MsgLiquidatePositionV2 from './exchange/msgs/MsgLiquidatePositionV2.js'
+import type MsgReclaimLockedFundsV2 from './exchange/msgs/MsgReclaimLockedFundsV2.js'
+import type MsgAuthorizeStakeGrantsV2 from './exchange/msgs/MsgAuthorizeStakeGrantsV2.js'
+import type MsgCreateSpotLimitOrderV2 from './exchange/msgs/MsgCreateSpotLimitOrderV2.js'
+import type MsgCancelDerivativeOrderV2 from './exchange/msgs/MsgCancelDerivativeOrderV2.js'
+import type MsgBatchCancelSpotOrdersV2 from './exchange/msgs/MsgBatchCancelSpotOrdersV2.js'
+import type MsgCreateSpotMarketOrderV2 from './exchange/msgs/MsgCreateSpotMarketOrderV2.js'
+import type MsgIncreasePositionMarginV2 from './exchange/msgs/MsgIncreasePositionMarginV2.js'
+import type MsgDecreasePositionMarginV2 from './exchange/msgs/MsgDecreasePositionMarginV2.js'
+import type MsgInstantSpotMarketLaunchV2 from './exchange/msgs/MsgInstantSpotMarketLaunchV2.js'
+import type MsgCancelBinaryOptionsOrderV2 from './exchange/msgs/MsgCancelBinaryOptionsOrderV2.js'
+import type MsgCreateDerivativeLimitOrderV2 from './exchange/msgs/MsgCreateDerivativeLimitOrderV2.js'
+import type MsgBatchCancelDerivativeOrdersV2 from './exchange/msgs/MsgBatchCancelDerivativeOrdersV2.js'
+import type MsgCreateDerivativeMarketOrderV2 from './exchange/msgs/MsgCreateDerivativeMarketOrderV2.js'
+import type MsgCreateBinaryOptionsLimitOrderV2 from './exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.js'
+import type MsgAdminUpdateBinaryOptionsMarketV2 from './exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.js'
+import type MsgBatchCancelBinaryOptionsOrdersV2 from './exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.js'
+import type MsgCreateBinaryOptionsMarketOrderV2 from './exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.js'
+import type MsgInstantBinaryOptionsMarketLaunchV2 from './exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.js'
 import type MsgSetDelegationTransferReceiversV2 from './exchange/msgs/MsgSetDelegationTransferReceiversV2.js'
 
 export type AuctionMsgs = MsgBid
@@ -120,6 +146,32 @@ export type ExchangeV1Msgs =
   | MsgBatchCancelBinaryOptionsOrders
   | MsgCreateBinaryOptionsMarketOrder
 export type ExchangeV2Msgs =
+  | MsgDepositV2
+  | MsgSignDataV2
+  | MsgWithdrawV2
+  | MsgRewardsOptOutV2
+  | MsgCancelSpotOrderV2
+  | MsgExternalTransferV2
+  | MsgBatchUpdateOrdersV2
+  | MsgLiquidatePositionV2
+  | MsgReclaimLockedFundsV2
+  | MsgAuthorizeStakeGrantsV2
+  | MsgCreateSpotLimitOrderV2
+  | MsgCancelDerivativeOrderV2
+  | MsgBatchCancelSpotOrdersV2
+  | MsgCreateSpotMarketOrderV2
+  | MsgIncreasePositionMarginV2
+  | MsgDecreasePositionMarginV2
+  | MsgInstantSpotMarketLaunchV2
+  | MsgCancelBinaryOptionsOrderV2
+  | MsgCreateDerivativeLimitOrderV2
+  | MsgBatchCancelDerivativeOrdersV2
+  | MsgCreateDerivativeMarketOrderV2
+  | MsgCreateBinaryOptionsLimitOrderV2
+  | MsgAdminUpdateBinaryOptionsMarketV2
+  | MsgBatchCancelBinaryOptionsOrdersV2
+  | MsgCreateBinaryOptionsMarketOrderV2
+  | MsgInstantBinaryOptionsMarketLaunchV2
   | MsgUpdateSpotMarketV2
   | MsgCancelPostOnlyModeV2
   | MsgUpdateDerivativeMarketV2

--- a/packages/sdk-ts/src/core/modules/msgs.ts
+++ b/packages/sdk-ts/src/core/modules/msgs.ts
@@ -17,7 +17,10 @@ import type MsgDelegate from './staking/msgs/MsgDelegate.js'
 import type MsgSignData from './exchange/msgs/MsgSignData.js'
 import type MsgWithdraw from './exchange/msgs/MsgWithdraw.js'
 import type MsgUpdateAdmin from './wasm/msgs/MsgUpdateAdmin.js'
+import type MsgDepositV2 from './exchange/msgs/MsgDepositV2.js'
 import type MsgUndelegate from './staking/msgs/MsgUndelegate.js'
+import type MsgSignDataV2 from './exchange/msgs/MsgSignDataV2.js'
+import type MsgWithdrawV2 from './exchange/msgs/MsgWithdrawV2.js'
 import type MsgUnderwrite from './insurance/msgs/MsgUnderwrite.js'
 import type MsgEditValidator from './staking/msgs/MsgEditValidator.js'
 import type MsgExec from './wasm/msgs/MsgPrivilegedExecuteContract.js'
@@ -35,68 +38,71 @@ import type MsgBeginRedelegate from './staking/msgs/MsgBeginRedelegate.js'
 import type MsgCreateValidator from './staking/msgs/MsgCreateValidator.js'
 import type MsgCancelSpotOrder from './exchange/msgs/MsgCancelSpotOrder.js'
 import type MsgRevokeAllowance from './feegrant/msgs/MsgRevokeAllowance.js'
+import type MsgRewardsOptOutV2 from './exchange/msgs/MsgRewardsOptOutV2.js'
 import type MsgExternalTransfer from './exchange/msgs/MsgExternalTransfer.js'
+import type MsgOffsetPositionV2 from './exchange/msgs/MsgOffsetPositionV2.js'
 import type MsgBatchUpdateOrders from './exchange/msgs/MsgBatchUpdateOrders.js'
 import type MsgLiquidatePosition from './exchange/msgs/MsgLiquidatePosition.js'
 import type MsgInstantiateContract from './wasm/msgs/MsgInstantiateContract.js'
+import type MsgCancelSpotOrderV2 from './exchange/msgs/MsgCancelSpotOrderV2.js'
 import type MsgRequestRedemption from './insurance/msgs/MsgRequestRedemption.js'
 import type MsgTransferDelegation from './staking/msgs/MsgTransferDelegation.js'
 import type MsgRelayProviderPrices from './oracle/msgs/MsgRelayProviderPrices.js'
 import type MsgReclaimLockedFunds from './exchange/msgs/MsgReclaimLockedFunds.js'
 import type MsgUpdateSpotMarketV2 from './exchange/msgs/MsgUpdateSpotMarketV2.js'
 import type MsgSetDenomMetadata from './tokenfactory/msgs/MsgSetDenomMetadata.js'
+import type MsgExternalTransferV2 from './exchange/msgs/MsgExternalTransferV2.js'
 import type MsgFundCommunityPool from './distribution/msgs/MsgFundCommunityPool.js'
 import type MsgExecuteContractCompat from './wasm/msgs/MsgExecuteContractCompat.js'
+import type MsgBatchUpdateOrdersV2 from './exchange/msgs/MsgBatchUpdateOrdersV2.js'
+import type MsgLiquidatePositionV2 from './exchange/msgs/MsgLiquidatePositionV2.js'
 import type MsgCreateInsuranceFund from './insurance/msgs/MsgCreateInsuranceFund.js'
 import type MsgAuthorizeStakeGrants from './exchange/msgs/MsgAuthorizeStakeGrants.js'
 import type MsgCreateSpotLimitOrder from './exchange/msgs/MsgCreateSpotLimitOrder.js'
 import type MsgCancelPostOnlyModeV2 from './exchange/msgs/MsgCancelPostOnlyModeV2.js'
+import type MsgReclaimLockedFundsV2 from './exchange/msgs/MsgReclaimLockedFundsV2.js'
+import type MsgSubaccountTransferV2 from './exchange/msgs/MsgSubaccountTransferV2.js'
+import type MsgActivateStakeGrantV2 from './exchange/msgs/MsgActivateStakeGrantV2.js'
 import type MsgGrantWithAuthorization from './authz/msgs/MsgGrantWithAuthorization.js'
 import type MsgBatchCancelSpotOrders from './exchange/msgs/MsgBatchCancelSpotOrders.js'
 import type MsgCancelDerivativeOrder from './exchange/msgs/MsgCancelDerivativeOrder.js'
 import type MsgCreateSpotMarketOrder from './exchange/msgs/MsgCreateSpotMarketOrder.js'
 import type MsgIncreasePositionMargin from './exchange/msgs/MsgIncreasePositionMargin.js'
 import type MsgDecreasePositionMargin from './exchange/msgs/MsgDecreasePositionMargin.js'
-import type MsgInstantSpotMarketLaunch from './exchange/msgs/MsgInstantSpotMarketLaunch.js'
-import type MsgCancelBinaryOptionsOrder from './exchange/msgs/MsgCancelBinaryOptionsOrder.js'
-import type MsgUpdateDerivativeMarketV2 from './exchange/msgs/MsgUpdateDerivativeMarketV2.js'
-import type MsgCancelUnbondingDelegation from './staking/msgs/MsgCancelUnbondingDelegation.js'
-import type MsgWithdrawDelegatorReward from './distribution/msgs/MsgWithdrawDelegatorReward.js'
-import type MsgCreateDerivativeLimitOrder from './exchange/msgs/MsgCreateDerivativeLimitOrder.js'
-import type MsgBatchCancelDerivativeOrders from './exchange/msgs/MsgBatchCancelDerivativeOrders.js'
-import type MsgCreateDerivativeMarketOrder from './exchange/msgs/MsgCreateDerivativeMarketOrder.js'
-import type MsgWithdrawValidatorCommission from './distribution/msgs/MsgWithdrawValidatorCommission.js'
-import type MsgCreateBinaryOptionsLimitOrder from './exchange/msgs/MsgCreateBinaryOptionsLimitOrder.js'
-import type MsgAdminUpdateBinaryOptionsMarket from './exchange/msgs/MsgAdminUpdateBinaryOptionsMarket.js'
-import type MsgBatchCancelBinaryOptionsOrders from './exchange/msgs/MsgBatchCancelBinaryOptionsOrders.js'
-import type MsgCreateBinaryOptionsMarketOrder from './exchange/msgs/MsgCreateBinaryOptionsMarketOrder.js'
-import type MsgDepositV2 from './exchange/msgs/MsgDepositV2.js'
-import type MsgSignDataV2 from './exchange/msgs/MsgSignDataV2.js'
-import type MsgWithdrawV2 from './exchange/msgs/MsgWithdrawV2.js'
-import type MsgRewardsOptOutV2 from './exchange/msgs/MsgRewardsOptOutV2.js'
-import type MsgCancelSpotOrderV2 from './exchange/msgs/MsgCancelSpotOrderV2.js'
-import type MsgExternalTransferV2 from './exchange/msgs/MsgExternalTransferV2.js'
-import type MsgBatchUpdateOrdersV2 from './exchange/msgs/MsgBatchUpdateOrdersV2.js'
-import type MsgLiquidatePositionV2 from './exchange/msgs/MsgLiquidatePositionV2.js'
-import type MsgReclaimLockedFundsV2 from './exchange/msgs/MsgReclaimLockedFundsV2.js'
 import type MsgAuthorizeStakeGrantsV2 from './exchange/msgs/MsgAuthorizeStakeGrantsV2.js'
 import type MsgCreateSpotLimitOrderV2 from './exchange/msgs/MsgCreateSpotLimitOrderV2.js'
+import type MsgActivatePostOnlyModeV2 from './exchange/msgs/MsgActivatePostOnlyModeV2.js'
+import type MsgInstantSpotMarketLaunch from './exchange/msgs/MsgInstantSpotMarketLaunch.js'
 import type MsgCancelDerivativeOrderV2 from './exchange/msgs/MsgCancelDerivativeOrderV2.js'
 import type MsgBatchCancelSpotOrdersV2 from './exchange/msgs/MsgBatchCancelSpotOrdersV2.js'
 import type MsgCreateSpotMarketOrderV2 from './exchange/msgs/MsgCreateSpotMarketOrderV2.js'
+import type MsgCancelBinaryOptionsOrder from './exchange/msgs/MsgCancelBinaryOptionsOrder.js'
+import type MsgUpdateDerivativeMarketV2 from './exchange/msgs/MsgUpdateDerivativeMarketV2.js'
 import type MsgIncreasePositionMarginV2 from './exchange/msgs/MsgIncreasePositionMarginV2.js'
 import type MsgDecreasePositionMarginV2 from './exchange/msgs/MsgDecreasePositionMarginV2.js'
+import type MsgCancelUnbondingDelegation from './staking/msgs/MsgCancelUnbondingDelegation.js'
+import type MsgWithdrawDelegatorReward from './distribution/msgs/MsgWithdrawDelegatorReward.js'
 import type MsgInstantSpotMarketLaunchV2 from './exchange/msgs/MsgInstantSpotMarketLaunchV2.js'
+import type MsgLiquidateCrossMarginPoolV2 from './exchange/msgs/MsgLiquidateCrossMarginPoolV2.js'
+import type MsgCreateDerivativeLimitOrder from './exchange/msgs/MsgCreateDerivativeLimitOrder.js'
 import type MsgCancelBinaryOptionsOrderV2 from './exchange/msgs/MsgCancelBinaryOptionsOrderV2.js'
+import type MsgBatchCancelDerivativeOrders from './exchange/msgs/MsgBatchCancelDerivativeOrders.js'
+import type MsgCreateDerivativeMarketOrder from './exchange/msgs/MsgCreateDerivativeMarketOrder.js'
 import type MsgCreateDerivativeLimitOrderV2 from './exchange/msgs/MsgCreateDerivativeLimitOrderV2.js'
+import type MsgWithdrawValidatorCommission from './distribution/msgs/MsgWithdrawValidatorCommission.js'
+import type MsgCreateBinaryOptionsLimitOrder from './exchange/msgs/MsgCreateBinaryOptionsLimitOrder.js'
 import type MsgBatchCancelDerivativeOrdersV2 from './exchange/msgs/MsgBatchCancelDerivativeOrdersV2.js'
 import type MsgCreateDerivativeMarketOrderV2 from './exchange/msgs/MsgCreateDerivativeMarketOrderV2.js'
+import type MsgUpdateSubaccountRiskProfileV2 from './exchange/msgs/MsgUpdateSubaccountRiskProfileV2.js'
+import type MsgAdminUpdateBinaryOptionsMarket from './exchange/msgs/MsgAdminUpdateBinaryOptionsMarket.js'
+import type MsgBatchCancelBinaryOptionsOrders from './exchange/msgs/MsgBatchCancelBinaryOptionsOrders.js'
+import type MsgCreateBinaryOptionsMarketOrder from './exchange/msgs/MsgCreateBinaryOptionsMarketOrder.js'
 import type MsgCreateBinaryOptionsLimitOrderV2 from './exchange/msgs/MsgCreateBinaryOptionsLimitOrderV2.js'
 import type MsgAdminUpdateBinaryOptionsMarketV2 from './exchange/msgs/MsgAdminUpdateBinaryOptionsMarketV2.js'
 import type MsgBatchCancelBinaryOptionsOrdersV2 from './exchange/msgs/MsgBatchCancelBinaryOptionsOrdersV2.js'
 import type MsgCreateBinaryOptionsMarketOrderV2 from './exchange/msgs/MsgCreateBinaryOptionsMarketOrderV2.js'
-import type MsgInstantBinaryOptionsMarketLaunchV2 from './exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.js'
 import type MsgSetDelegationTransferReceiversV2 from './exchange/msgs/MsgSetDelegationTransferReceiversV2.js'
+import type MsgInstantBinaryOptionsMarketLaunchV2 from './exchange/msgs/MsgInstantBinaryOptionsMarketLaunchV2.js'
 
 export type AuctionMsgs = MsgBid
 export type IbcMsgs = MsgTransfer
@@ -154,8 +160,12 @@ export type ExchangeV2Msgs =
   | MsgExternalTransferV2
   | MsgBatchUpdateOrdersV2
   | MsgLiquidatePositionV2
+  | MsgOffsetPositionV2
   | MsgReclaimLockedFundsV2
+  | MsgSubaccountTransferV2
+  | MsgActivateStakeGrantV2
   | MsgAuthorizeStakeGrantsV2
+  | MsgActivatePostOnlyModeV2
   | MsgCreateSpotLimitOrderV2
   | MsgCancelDerivativeOrderV2
   | MsgBatchCancelSpotOrdersV2
@@ -164,6 +174,7 @@ export type ExchangeV2Msgs =
   | MsgDecreasePositionMarginV2
   | MsgInstantSpotMarketLaunchV2
   | MsgCancelBinaryOptionsOrderV2
+  | MsgLiquidateCrossMarginPoolV2
   | MsgCreateDerivativeLimitOrderV2
   | MsgBatchCancelDerivativeOrdersV2
   | MsgCreateDerivativeMarketOrderV2
@@ -176,6 +187,7 @@ export type ExchangeV2Msgs =
   | MsgCancelPostOnlyModeV2
   | MsgUpdateDerivativeMarketV2
   | MsgSetDelegationTransferReceiversV2
+  | MsgUpdateSubaccountRiskProfileV2
 export type InsuranceMsgs =
   | MsgUnderwrite
   | MsgRequestRedemption

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       '@injectivelabs/olp-proto-ts-v2':
         specifier: 1.17.6
         version: 1.17.6
+      '@injectivelabs/platform-services-proto-ts-v2':
+        specifier: 1.0.0
+        version: 1.0.0
       '@injectivelabs/tc-abacus-proto-ts-v2':
         specifier: 1.18.6
         version: 1.18.6
@@ -680,6 +683,78 @@ importers:
       '@reown/appkit-adapter-ethers':
         specifier: 1.8.15
         version: 1.8.15(@ethersproject/sha2@5.8.0)(@types/react@19.2.10)(bufferutil@4.1.0)(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.0.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
+  protoV2/abacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/core/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/indexer/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/mito/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/olp/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/tcAbacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
 
 packages:
 
@@ -1181,6 +1256,9 @@ packages:
 
   '@injectivelabs/olp-proto-ts-v2@1.17.6':
     resolution: {integrity: sha512-3jTAyj342TXVe8qsVcDzAUnH5vAbqoHy5jqTUxHvJtfDaJ+X0uvN6d/yj60CxmrDOyKrn6pFx0prZ6J3Tl8S6g==}
+
+  '@injectivelabs/platform-services-proto-ts-v2@1.0.0':
+    resolution: {integrity: sha512-1j0S6k8moY6OQ5CzkqEiZsfNhwFaM85zOvYYcIun52sOWUAQN6dtib0s414ethyTJWWYCIrUQNv5YoJMBs1MVQ==}
 
   '@injectivelabs/string-decoder@1.3.0':
     resolution: {integrity: sha512-/SsVxTo7EKVP4WxEkrpbHC00Rfp15DcljOJa/BM33BcCIC+IiahEn4O9qXNTrSc0Nr3mLoONauKmkb+1z613kg==}
@@ -8661,6 +8739,12 @@ snapshots:
       '@protobuf-ts/runtime-rpc': 2.11.1
 
   '@injectivelabs/olp-proto-ts-v2@1.17.6':
+    dependencies:
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@injectivelabs/platform-services-proto-ts-v2@1.0.0':
     dependencies:
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for additional Exchange V2 messages, including transfers, liquidations, staking, position offsets, and risk-profile updates.
  * Added optional open-notional cap support for market launch and update messages.
  * RFQ WebSocket taker and maker streams now emit heartbeat `ping` events with send timestamps.
  * Added Web3 Gateway and EIP-712 support for reclaiming locked funds.

* **Bug Fixes**
  * Improved preservation of market precision and tick-size values during message serialization.
  * Heartbeat events now emit only after successful sends.

* **Documentation**
  * Updated RFQ WebSocket documentation and changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->