### PR TITLE
chore: add ping support on rfq stream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## Unreleased
+
+### Features
+
+* sdk-ts: expose RFQ websocket heartbeat `ping` events with `sentAt` metadata for taker and maker streams
+
+### Bug Fixes
+
+* sdk-ts: emit RFQ websocket heartbeat `ping` only after a successful heartbeat send
+
+
 ## [1.14.40](https://github.com/InjectiveLabs/injective-ts/compare/v1.14.35...v1.14.40) (2025-01-21)
 
 **Note:** Version bump only for package @injectivelabs/injective-ts

--- a/packages/sdk-ts/src/client/indexer/types/rfq.ts
+++ b/packages/sdk-ts/src/client/indexer/types/rfq.ts
@@ -214,6 +214,10 @@ export interface RFQMakerStreamAckData {
   status: string
 }
 
+export interface RFQStreamPingData {
+  sentAt: number
+}
+
 // # Event payloads for TakerStream
 export interface TakerStreamEvents {
   /** Received a quote from a maker */
@@ -232,6 +236,8 @@ export interface TakerStreamEvents {
   }
   /** Error received from server */
   error: RFQStreamErrorData
+  /** Heartbeat ping sent via the local transport */
+  ping: RFQStreamPingData
   /** Pong received (response to ping) */
   pong: void
   connect: {
@@ -288,6 +294,8 @@ export interface MakerStreamEvents {
   challenge: {
     challenge: RFQMakerChallenge
   }
+  /** Heartbeat ping sent via the local transport */
+  ping: RFQStreamPingData
   /** Pong received (response to ping) */
   pong: void
   connect: {

--- a/packages/sdk-ts/src/client/indexer/ws/README.md
+++ b/packages/sdk-ts/src/client/indexer/ws/README.md
@@ -58,6 +58,7 @@ High-level API for takers:
 - `quote` - Received a quote from a maker
 - `request_ack` - Request was acknowledged
 - `error` - Error received from server
+- `ping` - Heartbeat ping sent via the local transport, includes `sentAt`
 - `pong` - Pong received (response to ping)
 - `connect` - Connection established
 - `disconnect` - Connection closed
@@ -81,6 +82,7 @@ High-level API for makers:
 - `request` - Received an RFQ request from a taker
 - `quote_ack` - Quote was acknowledged
 - `error` - Error received from server
+- `ping` - Heartbeat ping sent via the local transport, includes `sentAt`
 - `pong` - Pong received (response to ping)
 - `connect` - Connection established
 - `disconnect` - Connection closed
@@ -108,6 +110,10 @@ takerStream.on('request_ack', ({ rfqId, status }) => {
 
 takerStream.on('error', ({ code, message }) => {
   console.error('Stream error:', code, message)
+})
+
+takerStream.on('ping', ({ sentAt }) => {
+  console.log('Heartbeat ping sent at:', sentAt)
 })
 
 // Connect to the stream
@@ -167,6 +173,10 @@ makerStream.on('quote_ack', ({ rfqId, status }) => {
 
 makerStream.on('error', ({ code, message }) => {
   console.error('Stream error:', code, message)
+})
+
+makerStream.on('ping', ({ sentAt }) => {
+  console.log('Heartbeat ping sent at:', sentAt)
 })
 
 // Connect to the stream

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.spec.ts
@@ -1,0 +1,95 @@
+import { vi } from 'vitest'
+import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
+import { WsState, WsDisconnectReason } from '../../types'
+import {
+  createPongFrame,
+  describeHeartbeatStreamBehavior,
+} from './heartbeatTestUtils.js'
+
+const { mockTransportInstances, MockGrpcWebSocketTransport } = vi.hoisted(
+  () => {
+    const mockTransportInstances: MockGrpcWebSocketTransport[] = []
+
+    class MockGrpcWebSocketTransport {
+      private listeners = new Map<string, Set<(data: any) => void>>()
+      private connected = false
+      send = vi.fn<(data: Uint8Array) => void>()
+
+      constructor(_config: unknown) {
+        mockTransportInstances.push(this)
+      }
+
+      getState(): WsState {
+        return this.connected ? WsState.Connected : WsState.Idle
+      }
+
+      isConnected(): boolean {
+        return this.connected
+      }
+
+      async connect(): Promise<void> {
+        this.connected = true
+        this.emit('connect', { isReconnect: false })
+      }
+
+      disconnect(): void {
+        this.connected = false
+        this.emit('disconnect', {
+          reason: WsDisconnectReason.UserStopped,
+          willRetry: false,
+        })
+      }
+
+      destroy(): void {
+        this.connected = false
+        this.listeners.clear()
+      }
+
+      on(event: string, listener: (data: any) => void): void {
+        if (!this.listeners.has(event)) {
+          this.listeners.set(event, new Set())
+        }
+
+        this.listeners.get(event)!.add(listener)
+      }
+
+      off(event: string, listener: (data: any) => void): void {
+        this.listeners.get(event)?.delete(listener)
+      }
+
+      emit(event: string, data: any): void {
+        this.listeners.get(event)?.forEach((listener) => listener(data))
+      }
+    }
+
+    return { mockTransportInstances, MockGrpcWebSocketTransport }
+  },
+)
+
+vi.mock('../GrpcWebSocketTransport.js', () => ({
+  GrpcWebSocketTransport: MockGrpcWebSocketTransport,
+}))
+
+import { IndexerWsMakerStream } from './IndexerWsMakerStream.js'
+
+function createMakerPongFrame() {
+  const response = InjectiveRFQExchangeRpcPb.MakerStreamResponse.create({
+    messageType: 'pong',
+  })
+
+  return createPongFrame(
+    InjectiveRFQExchangeRpcPb.MakerStreamResponse.toBinary(response),
+  )
+}
+
+describeHeartbeatStreamBehavior({
+  title: 'IndexerWsMakerStream heartbeat events',
+  mockTransportInstances,
+  createStream: (pingIntervalMs) =>
+    new IndexerWsMakerStream({
+      url: 'wss://rfq.example',
+      makerAddress: 'inj1maker',
+      ...(pingIntervalMs ? { pingIntervalMs } : {}),
+    }),
+  createPongFrame: createMakerPongFrame,
+})

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsMakerStream.ts
@@ -259,8 +259,10 @@ export class IndexerWsMakerStream {
     this.pingInterval = setInterval(() => {
       if (this.isConnected()) {
         try {
+          const sentAt = Date.now()
           const pingMessage = GrpcWebSocketCodec.encodeMakerPing()
           this.transport.send(pingMessage)
+          this.emit('ping', { sentAt })
         } catch (error) {
           console.error('Failed to send ping:', error)
         }

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
@@ -1,0 +1,95 @@
+import { vi } from 'vitest'
+import * as InjectiveRFQExchangeRpcPb from '@injectivelabs/indexer-proto-ts-v2/generated/injective_rfq_rpc_pb'
+import { WsState, WsDisconnectReason } from '../../types'
+import {
+  createPongFrame,
+  describeHeartbeatStreamBehavior,
+} from './heartbeatTestUtils.js'
+
+const { mockTransportInstances, MockGrpcWebSocketTransport } = vi.hoisted(
+  () => {
+    const mockTransportInstances: MockGrpcWebSocketTransport[] = []
+
+    class MockGrpcWebSocketTransport {
+      private listeners = new Map<string, Set<(data: any) => void>>()
+      private connected = false
+      send = vi.fn<(data: Uint8Array) => void>()
+
+      constructor(_config: unknown) {
+        mockTransportInstances.push(this)
+      }
+
+      getState(): WsState {
+        return this.connected ? WsState.Connected : WsState.Idle
+      }
+
+      isConnected(): boolean {
+        return this.connected
+      }
+
+      async connect(): Promise<void> {
+        this.connected = true
+        this.emit('connect', { isReconnect: false })
+      }
+
+      disconnect(): void {
+        this.connected = false
+        this.emit('disconnect', {
+          reason: WsDisconnectReason.UserStopped,
+          willRetry: false,
+        })
+      }
+
+      destroy(): void {
+        this.connected = false
+        this.listeners.clear()
+      }
+
+      on(event: string, listener: (data: any) => void): void {
+        if (!this.listeners.has(event)) {
+          this.listeners.set(event, new Set())
+        }
+
+        this.listeners.get(event)!.add(listener)
+      }
+
+      off(event: string, listener: (data: any) => void): void {
+        this.listeners.get(event)?.delete(listener)
+      }
+
+      emit(event: string, data: any): void {
+        this.listeners.get(event)?.forEach((listener) => listener(data))
+      }
+    }
+
+    return { mockTransportInstances, MockGrpcWebSocketTransport }
+  },
+)
+
+vi.mock('../GrpcWebSocketTransport.js', () => ({
+  GrpcWebSocketTransport: MockGrpcWebSocketTransport,
+}))
+
+import { IndexerWsTakerStream } from './IndexerWsTakerStream.js'
+
+function createTakerPongFrame() {
+  const response = InjectiveRFQExchangeRpcPb.TakerStreamResponse.create({
+    messageType: 'pong',
+  })
+
+  return createPongFrame(
+    InjectiveRFQExchangeRpcPb.TakerStreamResponse.toBinary(response),
+  )
+}
+
+describeHeartbeatStreamBehavior({
+  title: 'IndexerWsTakerStream heartbeat events',
+  mockTransportInstances,
+  createStream: (pingIntervalMs) =>
+    new IndexerWsTakerStream({
+      url: 'wss://rfq.example',
+      requestAddress: 'inj1test',
+      ...(pingIntervalMs ? { pingIntervalMs } : {}),
+    }),
+  createPongFrame: createTakerPongFrame,
+})

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
@@ -236,8 +236,10 @@ export class IndexerWsTakerStream {
     this.pingInterval = setInterval(() => {
       if (this.isConnected()) {
         try {
+          const sentAt = Date.now()
           const pingMessage = GrpcWebSocketCodec.encodeTakerPing()
           this.transport.send(pingMessage)
+          this.emit('ping', { sentAt })
         } catch (error) {
           console.error('Failed to send ping:', error)
         }

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/heartbeatTestUtils.ts
@@ -1,0 +1,112 @@
+import { it, vi, expect, describe, afterEach, beforeEach } from 'vitest'
+
+type MockTransportInstance = {
+  send: ReturnType<typeof vi.fn<(data: Uint8Array) => void>>
+  emit: (event: string, data: any) => void
+}
+
+function getLatestTransport(mockTransportInstances: MockTransportInstance[]) {
+  const transport = mockTransportInstances.at(-1)
+
+  if (!transport) {
+    throw new Error('Expected mock transport instance')
+  }
+
+  return transport
+}
+
+function encodeGrpcFrame(payload: Uint8Array) {
+  const frame = new Uint8Array(5 + payload.length)
+
+  new DataView(frame.buffer).setUint32(1, payload.length, false)
+  frame.set(payload, 5)
+
+  return frame
+}
+
+export function createPongFrame(payload: Uint8Array) {
+  return encodeGrpcFrame(payload)
+}
+
+type HeartbeatStreamSpecOptions<TStream> = {
+  title: string
+  mockTransportInstances: MockTransportInstance[]
+  createStream: (pingIntervalMs?: number) => TStream
+  createPongFrame: () => Uint8Array
+}
+
+type HeartbeatStream = {
+  connect: () => Promise<void>
+  on: (event: 'ping' | 'pong', listener: (...args: any[]) => void) => void
+}
+
+export function describeHeartbeatStreamBehavior<
+  TStream extends HeartbeatStream,
+>(options: HeartbeatStreamSpecOptions<TStream>) {
+  describe(options.title, () => {
+    beforeEach(() => {
+      vi.useFakeTimers()
+      vi.setSystemTime(new Date('2026-07-27T00:00:00.000Z'))
+      vi.spyOn(console, 'error').mockImplementation(() => undefined)
+      options.mockTransportInstances.length = 0
+    })
+
+    afterEach(() => {
+      vi.useRealTimers()
+      vi.restoreAllMocks()
+      options.mockTransportInstances.length = 0
+    })
+
+    it('emits ping after a successful heartbeat send', async () => {
+      const stream = options.createStream(100)
+      const pingListener = vi.fn()
+
+      stream.on('ping', pingListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      vi.advanceTimersByTime(100)
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(pingListener).toHaveBeenCalledTimes(1)
+      expect(pingListener).toHaveBeenCalledWith({
+        sentAt: Date.parse('2026-07-27T00:00:00.100Z'),
+      })
+    })
+
+    it('does not emit ping when the heartbeat send throws', async () => {
+      const stream = options.createStream(100)
+      const pingListener = vi.fn()
+
+      stream.on('ping', pingListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      transport.send.mockImplementationOnce(() => {
+        throw new Error('send failed')
+      })
+
+      vi.advanceTimersByTime(100)
+
+      expect(transport.send).toHaveBeenCalledTimes(1)
+      expect(pingListener).not.toHaveBeenCalled()
+      expect(console.error).toHaveBeenCalledTimes(1)
+    })
+
+    it('continues to emit pong for heartbeat responses', async () => {
+      const stream = options.createStream()
+      const pongListener = vi.fn()
+
+      stream.on('pong', pongListener)
+
+      await stream.connect()
+
+      const transport = getLatestTransport(options.mockTransportInstances)
+      transport.emit('message', options.createPongFrame().buffer)
+
+      expect(pongListener).toHaveBeenCalledTimes(1)
+    })
+  })
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       '@injectivelabs/olp-proto-ts-v2':
         specifier: 1.17.6
         version: 1.17.6
+      '@injectivelabs/platform-services-proto-ts-v2':
+        specifier: 1.0.0
+        version: 1.0.0
       '@injectivelabs/tc-abacus-proto-ts-v2':
         specifier: 1.18.6
         version: 1.18.6
@@ -680,6 +683,78 @@ importers:
       '@reown/appkit-adapter-ethers':
         specifier: 1.8.15
         version: 1.8.15(@ethersproject/sha2@5.8.0)(@types/react@19.2.10)(bufferutil@4.1.0)(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.0.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
+  protoV2/abacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/core/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/indexer/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/mito/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/olp/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/tcAbacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
 
 packages:
 
@@ -1181,6 +1256,9 @@ packages:
 
   '@injectivelabs/olp-proto-ts-v2@1.17.6':
     resolution: {integrity: sha512-3jTAyj342TXVe8qsVcDzAUnH5vAbqoHy5jqTUxHvJtfDaJ+X0uvN6d/yj60CxmrDOyKrn6pFx0prZ6J3Tl8S6g==}
+
+  '@injectivelabs/platform-services-proto-ts-v2@1.0.0':
+    resolution: {integrity: sha512-1j0S6k8moY6OQ5CzkqEiZsfNhwFaM85zOvYYcIun52sOWUAQN6dtib0s414ethyTJWWYCIrUQNv5YoJMBs1MVQ==}
 
   '@injectivelabs/string-decoder@1.3.0':
     resolution: {integrity: sha512-/SsVxTo7EKVP4WxEkrpbHC00Rfp15DcljOJa/BM33BcCIC+IiahEn4O9qXNTrSc0Nr3mLoONauKmkb+1z613kg==}
@@ -8661,6 +8739,12 @@ snapshots:
       '@protobuf-ts/runtime-rpc': 2.11.1
 
   '@injectivelabs/olp-proto-ts-v2@1.17.6':
+    dependencies:
+      '@protobuf-ts/grpcweb-transport': 2.11.1
+      '@protobuf-ts/runtime': 2.11.1
+      '@protobuf-ts/runtime-rpc': 2.11.1
+
+  '@injectivelabs/platform-services-proto-ts-v2@1.0.0':
     dependencies:
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - RFQ WebSocket streams now emit heartbeat `ping` events after successful sends.
  - Each event includes a `sentAt` timestamp showing when the heartbeat was sent.
  - Added documentation and usage examples for handling `ping` events.

- **Bug Fixes**
  - `ping` events are no longer emitted when sending the heartbeat fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->