### PR TITLE
chore: add grpc metadata logs

### DIFF
--- a/packages/exceptions/src/exceptions/base.spec.ts
+++ b/packages/exceptions/src/exceptions/base.spec.ts
@@ -36,6 +36,13 @@ describe('ConcreteException - Issue #259 Regression', () => {
     expect('contextCode' in object).toBe(false)
   })
 
+  it('omits undefined metadata in toObject()', () => {
+    const exception = new GrpcUnaryRequestException(new Error('test error'))
+    const object = exception.toObject()
+
+    expect('metadata' in object).toBe(false)
+  })
+
   it('preserves defined contextCode in toObject()', () => {
     const exception = new GrpcUnaryRequestException(new Error('test error'), {
       contextCode: 5,
@@ -45,6 +52,37 @@ describe('ConcreteException - Issue #259 Regression', () => {
     expect(object.contextCode).toBe(5)
   })
 
+  it('preserves defined metadata in toObject()', () => {
+    const exception = new GrpcUnaryRequestException(new Error('test error'), {
+      metadata: {
+        rawErrorName: 'RpcError',
+        retryAttempt: 3,
+        wasRetried: true,
+      },
+    })
+    const object = exception.toObject()
+
+    expect(object.metadata).toEqual({
+      rawErrorName: 'RpcError',
+      retryAttempt: 3,
+      wasRetried: true,
+    })
+  })
+
+  it('omits undefined metadata values in toObject()', () => {
+    const exception = new GrpcUnaryRequestException(new Error('test error'), {
+      metadata: {
+        rawErrorCode: undefined,
+        rawErrorName: 'RpcError',
+      },
+    })
+    const object = exception.toObject()
+
+    expect(object.metadata).toEqual({
+      rawErrorName: 'RpcError',
+    })
+  })
+
   it('omits undefined contextCode in toCompactError() details', () => {
     const exception = new GrpcUnaryRequestException(new Error('test error'))
     const compactError = exception.toCompactError()
@@ -52,6 +90,21 @@ describe('ConcreteException - Issue #259 Regression', () => {
     const details = JSON.parse(rawDetails)
 
     expect('contextCode' in details).toBe(false)
+  })
+
+  it('preserves defined metadata in toCompactError() details', () => {
+    const exception = new GrpcUnaryRequestException(new Error('test error'), {
+      metadata: {
+        rawErrorName: 'RpcError',
+      },
+    })
+    const compactError = exception.toCompactError()
+    const [, rawDetails] = compactError.message.split(' | ')
+    const details = JSON.parse(rawDetails)
+
+    expect(details.metadata).toEqual({
+      rawErrorName: 'RpcError',
+    })
   })
 })
 

--- a/packages/exceptions/src/exceptions/base.ts
+++ b/packages/exceptions/src/exceptions/base.ts
@@ -4,6 +4,7 @@ import type {
   ErrorCode,
   ErrorContext,
   ErrorContextCode,
+  ErrorContextMetadata,
 } from './types/index.js'
 
 /**
@@ -64,6 +65,11 @@ export abstract class ConcreteException extends Error implements Exception {
   public contextCode?: ErrorContextCode
 
   /**
+   * Structured diagnostics for observability.
+   */
+  public metadata?: ErrorContextMetadata
+
+  /**
    * Parsed message of the exception
    */
   public message: string = ''
@@ -97,13 +103,14 @@ export abstract class ConcreteException extends Error implements Exception {
   }
 
   public parseContext(errorContext?: ErrorContext) {
-    const { contextModule, type, code, context, contextCode } =
+    const { contextModule, type, code, context, contextCode, metadata } =
       errorContext || {
         contextModule: 'Unknown',
         context: 'Unknown',
         code: UnspecifiedErrorCode,
         type: ErrorType.Unspecified,
         contextCode: undefined,
+        metadata: undefined,
       }
 
     this.context = context
@@ -111,6 +118,7 @@ export abstract class ConcreteException extends Error implements Exception {
     this.type = type || ErrorType.Unspecified
     this.code = code || UnspecifiedErrorCode
     this.contextCode = contextCode
+    this.metadata = this.getMetadata(metadata)
   }
 
   public setType(type: ErrorType) {
@@ -150,6 +158,20 @@ export abstract class ConcreteException extends Error implements Exception {
     this.contextCode = code
   }
 
+  private getMetadata(metadata?: ErrorContextMetadata) {
+    if (!metadata) {
+      return
+    }
+
+    const sanitizedMetadata = Object.fromEntries(
+      Object.entries(metadata).filter(([, value]) => value !== undefined),
+    )
+
+    return Object.keys(sanitizedMetadata).length > 0
+      ? sanitizedMetadata
+      : undefined
+  }
+
   public toOriginalError(): Error {
     const error = new Error(this.originalMessage)
     error.stack = this.stack
@@ -176,6 +198,7 @@ export abstract class ConcreteException extends Error implements Exception {
       ...(this.contextCode !== undefined
         ? { contextCode: this.contextCode }
         : {}),
+      ...(this.metadata !== undefined ? { metadata: this.metadata } : {}),
       contextModule: this.contextModule,
       originalMessage: this.originalMessage,
       stack: (this.stack || '').split('\n').map((line) => line.trim()),

--- a/packages/exceptions/src/exceptions/types/context.ts
+++ b/packages/exceptions/src/exceptions/types/context.ts
@@ -1,5 +1,10 @@
 import type { ErrorCode, ErrorContextCode } from './codes.js'
 
+export type ErrorContextMetadata = Record<
+  string,
+  string | number | boolean | undefined
+>
+
 export const HttpRequestMethod = {
   Get: 'GET',
   Post: 'POST',
@@ -47,6 +52,12 @@ export interface ErrorContext {
   contextCode?: ErrorContextCode
 
   /**
+   * Structured diagnostics for observability. This is intentionally separate
+   * from context so consumers can keep relying on stable context strings.
+   */
+  metadata?: ErrorContextMetadata
+
+  /**
    * If true, skip parsing the error message and use the raw message
    * Useful when you want to preserve the original error message without
    * any transformation or mapping
@@ -81,6 +92,11 @@ export interface Exception {
    * (ex: on-chain error code, etc)
    */
   contextCode?: ErrorContextCode
+
+  /**
+   * Structured diagnostics for observability.
+   */
+  metadata?: ErrorContextMetadata
 
   /**
    * Parsed message of the exception

--- a/packages/exceptions/src/index.ts
+++ b/packages/exceptions/src/index.ts
@@ -1,3 +1,4 @@
 export * from './utils.js'
 export type * from './types.js'
 export * from './exceptions/index.js'
+export type * from './exceptions/types/index.js'

--- a/packages/sdk-ts/src/client/base/BaseGrpcConsumer.spec.ts
+++ b/packages/sdk-ts/src/client/base/BaseGrpcConsumer.spec.ts
@@ -86,6 +86,39 @@ describe('BaseGrpcConsumer', () => {
       await assertion
       expect(grpcCall).toHaveBeenCalledTimes(3)
     })
+
+    it('adds retry exhaustion details to wrapped errors', async () => {
+      vi.useFakeTimers()
+
+      const error = new RpcError('unavailable', 'UNAVAILABLE')
+      const grpcCall = vi.fn<() => Promise<string>>().mockRejectedValue(error)
+
+      const promise = consumer.retryCall(grpcCall, 3, 10)
+      const assertion = expect(promise).rejects.toBe(error)
+
+      await vi.runAllTimersAsync()
+      await assertion
+
+      try {
+        consumer.throwGrpcError(error, 'fetchPositions')
+        expect.unreachable('Expected handleGrpcError to throw')
+      } catch (e: unknown) {
+        expect(e).toBeInstanceOf(GrpcUnaryRequestException)
+
+        const exception = e as GrpcUnaryRequestException
+
+        expect(exception.context).toBe(
+          'fetchPositions (baseUrl: http://localhost:9090)',
+        )
+        expect(exception.metadata).toMatchObject({
+          wasRetried: true,
+          retryAttempt: 3,
+          retryMaxAttempts: 3,
+          retryDelayMs: 10,
+          retryStopReason: 'exhausted',
+        })
+      }
+    })
   })
 
   describe('handleGrpcError', () => {
@@ -110,6 +143,12 @@ describe('BaseGrpcConsumer', () => {
         expect(exception.context).toBe(
           'prepareFeeGrant (baseUrl: http://localhost:9090, rpc: injective_exchange_rpc.InjectiveExchangeRPC/PrepareFeeGrant)',
         )
+        expect(exception.metadata).toMatchObject({
+          rawErrorName: 'RpcError',
+          grpcStatusCode: 5,
+          grpcStatusName: 'NOT_FOUND',
+          isRetryableGrpcStatus: false,
+        })
         expect(exception.contextModule).toBe('test-module')
         expect(exception.contextCode).toBeUndefined()
       }
@@ -133,6 +172,11 @@ describe('BaseGrpcConsumer', () => {
         expect(exception.context).toBe(
           'prepareFeeGrant (baseUrl: http://localhost:9090)',
         )
+        expect(exception.metadata).toMatchObject({
+          rawErrorCode: '5',
+          grpcStatusCode: 5,
+          grpcStatusName: 'NOT_FOUND',
+        })
         expect(exception.contextModule).toBe('test-module')
         expect(exception.contextCode).toBeUndefined()
       }
@@ -152,8 +196,39 @@ describe('BaseGrpcConsumer', () => {
         expect(exception.context).toBe(
           'prepareFeeGrant (baseUrl: http://localhost:9090)',
         )
+        expect(exception.metadata).toMatchObject({
+          rawErrorName: 'Error',
+          rawErrorMessage: 'network failure',
+        })
         expect(exception.contextModule).toBe('test-module')
         expect(exception.contextCode).toBeUndefined()
+      }
+    })
+
+    it('keeps grpc-web wrapped fetch failure details', () => {
+      const error = new RpcError('Failed to fetch', 'INTERNAL')
+      error.methodName = 'Positions'
+      error.serviceName =
+        'injective_derivative_exchange_rpc.InjectiveDerivativeExchangeRPC'
+
+      try {
+        consumer.throwGrpcError(error, 'positions')
+        expect.unreachable('Expected handleGrpcError to throw')
+      } catch (e: unknown) {
+        expect(e).toBeInstanceOf(GrpcUnaryRequestException)
+
+        const exception = e as GrpcUnaryRequestException
+
+        expect(exception.context).toContain(
+          'rpc: injective_derivative_exchange_rpc.InjectiveDerivativeExchangeRPC/Positions',
+        )
+        expect(exception.metadata).toMatchObject({
+          rawErrorName: 'RpcError',
+          rawErrorMessage: 'Failed to fetch',
+          rawErrorCode: 'INTERNAL',
+          grpcStatusCode: 13,
+          grpcStatusName: 'INTERNAL',
+        })
       }
     })
 

--- a/packages/sdk-ts/src/client/base/BaseGrpcConsumer.ts
+++ b/packages/sdk-ts/src/client/base/BaseGrpcConsumer.ts
@@ -8,7 +8,15 @@ import {
 import { GrpcStatusCode } from '../../types/stream.js'
 import { GrpcWebRpcTransport } from './GrpcWebRpcTransport.js'
 import type { UnaryCall, RpcOptions } from '@protobuf-ts/runtime-rpc'
+import type { ErrorContextMetadata } from '@injectivelabs/exceptions'
 import type { GrpcWebTransportAdditionalOptions } from '../../types'
+
+type GrpcRetryDiagnostics = {
+  retryAttempt: number
+  retryMaxAttempts: number
+  retryDelayMs: number
+  retryStopReason: 'exhausted' | 'non-retryable'
+}
 
 const GRPC_STATUS_CODE_BY_NAME: Partial<Record<string, GrpcStatusCode>> = {
   OK: GrpcStatusCode.OK,
@@ -57,6 +65,7 @@ const GRPC_RETRYABLE_STATUS_CODES = new Set<GrpcStatusCode>([
  */
 export default class BaseGrpcConsumer {
   private _client: unknown
+  private grpcRetryDiagnostics = new WeakMap<object, GrpcRetryDiagnostics>()
   protected endpoint: string
   protected module: string = ''
   protected transport: GrpcWebRpcTransport
@@ -234,7 +243,16 @@ export default class BaseGrpcConsumer {
       try {
         return await grpcCall()
       } catch (e: unknown) {
-        if (attempt >= retries || !this.isRetryableGrpcError(e)) {
+        const isRetryable = this.isRetryableGrpcError(e)
+
+        if (attempt >= retries || !isRetryable) {
+          this.setGrpcRetryDiagnostics(e, {
+            retryAttempt: attempt,
+            retryMaxAttempts: retries,
+            retryDelayMs: delay,
+            retryStopReason: isRetryable ? 'exhausted' : 'non-retryable',
+          })
+
           throw e
         }
 
@@ -248,6 +266,68 @@ export default class BaseGrpcConsumer {
     }
 
     return retryGrpcCall()
+  }
+
+  private setGrpcRetryDiagnostics(
+    error: unknown,
+    diagnostics: GrpcRetryDiagnostics,
+  ) {
+    if (!error || typeof error !== 'object') {
+      return
+    }
+
+    this.grpcRetryDiagnostics.set(error, diagnostics)
+  }
+
+  private getGrpcRetryDiagnostics(error: unknown) {
+    if (!error || typeof error !== 'object') {
+      return
+    }
+
+    return this.grpcRetryDiagnostics.get(error)
+  }
+
+  private getGrpcErrorMetadata(e: unknown): ErrorContextMetadata {
+    const isRpcError = e instanceof RpcError
+    const error = e instanceof Error ? e : undefined
+    const grpcStatusCode = isRpcError
+      ? this.getGrpcStatusCode(e.code)
+      : undefined
+    const retryDiagnostics = this.getGrpcRetryDiagnostics(e)
+
+    return {
+      wasRetried: retryDiagnostics
+        ? retryDiagnostics.retryAttempt > 1
+        : undefined,
+      retryAttempt: retryDiagnostics?.retryAttempt,
+      retryMaxAttempts: retryDiagnostics?.retryMaxAttempts,
+      retryDelayMs: retryDiagnostics?.retryDelayMs,
+      retryStopReason: retryDiagnostics?.retryStopReason,
+      rawErrorName: error?.name,
+      rawErrorMessage: error?.message,
+      rawErrorCode: isRpcError ? e.code : this.getErrorScalar(e, 'code'),
+      grpcStatusCode,
+      grpcStatusName: isRpcError ? this.getGrpcStatusName(e.code) : undefined,
+      isRetryableGrpcStatus:
+        grpcStatusCode === undefined
+          ? undefined
+          : GRPC_RETRYABLE_STATUS_CODES.has(grpcStatusCode),
+    }
+  }
+
+  private getErrorScalar(
+    error: unknown,
+    key: string,
+  ): string | number | boolean | undefined {
+    if (!error || typeof error !== 'object' || !(key in error)) {
+      return undefined
+    }
+
+    const value = (error as Record<string, unknown>)[key]
+
+    return ['string', 'number', 'boolean'].includes(typeof value)
+      ? (value as string | number | boolean)
+      : undefined
   }
 
   /**
@@ -316,6 +396,7 @@ export default class BaseGrpcConsumer {
               : UnspecifiedErrorCode,
           context: this.getRpcErrorContext(e, context),
           contextModule: this.module,
+          metadata: this.getGrpcErrorMetadata(e),
         },
       )
     }
@@ -339,6 +420,7 @@ export default class BaseGrpcConsumer {
       code: UnspecifiedErrorCode,
       context: this.getGrpcErrorContext(context),
       contextModule: this.module,
+      metadata: this.getGrpcErrorMetadata(e),
     })
   }
 

--- a/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.spec.ts
@@ -346,6 +346,47 @@ describe('StreamManagerV2', () => {
       expect(manager.getState()).toBe(StreamState.Stopped)
     })
 
+    it('should reset retry attempts when manually started after max retries', () => {
+      const manager = new StreamManagerV2({
+        id: 'test-stream',
+        streamFactory,
+        onData: onDataCallback,
+        retryConfig: {
+          enabled: true,
+          maxAttempts: 2,
+          initialDelayMs: 100,
+          maxDelayMs: 1000,
+          backoffMultiplier: 2,
+          persistent: false,
+        },
+      })
+
+      const retryEvents: any[] = []
+      const errorEvents: any[] = []
+      manager.on('retry', (payload) => retryEvents.push(payload))
+      manager.on('error', (payload) => errorEvents.push(payload))
+
+      vi.mocked(streamFactory).mockImplementation(() => {
+        throw new Error('Always fails')
+      })
+
+      manager.start()
+      vi.advanceTimersByTime(100)
+      vi.advanceTimersByTime(200)
+
+      expect(manager.getState()).toBe(StreamState.Stopped)
+      expect(retryEvents.map((event) => event.attempt)).toEqual([1, 2])
+
+      manager.start()
+      vi.advanceTimersByTime(100)
+
+      expect(retryEvents.map((event) => event.attempt)).toEqual([1, 2, 1])
+      expect(streamFactory).toHaveBeenCalledTimes(5)
+      expect(
+        errorEvents.filter((event) => event.message.includes('Max retries')),
+      ).toHaveLength(1)
+    })
+
     it('should use persistent mode after exhausting backoff', () => {
       const manager = new StreamManagerV2({
         id: 'test-stream',

--- a/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.ts
+++ b/packages/sdk-ts/src/client/indexer/grpc_stream/streamV2/StreamManagerV2.ts
@@ -156,6 +156,10 @@ export class StreamManagerV2<TResponse> extends EventEmitter<
       return
     }
 
+    if (this.state === StreamState.Stopped) {
+      this.retryAttempt = 0
+    }
+
     this.connect()
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error details with structured metadata, including status, retryability, raw error information, and retry diagnostics.
  * Preserved useful details from gRPC and network failures, including errors without named RPC methods.
  * Restarting a stopped stream now correctly begins a fresh retry cycle without duplicate max-retry errors.
* **Developer Experience**
  * Exception types now support optional metadata for clearer troubleshooting and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->