### PR TITLE
feat: support taker stream auth metadata

### DIFF
--- a/packages/sdk-ts/src/client/indexer/types/rfq.ts
+++ b/packages/sdk-ts/src/client/indexer/types/rfq.ts
@@ -281,6 +281,8 @@ export interface TakerStreamEvents {
 export interface TakerStreamConfig {
   url: string
   requestAddress: string
+  authVersion?: 'v1'
+  autosignAddress?: string
   pingIntervalMs?: number
   connectionTimeoutMs?: number
   reconnect?: WsTransportConfig['reconnect']

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
@@ -12,11 +12,13 @@ const { mockTransportInstances, MockGrpcWebSocketTransport } = vi.hoisted(
     const mockTransportInstances: MockGrpcWebSocketTransport[] = []
 
     class MockGrpcWebSocketTransport {
+      config: unknown
       private listeners = new Map<string, Set<(data: any) => void>>()
       private connected = false
       send = vi.fn<(data: Uint8Array) => void>()
 
-      constructor(_config: unknown) {
+      constructor(config: unknown) {
+        this.config = config
         mockTransportInstances.push(this)
       }
 
@@ -208,6 +210,26 @@ describe('IndexerWsTakerStream authentication', () => {
       authenticated: true,
       code: 'success',
       message: 'verified',
+    })
+  })
+
+  it('passes requested auth metadata when creating the transport', () => {
+    new IndexerWsTakerStream({
+      url: 'wss://rfq.example',
+      requestAddress: 'inj1test',
+      authVersion: 'v1',
+      autosignAddress: 'inj1autosign',
+    })
+
+    expect(mockTransportInstances.at(-1)).toMatchObject({
+      config: {
+        metadata: {
+          request_address: 'inj1test',
+          auth_version: 'v1',
+          autosign_address: 'inj1autosign',
+          subscribe_to_conditional_order_updates: 'true',
+        },
+      },
     })
   })
 })

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
@@ -38,6 +38,10 @@ export class IndexerWsTakerStream {
       reconnect: config.reconnect,
       metadata: {
         request_address: config.requestAddress,
+        ...(config.authVersion ? { auth_version: config.authVersion } : {}),
+        ...(config.autosignAddress
+          ? { autosign_address: config.autosignAddress }
+          : {}),
         subscribe_to_conditional_order_updates: 'true',
       },
     })


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for legacy authentication settings in taker stream configurations.
  * Taker WebSocket streams can now include authentication version and autosigning address metadata when configured.

* **Tests**
  * Added coverage verifying authentication and conditional-order subscription details are passed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->