### PR TITLE
feat: add TC referral category support

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -493,7 +493,7 @@
     "@injectivelabs/networks": "workspace:*",
     "@injectivelabs/olp-proto-ts-v2": "1.17.6",
     "@injectivelabs/platform-services-proto-ts-v2": "1.0.2",
-    "@injectivelabs/tc-abacus-proto-ts-v2": "1.18.6",
+    "@injectivelabs/tc-abacus-proto-ts-v2": "1.18.7",
     "@injectivelabs/ts-types": "workspace:*",
     "@injectivelabs/utils": "workspace:*",
     "@injectivelabs/ws-price-oracle-proto-ts-v2": "1.0.5",

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
@@ -233,6 +233,34 @@ describe('TcAbacusGrpcApi', () => {
     ).toBe('kol1')
   })
 
+  test('maps account stats categories', () => {
+    const response = TcAbacusPb.GetAccountStatsResponse.create({
+      category: 'kol2',
+    })
+
+    expect(
+      TcAbacusGrpcTransformer.grpcAccountStatsToAccountStats(response).category,
+    ).toBe('kol2')
+  })
+
+  test('normalizes empty referrer categories to default', () => {
+    const response = TcAbacusPb.Referrer.create()
+
+    expect(
+      TcAbacusGrpcTransformer.grpcReferrerToReferrer(response).category,
+    ).toBe('default')
+  })
+
+  test('rejects unknown referrer categories', () => {
+    const response = TcAbacusPb.Referrer.create({
+      category: 'unknown',
+    })
+
+    expect(() =>
+      TcAbacusGrpcTransformer.grpcReferrerToReferrer(response),
+    ).toThrow('Unknown referrer category: unknown')
+  })
+
   test('setReferrerCategory', async () => {
     const executeGrpcCall = vi
       .spyOn(tcAbacusGrpcApi as any, 'executeGrpcCall')

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
@@ -251,14 +251,14 @@ describe('TcAbacusGrpcApi', () => {
     ).toBe('default')
   })
 
-  test('normalizes unknown referrer categories to default', () => {
+  test('preserves unknown referrer categories', () => {
     const response = TcAbacusPb.Referrer.create({
       category: 'unknown',
     })
 
     expect(
       TcAbacusGrpcTransformer.grpcReferrerToReferrer(response).category,
-    ).toBe('default')
+    ).toBe('unknown')
   })
 
   test('setReferrerCategory', async () => {
@@ -277,5 +277,17 @@ describe('TcAbacusGrpcApi', () => {
         category: 'kol2',
       }),
     )
+  })
+
+  test('rejects invalid referrer categories', async () => {
+    const executeGrpcCall = vi.spyOn(tcAbacusGrpcApi as any, 'executeGrpcCall')
+    const category = 'unknown' as Parameters<
+      typeof tcAbacusGrpcApi.setReferrerCategory
+    >[1]
+
+    await expect(
+      tcAbacusGrpcApi.setReferrerCategory(injectiveAddress, category),
+    ).rejects.toThrow('Invalid referrer category: unknown')
+    expect(executeGrpcCall).not.toHaveBeenCalled()
   })
 })

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
@@ -251,14 +251,14 @@ describe('TcAbacusGrpcApi', () => {
     ).toBe('default')
   })
 
