### PR TITLE
chore: update taker stream auth payload

### DIFF
--- a/packages/sdk-ts/package.json
+++ b/packages/sdk-ts/package.json
@@ -488,7 +488,7 @@
     "@injectivelabs/grpc-web": "^0.0.1",
     "@injectivelabs/grpc-web-node-http-transport": "^0.0.2",
     "@injectivelabs/grpc-web-react-native-transport": "^0.0.2",
-    "@injectivelabs/indexer-proto-ts-v2": "1.20.1",
+    "@injectivelabs/indexer-proto-ts-v2": "1.20.2",
     "@injectivelabs/mito-proto-ts-v2": "1.17.3",
     "@injectivelabs/networks": "workspace:*",
     "@injectivelabs/olp-proto-ts-v2": "1.17.6",

--- a/packages/sdk-ts/src/client/indexer/types/rfq.ts
+++ b/packages/sdk-ts/src/client/indexer/types/rfq.ts
@@ -211,13 +211,11 @@ export interface RFQTakerStreamAckData {
 }
 
 export interface RFQTakerAuth {
-  evmChainId: number
   signature: string
 }
 
 export interface RFQTakerChallenge {
   nonce: string
-  evmChainId: number
   expiresAt: number
   autosignAddress: string
 }

--- a/packages/sdk-ts/src/client/indexer/ws/GrpcWebSocketCodec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/GrpcWebSocketCodec.ts
@@ -61,7 +61,6 @@ export const GrpcWebSocketCodec = {
         messageType: 'auth',
         auth: InjectiveRFQExchangeRpcPb.TakerAuth.create({
           signature: auth.signature,
-          evmChainId: BigInt(auth.evmChainId),
         }),
       })
     return encodeGrpcFrame(

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.spec.ts
@@ -152,7 +152,7 @@ describe('IndexerWsTakerStream authentication', () => {
     stream.on('auth_result', resultListener)
 
     await stream.connect()
-    stream.sendAuth({ evmChainId: 1, signature: '0xsig' })
+    stream.sendAuth({ signature: '0xsig' })
 
     const transport = mockTransportInstances.at(-1)
     if (!transport) {
@@ -166,7 +166,7 @@ describe('IndexerWsTakerStream authentication', () => {
       )
     expect(auth).toMatchObject({
       messageType: 'auth',
-      auth: { evmChainId: 1n, signature: '0xsig' },
+      auth: { signature: '0xsig' },
     })
 
     for (const response of [
@@ -174,7 +174,6 @@ describe('IndexerWsTakerStream authentication', () => {
         messageType: 'challenge',
         challenge: {
           nonce: '0xnonce',
-          evmChainId: 1n,
           expiresAt: 2n,
           autosignAddress: '0xauto',
         },
@@ -201,7 +200,6 @@ describe('IndexerWsTakerStream authentication', () => {
     expect(challengeListener).toHaveBeenCalledWith({
       challenge: {
         nonce: '0xnonce',
-        evmChainId: 1,
         expiresAt: 2,
         autosignAddress: '0xauto',
       },

--- a/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
+++ b/packages/sdk-ts/src/client/indexer/ws/rfq/IndexerWsTakerStream.ts
@@ -170,7 +170,6 @@ export class IndexerWsTakerStream {
           if (response.challenge) {
             const challenge: RFQTakerChallenge = {
               nonce: response.challenge.nonce,
-              evmChainId: Number(response.challenge.evmChainId),
               expiresAt: Number(response.challenge.expiresAt),
               autosignAddress: response.challenge.autosignAddress,
             }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -259,8 +259,8 @@ importers:
         specifier: ^0.0.2
         version: 0.0.2(@injectivelabs/grpc-web@0.0.1(google-protobuf@3.21.4))
       '@injectivelabs/indexer-proto-ts-v2':
-        specifier: 1.20.1
-        version: 1.20.1
+        specifier: 1.20.2
+        version: 1.20.2
       '@injectivelabs/mito-proto-ts-v2':
         specifier: 1.17.3
         version: 1.17.3
@@ -683,6 +683,78 @@ importers:
       '@reown/appkit-adapter-ethers':
         specifier: 1.8.15
         version: 1.8.15(@ethersproject/sha2@5.8.0)(@types/react@19.2.10)(bufferutil@4.1.0)(ethers@6.17.0(bufferutil@4.1.0)(utf-8-validate@5.0.10))(fastestsmallesttextencoderdecoder@1.0.22)(immer@11.1.8)(react@19.0.0)(typescript@5.9.3)(utf-8-validate@5.0.10)(zod@3.25.76)
+
+  protoV2/abacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/core/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/indexer/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/mito/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/olp/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
+
+  protoV2/tcAbacus/proto-ts:
+    dependencies:
+      '@protobuf-ts/grpcweb-transport':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime':
+        specifier: ^2.11.1
+        version: 2.11.1
+      '@protobuf-ts/runtime-rpc':
+        specifier: ^2.11.1
+        version: 2.11.1
 
 packages:
 
@@ -1176,8 +1248,8 @@ packages:
     peerDependencies:
       google-protobuf: ^3.14.0
 
-  '@injectivelabs/indexer-proto-ts-v2@1.20.1':
-    resolution: {integrity: sha512-20M9+BQXJQOgumvvaUUQeyKG9XLyVPKfCNxVl1oskpaYUzyRr6GZngts/8bzfB1UbnnEpTLJouwO/qHSq7sHYg==}
+  '@injectivelabs/indexer-proto-ts-v2@1.20.2':
+    resolution: {integrity: sha512-eHAbCt+C1Pfak20qIO7CGLmjYQo3/dPg4AGiglrxdmN9r3v0XqjOgEB4LOvBuRmIzFUI7PNafqwLLwYDI7ys0w==}
 
   '@injectivelabs/mito-proto-ts-v2@1.17.3':
     resolution: {integrity: sha512-Fo6k1MCPT3CKUS9tbMbl/poGv7R8KHtA7RfU7mvxxVWS7MpF+LLZA6UgegfEA1iiJgIrhe+eEwEvhIOe6SiUzw==}
@@ -8655,7 +8727,7 @@ snapshots:
       browser-headers: 0.4.1
       google-protobuf: 3.21.4
 
-  '@injectivelabs/indexer-proto-ts-v2@1.20.1':
+  '@injectivelabs/indexer-proto-ts-v2@1.20.2':
     dependencies:
       '@protobuf-ts/grpcweb-transport': 2.11.1
       '@protobuf-ts/runtime': 2.11.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - RFQ taker authentication and challenge messages no longer include the EVM chain ID.
  - Updated authentication payloads and challenge data to match the revised protocol.

- **Maintenance**
  - Updated the indexer protocol package to version 1.20.2.
  - Updated authentication test coverage for the revised message format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->