### PR TITLE
fix: route wallet transaction RPCs through signers

### DIFF
--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.spec.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { getViemWalletClient } from '@injectivelabs/wallet-base'
 import { LedgerEip1193Provider } from './Eip1193Provider.js'
 import type LedgerHW from './hw/index.js'
 
@@ -103,4 +104,48 @@ describe('Ledger EIP-1193 provider', () => {
       provider.request({ method: 'eth_signTypedData_v4', params: [address] }),
     ).rejects.toThrow('Missing typed data parameter for eth_signTypedData_v4')
   })
+
+  it.each(['eth_sendTransaction', 'wallet_sendTransaction'])(
+    'routes %s through the Ledger transaction signer',
+    async (method) => {
+      const transaction = {
+        from: address,
+        to: '0x0000000000000000000000000000000000000002',
+        value: '0x0',
+        data: '0x',
+      }
+      const preparedTransaction = {
+        ...transaction,
+        gas: 21_000n,
+      }
+      const prepareTransactionRequest = vi
+        .fn()
+        .mockResolvedValue(preparedTransaction)
+      const sendRawTransaction = vi.fn().mockResolvedValue('0xtxhash')
+      const request = vi.fn(() => {
+        throw new Error('Unexpected RPC fallback')
+      })
+
+      vi.mocked(getViemWalletClient).mockReturnValue({
+        prepareTransactionRequest,
+        sendRawTransaction,
+        request,
+      } as any)
+
+      const provider = getProvider()
+      const signTransaction = vi
+        .spyOn(provider, 'signTransaction')
+        .mockResolvedValue('0xsignedtx')
+
+      await expect(
+        provider.request({ method, params: [transaction] }),
+      ).resolves.toBe('0xtxhash')
+      expect(prepareTransactionRequest).toHaveBeenCalledWith(transaction)
+      expect(signTransaction).toHaveBeenCalledWith(preparedTransaction)
+      expect(sendRawTransaction).toHaveBeenCalledWith({
+        serializedTransaction: '0xsignedtx',
+      })
+      expect(request).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
+++ b/packages/wallets/wallet-ledger/src/strategy/Ledger/Eip1193Provider.ts
@@ -20,6 +20,11 @@ const signTypedDataMethods = new Set([
 
 const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
 
+const sendTransactionMethods = new Set([
+  'eth_sendTransaction',
+  'wallet_sendTransaction',
+])
+
 const isEthAddress = (value: unknown) =>
   typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
 
@@ -247,7 +252,7 @@ export class LedgerEip1193Provider implements Eip1193Provider {
       return `0x${count.toString(16)}`
     }
 
-    if (args.method === 'eth_sendTransaction') {
+    if (sendTransactionMethods.has(args.method)) {
       const address = await this.getAddress()
 
       const walletClient = getViemWalletClient({

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.spec.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { getViemWalletClient } from '@injectivelabs/wallet-base'
 import { TrezorEip1193Provider } from './Eip1193Provider.js'
 import type { BaseTrezorTransport } from './hw/index.js'
 
@@ -105,4 +106,49 @@ describe('Trezor EIP-1193 provider', () => {
       provider.request({ method: 'eth_signTypedData_v4', params: [address] }),
     ).rejects.toThrow('Missing typed data parameter for eth_signTypedData_v4')
   })
+
+  it.each(['eth_sendTransaction', 'wallet_sendTransaction'])(
+    'routes %s through the Trezor transaction signer',
+    async (method) => {
+      const transaction = {
+        from: address,
+        to: '0x0000000000000000000000000000000000000002',
+        value: '0x0',
+        data: '0x',
+      }
+      const preparedTransaction = {
+        ...transaction,
+        gas: 21_000n,
+      }
+      const prepareTransactionRequest = vi
+        .fn()
+        .mockResolvedValue(preparedTransaction)
+      const sendRawTransaction = vi.fn().mockResolvedValue('0xtxhash')
+      const request = vi.fn(() => {
+        throw new Error('Unexpected RPC fallback')
+      })
+
+      vi.mocked(getViemWalletClient).mockReturnValue({
+        prepareTransactionRequest,
+        sendRawTransaction,
+        request,
+      } as any)
+
+      const provider = getProvider()
+      vi.spyOn(provider, 'getAddress').mockResolvedValue(address)
+      const signTransaction = vi
+        .spyOn(provider, 'signTransaction')
+        .mockResolvedValue('0xsignedtx')
+
+      await expect(
+        provider.request({ method, params: [transaction] }),
+      ).resolves.toBe('0xtxhash')
+      expect(prepareTransactionRequest).toHaveBeenCalledWith(transaction)
+      expect(signTransaction).toHaveBeenCalledWith(preparedTransaction)
+      expect(sendRawTransaction).toHaveBeenCalledWith({
+        serializedTransaction: '0xsignedtx',
+      })
+      expect(request).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-trezor/src/strategy/Eip1193Provider.ts
@@ -34,6 +34,11 @@ const signTypedDataMethods = new Set([
 
 const signMessageMethods = new Set(['eth_sign', 'personal_sign'])
 
+const sendTransactionMethods = new Set([
+  'eth_sendTransaction',
+  'wallet_sendTransaction',
+])
+
 const isEthAddress = (value: unknown) =>
   typeof value === 'string' && /^0x[a-fA-F0-9]{40}$/.test(value)
 
@@ -338,7 +343,7 @@ export class TrezorEip1193Provider implements Eip1193Provider {
       return `0x${count.toString(16)}`
     }
 
-    if (args.method === 'eth_sendTransaction') {
+    if (sendTransactionMethods.has(args.method)) {
       const address = await this.getAddress()
 
       const walletClient = getViemWalletClient({

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.spec.ts
@@ -1,4 +1,5 @@
 import { vi } from 'vitest'
+import { getViemWalletClient } from '@injectivelabs/wallet-base'
 import { getEip1193ProviderForTurnkey } from './Eip1193Provider.js'
 import type { LocalAccount } from 'viem'
 
@@ -168,4 +169,59 @@ describe('Turnkey EIP-1193 provider', () => {
     ).resolves.toBe('0xsignedtx')
     expect(signTransaction).toHaveBeenCalledWith({ to: address })
   })
+
+  it.each(['eth_sendTransaction', 'wallet_sendTransaction'])(
+    'routes %s through the Turnkey transaction signer',
+    async (method) => {
+      const transaction = {
+        from: address,
+        to: '0x0000000000000000000000000000000000000002',
+        value: '0x0',
+        data: '0x',
+      }
+      const preparedTransaction = {
+        ...transaction,
+        value: 0n,
+        gas: 21_000n,
+      }
+      const prepareTransactionRequest = vi
+        .fn()
+        .mockResolvedValue(preparedTransaction)
+      const sendRawTransaction = vi.fn().mockResolvedValue('0xtxhash')
+      const request = vi.fn(() => {
+        throw new Error('Unexpected RPC fallback')
+      })
+
+      vi.mocked(getViemWalletClient).mockReturnValue({
+        prepareTransactionRequest,
+        sendRawTransaction,
+        request,
+      } as any)
+
+      const signTransaction = vi.fn().mockResolvedValue('0xsignedtx')
+      const provider = await getEip1193ProviderForTurnkey(
+        {
+          ...account,
+          signTransaction,
+        } as unknown as LocalAccount,
+        1,
+        {
+          rpcUrl: 'http://127.0.0.1:1',
+        },
+      )
+
+      await expect(
+        provider.request({ method, params: [transaction] }),
+      ).resolves.toBe('0xtxhash')
+      expect(prepareTransactionRequest).toHaveBeenCalledWith({
+        ...transaction,
+        value: 0n,
+      })
+      expect(signTransaction).toHaveBeenCalledWith(preparedTransaction)
+      expect(sendRawTransaction).toHaveBeenCalledWith({
+        serializedTransaction: '0xsignedtx',
+      })
+      expect(request).not.toHaveBeenCalled()
+    },
+  )
 })

--- a/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
+++ b/packages/wallets/wallet-turnkey/src/strategy/Eip1193Provider.ts
@@ -21,6 +21,11 @@ const signMessageMethods = new Set([
   'eth_signMessage',
 ])
 
+const sendTransactionMethods = new Set([
+  'eth_sendTransaction',
+  'wallet_sendTransaction',
+])
+
 const parseChainId = (chainId: number | string) => {
   if (typeof chainId === 'number') {
     return chainId
@@ -265,7 +270,7 @@ class CustomEip1193Provider implements Eip1193Provider {
       return true
     }
 
-    if (args.method === 'eth_sendTransaction') {
+    if (sendTransactionMethods.has(args.method)) {
       if (!args.params) {
         throw new Error('params is required')
       }


### PR DESCRIPTION
## Summary

- Treat `wallet_sendTransaction` as a wallet-signing method in the Turnkey, Ledger, and Trezor EIP-1193 providers.
- Route both transaction method names through the existing prepare, local-sign, and `eth_sendRawTransaction` broadcast flow.
- Add regression coverage proving neither method falls through to the generic public-RPC request path.

## Root cause

Viem can retry `eth_sendTransaction` as `wallet_sendTransaction`. The SDK-owned providers only recognized the former, so the latter fell through to the Viem client backed by the configured public RPC. Providers such as Alchemy cannot handle wallet signing methods and rejected the request.

Browser-injected wallets, WalletConnect, and Magic were audited and do not need this change because they use their native wallet providers rather than these SDK-owned request routers.

## Impact

Halliday and other Viem consumers can submit EVM transactions through Turnkey, Ledger, and Trezor without leaking `wallet_sendTransaction` to a public RPC.

## Validation

- `pnpm exec vitest run packages/wallets/wallet-turnkey packages/wallets/wallet-ledger packages/wallets/wallet-trezor` — 5 files and 43 tests passed.
- Lint passed for `@injectivelabs/wallet-turnkey`, `@injectivelabs/wallet-ledger`, and `@injectivelabs/wallet-trezor`.
- `git diff --check origin/master...HEAD` passed.

## Local workspace check limitation

The full pre-push hook could not complete because the existing local workspace dependency/generated-type state produces unrelated errors. A frozen install is also currently rejected because `pnpm-lock.yaml` is out of date with `protoV2/abacus/proto-ts/package.json`. The affected provider tests and package lints pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `wallet_sendTransaction` support across Ledger, Trezor, and Turnkey wallets.
  * Transactions are prepared, signed by the selected wallet, broadcast, and returned with their transaction hash.

* **Bug Fixes**
  * Ensured supported transaction requests use wallet signing instead of RPC fallback.

* **Tests**
  * Added coverage for signing, broadcasting, transaction-hash responses, and fallback prevention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->