-  test('rejects unknown referrer categories', () => {
+  test('normalizes unknown referrer categories to default', () => {
     const response = TcAbacusPb.Referrer.create({
       category: 'unknown',
     })
 
-    expect(() =>
-      TcAbacusGrpcTransformer.grpcReferrerToReferrer(response),
-    ).toThrow('Unknown referrer category: unknown')
+    expect(
+      TcAbacusGrpcTransformer.grpcReferrerToReferrer(response).category,
+    ).toBe('default')
   })
 
   test('setReferrerCategory', async () => {

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts
@@ -1,5 +1,6 @@
+import * as TcAbacusPb from '@injectivelabs/tc-abacus-proto-ts-v2/generated/injective_tc_abacus_rpc_pb'
 import { TcAbacusGrpcApi } from './TcAbacusGrpcApi.js'
-import type { TcAbacusGrpcTransformer } from './transformers/index.js'
+import { TcAbacusGrpcTransformer } from './transformers/index.js'
 
 const injectiveAddress = 'inj1995xnrrtnmtdgjmx0g937vf28dwefhkhy6gy5e'
 
@@ -8,6 +9,10 @@ const tcAbacusGrpcApi = new TcAbacusGrpcApi(
 )
 
 describe('TcAbacusGrpcApi', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
   test('fetchCurrentEpoch', async () => {
     try {
       const response = await tcAbacusGrpcApi.fetchCurrentEpoch()
@@ -216,5 +221,33 @@ describe('TcAbacusGrpcApi', () => {
         'TcAbacusGrpcApi.fetchInviteeReferrer => ' + (e as any).message,
       )
     }
+  })
+
+  test('maps referrer categories', () => {
+    const response = TcAbacusPb.Referrer.create({
+      category: 'kol1',
+    })
+
+    expect(
+      TcAbacusGrpcTransformer.grpcReferrerToReferrer(response).category,
+    ).toBe('kol1')
+  })
+
+  test('setReferrerCategory', async () => {
+    const executeGrpcCall = vi
+      .spyOn(tcAbacusGrpcApi as any, 'executeGrpcCall')
+      .mockResolvedValue({})
+
+    await expect(
+      tcAbacusGrpcApi.setReferrerCategory(injectiveAddress, 'kol2'),
+    ).resolves.toEqual({})
+
+    expect(executeGrpcCall).toHaveBeenCalledOnce()
+    expect(executeGrpcCall.mock.calls[0]?.[0]).toEqual(
+      expect.objectContaining({
+        address: injectiveAddress,
+        category: 'kol2',
+      }),
+    )
   })
 })

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.ts
@@ -3,6 +3,7 @@ import * as TcAbacusPb from '@injectivelabs/tc-abacus-proto-ts-v2/generated/inje
 import { InjectiveTCAbacusRPCClient } from '@injectivelabs/tc-abacus-proto-ts-v2/generated/injective_tc_abacus_rpc_pb.client'
 import BaseGrpcConsumer from '../../base/BaseGrpcConsumer.js'
 import { TcAbacusGrpcTransformer } from './transformers/index.js'
+import type { ReferrerCategory } from '../types/index.js'
 
 export class TcAbacusGrpcApi extends BaseGrpcConsumer {
   protected module: string = IndexerErrorModule.Abacus
@@ -129,6 +130,18 @@ export class TcAbacusGrpcApi extends BaseGrpcConsumer {
     >(request, this.client.createReferrerCode.bind(this.client))
 
     return response // has no response fields
+  }
+
+  async setReferrerCategory(address: string, category: ReferrerCategory) {
+    const request = TcAbacusPb.SetReferrerCategoryRequest.create({
+      address,
+      category,
+    })
+
+    return this.executeGrpcCall<
+      TcAbacusPb.SetReferrerCategoryRequest,
+      TcAbacusPb.SetReferrerCategoryResponse
+    >(request, this.client.setReferrerCategory.bind(this.client))
   }
 
   async fetchReferrerCodes(address: string, cursor?: string, limit?: number) {

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.ts
@@ -133,6 +133,10 @@ export class TcAbacusGrpcApi extends BaseGrpcConsumer {
   }
 
   async setReferrerCategory(address: string, category: ReferrerCategory) {
+    if (category !== 'default' && category !== 'kol1' && category !== 'kol2') {
+      throw new Error(`Invalid referrer category: ${category}`)
+    }
+
     const request = TcAbacusPb.SetReferrerCategoryRequest.create({
       address,
       category,

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
@@ -5,7 +5,6 @@ import type {
   SnapshotPoints,
   ReferrerInvitee,
   InviteeReferrer,
-  ReferrerCategory,
   HealthCheckResponse,
   CurrentEpochResponse,
   AccountStatsResponse,
@@ -19,8 +18,8 @@ import type {
 export class TcAbacusGrpcTransformer {
   private static grpcReferrerCategoryToReferrerCategory(
     category: string,
-  ): ReferrerCategory {
-    return category === 'kol1' || category === 'kol2' ? category : 'default'
+  ): NonNullable<AccountStatsResponse['category']> {
+    return category || 'default'
   }
 
   static grpcCurrentEpochToCurrentEpoch(

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
@@ -71,6 +71,7 @@ export class TcAbacusGrpcTransformer {
       code: response.code,
       address: response.address,
       isKol: response.isKol,
+      category: response.category as AccountStatsResponse['category'],
       last7DVolume: response.last7DVolume,
       inviteeCount: response.inviteeCount,
       allTimeVolume: response.allTimeVolume,
@@ -88,6 +89,7 @@ export class TcAbacusGrpcTransformer {
       height: referrer.height.toString(),
       isKol: referrer.isKol,
       status: referrer.status,
+      category: referrer.category as Referrer['category'],
       inviteeCount: referrer.inviteeCount,
       creatorAddress: referrer.creatorAddress,
     }

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
@@ -5,6 +5,7 @@ import type {
   SnapshotPoints,
   ReferrerInvitee,
   InviteeReferrer,
+  ReferrerCategory,
   HealthCheckResponse,
   CurrentEpochResponse,
   AccountStatsResponse,
@@ -16,6 +17,21 @@ import type {
 } from '../../types/index.js'
 
 export class TcAbacusGrpcTransformer {
+  private static grpcReferrerCategoryToReferrerCategory(
+    category: string,
+  ): ReferrerCategory {
+    switch (category) {
+      case '':
+      case 'default':
+        return 'default'
+      case 'kol1':
+      case 'kol2':
+        return category
+      default:
+        throw new Error(`Unknown referrer category: ${category}`)
+    }
+  }
+
   static grpcCurrentEpochToCurrentEpoch(
     response: TcAbacusPb.GetCurrentEpochResponse,
   ): CurrentEpochResponse {
@@ -71,7 +87,9 @@ export class TcAbacusGrpcTransformer {
       code: response.code,
       address: response.address,
       isKol: response.isKol,
-      category: response.category as AccountStatsResponse['category'],
+      category: TcAbacusGrpcTransformer.grpcReferrerCategoryToReferrerCategory(
+        response.category,
+      ),
       last7DVolume: response.last7DVolume,
       inviteeCount: response.inviteeCount,
       allTimeVolume: response.allTimeVolume,
@@ -89,7 +107,9 @@ export class TcAbacusGrpcTransformer {
       height: referrer.height.toString(),
       isKol: referrer.isKol,
       status: referrer.status,
-      category: referrer.category as Referrer['category'],
+      category: TcAbacusGrpcTransformer.grpcReferrerCategoryToReferrerCategory(
+        referrer.category,
+      ),
       inviteeCount: referrer.inviteeCount,
       creatorAddress: referrer.creatorAddress,
     }

--- a/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/grpc/transformers/index.ts
@@ -20,16 +20,7 @@ export class TcAbacusGrpcTransformer {
   private static grpcReferrerCategoryToReferrerCategory(
     category: string,
   ): ReferrerCategory {
-    switch (category) {
-      case '':
-      case 'default':
-        return 'default'
-      case 'kol1':
-      case 'kol2':
-        return category
-      default:
-        throw new Error(`Unknown referrer category: ${category}`)
-    }
+    return category === 'kol1' || category === 'kol2' ? category : 'default'
   }
 
   static grpcCurrentEpochToCurrentEpoch(

--- a/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
@@ -1,3 +1,5 @@
+export type ReferrerCategory = 'default' | 'kol1' | 'kol2'
+
 export interface CurrentEpochResponse {
   epochEnd: string
   epochPoints: string
@@ -32,6 +34,7 @@ export interface AccountStatsResponse {
   code: string
   address: string
   isKol: boolean
+  category: ReferrerCategory
   last7DVolume: string
   inviteeCount: number
   allTimeVolume: string
@@ -47,6 +50,7 @@ export interface Referrer {
   createdAt: string
   isKol: boolean
   status: string
+  category: ReferrerCategory
   inviteeCount: number
   creatorAddress: string
 }

--- a/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
@@ -1,4 +1,5 @@
 export type ReferrerCategory = 'default' | 'kol1' | 'kol2'
+export type ReferrerCategoryResponse = ReferrerCategory | (string & {})
 
 export interface CurrentEpochResponse {
   epochEnd: string
@@ -34,7 +35,7 @@ export interface AccountStatsResponse {
   code: string
   address: string
   isKol: boolean
-  category?: ReferrerCategory
+  category?: ReferrerCategoryResponse
   last7DVolume: string
   inviteeCount: number
   allTimeVolume: string
@@ -50,7 +51,7 @@ export interface Referrer {
   createdAt: string
   isKol: boolean
   status: string
-  category?: ReferrerCategory
+  category?: ReferrerCategoryResponse
   inviteeCount: number
   creatorAddress: string
 }

--- a/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
+++ b/packages/sdk-ts/src/client/tcAbacus/types/tcAbacus.ts
@@ -34,7 +34,7 @@ export interface AccountStatsResponse {
   code: string
   address: string
   isKol: boolean
-  category: ReferrerCategory
+  category?: ReferrerCategory
   last7DVolume: string
   inviteeCount: number
   allTimeVolume: string
@@ -50,7 +50,7 @@ export interface Referrer {
   createdAt: string
   isKol: boolean
   status: string
-  category: ReferrerCategory
+  category?: ReferrerCategory
   inviteeCount: number
   creatorAddress: string
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -274,8 +274,8 @@ importers:
         specifier: 1.0.2
         version: 1.0.2
       '@injectivelabs/tc-abacus-proto-ts-v2':
-        specifier: 1.18.6
-        version: 1.18.6
+        specifier: 1.18.7
+        version: 1.18.7
       '@injectivelabs/ts-types':
         specifier: workspace:*
         version: link:../ts-types
@@ -1191,8 +1191,8 @@ packages:
   '@injectivelabs/string-decoder@1.3.0':
     resolution: {integrity: sha512-/SsVxTo7EKVP4WxEkrpbHC00Rfp15DcljOJa/BM33BcCIC+IiahEn4O9qXNTrSc0Nr3mLoONauKmkb+1z613kg==}
 
-  '@injectivelabs/tc-abacus-proto-ts-v2@1.18.6':
-    resolution: {integrity: sha512-Bl3MQir4UUYOB1O24PkFqbznlBoxkBfQC6e0lnnFkpn5Sno0kVaA0lWHjYG9JVoqDkwcKo3CefFQoLnv59hVZQ==}
+  '@injectivelabs/tc-abacus-proto-ts-v2@1.18.7':
+    resolution: {integrity: sha512-589j5nS7OyRArSYRhYy+Sh1ku78qMKbep8uZA4wz7ZMqZR97nu+fIodwrIW7UyQD819jqcJ4asLxPSIBGYsk8Q==}
 
   '@injectivelabs/ws-price-oracle-proto-ts-v2@1.0.5':
     resolution: {integrity: sha512-dGCUzEurROr8RiasViZH+i2g8FJdl46Vcm6pnyUcldxHgYCztlJNDxzUc5Unqze7+9+bWeu+5QMwXhw5DrtCvA==}
@@ -8683,7 +8683,7 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  '@injectivelabs/tc-abacus-proto-ts-v2@1.18.6':
+  '@injectivelabs/tc-abacus-proto-ts-v2@1.18.7':
     dependencies:
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1


### PR DESCRIPTION
## Summary
- update the TC Abacus proto dependency to 1.18.7
- expose referrer categories on account stats and referrer responses
- add the authenticated referrer-category mutation to `TcAbacusGrpcApi`

## Testing
- `pnpm --filter @injectivelabs/sdk-ts lint`
- `pnpm --filter @injectivelabs/sdk-ts type-check`
- `pnpm exec vitest run packages/sdk-ts/src/client/tcAbacus/grpc/TcAbacusGrpcApi.spec.ts`
- `pnpm --filter @injectivelabs/sdk-ts build`
- `pnpm type-check`
- pre-push monorepo build checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for referrer categories: `default`, `kol1`, and `kol2`.
  * Added the ability to assign a category to a referrer through the SDK.
  * Account statistics and referrer responses now include category information.
  * Empty or unsupported category values are mapped to `default`.
  * Invalid category assignments are rejected before submission.

* **Tests**
  * Added coverage for category mapping, default handling, valid updates, and invalid category rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->